### PR TITLE
fix: e2e install test verifies presets are bundled, fix mkdir typo in package-release

### DIFF
--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -31,7 +31,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "$stage_dir" "out_dir"
+mkdir -p "$stage_dir" "$out_dir"
 
 # Write a shell-wrapper launcher that auto-sets AUTOLOOPS_BUNDLE_ROOT
 # and invokes tonic directly so its arg routing works correctly.

--- a/test/release_install_test.tn
+++ b/test/release_install_test.tn
@@ -22,6 +22,12 @@ defmodule ReleaseInstallTest do
     Assert.assert_equal(Map.get(result, :exit_code, 1), 0)
     Assert.assert_contains(Map.get(result, :output, ""), "installed autoloops to")
     Assert.assert_contains(System.run(shell_quote(Path.join(Map.get(fixture, :install_dir, ""), "autoloops")) <> " --help") |> Map.get(:output, ""), "autoloops fixture")
+
+    install_dir = Map.get(fixture, :install_dir, "")
+    Assert.assert(System.path_exists(Path.join(install_dir, "presets")), "presets/ should be installed")
+    Assert.assert(System.path_exists(Path.join(install_dir, "roles")), "roles/ should be installed")
+    Assert.assert(System.path_exists(Path.join(install_dir, "src")), "src/ should be installed")
+    Assert.assert(System.path_exists(Path.join(install_dir, "tonic.toml")), "tonic.toml should be installed")
   end
 
   def test_package_release_supports_relative_output_dir() do


### PR DESCRIPTION
- Add assertions to release_install_test to verify presets/, roles/,
  src/, and tonic.toml are present after install
- Fix package-release.sh: mkdir "out_dir" (literal) → "$out_dir" (variable)

https://claude.ai/code/session_013ZrPDNfZrcX3Ke7zK6CcR6