### PR TITLE
feat: Add Kiro adapter via Agent Client Protocol (ACP)

### DIFF
--- a/.agents/tasks/kiro-acp-backend/kiro-acp-backend-1-acp-client.code-task.md
+++ b/.agents/tasks/kiro-acp-backend/kiro-acp-backend-1-acp-client.code-task.md
@@ -1,0 +1,82 @@
+# Sub-task 1: ACP Client Module
+
+**Parent task:** `kiro-acp-backend.code-task.md`
+**New files:** `src/backend/acp-client.ts`
+**Depends on:** None
+**Estimated scope:** ~200 lines
+
+## Objective
+
+Create a persistent ACP client that manages a `kiro-cli acp` child process, handles the JSON-RPC 2.0 protocol over stdio, and exposes a clean async API for session management and prompt execution.
+
+## Steps
+
+### 1. Add `@agentclientprotocol/sdk` dependency
+
+Add to `package.json`. This provides `ClientSideConnection`, `ndJsonStream`, and all ACP schema types.
+
+### 2. Create `src/backend/acp-client.ts`
+
+Implement the core ACP client:
+
+```typescript
+export interface AcpClientOptions {
+  command: string;        // e.g. "kiro-cli"
+  args: string[];         // e.g. ["acp"]
+  cwd: string;
+  trustAllTools?: boolean;
+  agentName?: string;     // maps to session/set_mode
+  modelId?: string;       // maps to session/set_model
+}
+
+export interface AcpSession {
+  sessionId: string;
+  connection: ClientSideConnection;
+  process: ChildProcess;
+}
+
+export interface AcpPromptResult {
+  output: string;
+  stopReason: string;
+  timedOut: boolean;
+  error?: string;
+}
+```
+
+Functions:
+
+- `spawnAcpProcess(command: string, args: string[]): ChildProcess` — spawn with `stdio: ['pipe', 'pipe', 'pipe']`, route stderr to a log buffer
+- `initializeConnection(process: ChildProcess): Promise<ClientSideConnection>` — create NDJSON transport over stdin/stdout, call `connection.initialize()` with client info
+- `createSession(connection, cwd, options): Promise<AcpSession>` — call `connection.newSession({ cwd, mcpServers: [] })`, optionally call `setSessionMode` and `setSessionModel`
+- `sendPrompt(session, prompt, timeoutMs): Promise<AcpPromptResult>` — send `connection.prompt()`, collect `agent_message_chunk` text deltas, handle timeout via `connection.cancel()`, return assembled text
+- `terminateSession(session): Promise<void>` — SIGTERM, wait 3s, SIGKILL fallback
+
+### 3. Handle session notifications
+
+Implement the `Client` interface from the ACP SDK:
+
+- `sessionUpdate(params)` — accumulate `agent_message_chunk` text into a buffer, track `tool_call` events for logging
+- `requestPermission(params)` — auto-approve with `allow_once` when `trustAllTools` is true, otherwise reject (headless mode has no UI)
+
+### 4. Handle timeout
+
+When `timeoutMs` elapses during a prompt:
+- Send `connection.cancel({ sessionId })`
+- Wait up to 2s for the `Cancelled` stop reason
+- If no response, mark as timed out
+
+### Acceptance Criteria
+
+- `spawnAcpProcess()` starts a `kiro-cli acp` child process with stdio pipes
+- `initializeConnection()` completes the ACP handshake
+- `createSession()` returns a valid session ID
+- `sendPrompt()` collects streamed text and returns it as a single string
+- Tool approval requests are auto-approved in trust-all mode
+- Timeout triggers cancellation and returns `timedOut: true`
+- `terminateSession()` cleans up the child process
+
+## Metadata
+
+- **Complexity**: Medium
+- **Parent Task**: `kiro-acp-backend.code-task.md`
+- **Depends On**: None

--- a/.agents/tasks/kiro-acp-backend/kiro-acp-backend-2-backend-registration.code-task.md
+++ b/.agents/tasks/kiro-acp-backend/kiro-acp-backend-2-backend-registration.code-task.md
@@ -1,0 +1,86 @@
+# Sub-task 2: Backend Kind Registration and CLI Flag
+
+**Parent task:** `kiro-acp-backend.code-task.md`
+**Modified files:** `src/backend/index.ts`, `src/backend/types.ts`, `src/commands/run.ts`
+**New files:** `src/backend/run-kiro.ts`
+**Depends on:** Sub-task 1 (acp-client.ts)
+**Estimated scope:** ~80 lines
+
+## Objective
+
+Register `kiro` as a recognized backend kind, add the `-b kiro` CLI flag, and create the iteration-level runner that bridges the ACP client into the `BackendRunResult` contract.
+
+## Steps
+
+### 1. Create `src/backend/run-kiro.ts`
+
+```typescript
+import type { AcpSession, AcpPromptResult } from "./acp-client.js";
+import type { BackendRunResult } from "./types.js";
+
+export async function runKiroIteration(
+  session: AcpSession,
+  prompt: string,
+  timeoutMs: number,
+): Promise<BackendRunResult>
+```
+
+Implementation:
+1. Call `sendPrompt(session, prompt, timeoutMs)` from the ACP client
+2. Map the `AcpPromptResult` to `BackendRunResult`:
+   - `output` = assembled text
+   - `exitCode` = 0 if `stopReason` is `EndTurn`, 1 otherwise
+   - `timedOut` = from the ACP result
+   - `providerKind` = `"kiro"`
+   - `errorCategory` = `"none"` | `"timeout"` | `"non_zero_exit"` based on result
+
+### 2. Update `src/backend/index.ts`
+
+In `normalizeProviderKind()`:
+```typescript
+if (spec.kind === "kiro") return "kiro";
+if (spec.command === "kiro-cli" || spec.command.endsWith("/kiro-cli")) return "kiro";
+```
+
+In `normalizeBackendLabel()`:
+```typescript
+if (base === "kiro-cli") return "kiro";
+```
+
+No changes to `buildBackendShellCommand()` — the kiro backend bypasses shell invocation entirely. The harness will call `runKiroIteration()` directly instead.
+
+### 3. Update `src/commands/run.ts`
+
+In `backendOverrideSpec()`, add the `kiro` case:
+
+```typescript
+if (backend === "kiro") {
+  return { kind: "kiro", command: "kiro-cli", args: ["acp"], prompt_mode: "acp" };
+}
+```
+
+This means `autoloops run autocode -b kiro "Fix the bug"` sets the backend to kiro.
+
+Also support `kiro-cli` as a command name (auto-detect):
+```typescript
+if (backend === "kiro-cli" || backend.endsWith("/kiro-cli")) {
+  return { kind: "kiro", command: backend, args: ["acp"], prompt_mode: "acp" };
+}
+```
+
+### 4. Update `src/backend/types.ts`
+
+Add `prompt_mode: "acp"` as a recognized value in documentation comments. No type changes needed since `promptMode` is already `string`.
+
+### Acceptance Criteria
+
+- `backendOverrideSpec("kiro")` returns `{ kind: "kiro", command: "kiro-cli", args: ["acp"], prompt_mode: "acp" }`
+- `normalizeProviderKind({ kind: "kiro", ... })` returns `"kiro"`
+- `runKiroIteration()` returns a valid `BackendRunResult` from an ACP prompt response
+- `-b kiro` is accepted by the CLI parser without error
+
+## Metadata
+
+- **Complexity**: Small
+- **Parent Task**: `kiro-acp-backend.code-task.md`
+- **Depends On**: Sub-task 1

--- a/.agents/tasks/kiro-acp-backend/kiro-acp-backend-3-harness-integration.code-task.md
+++ b/.agents/tasks/kiro-acp-backend/kiro-acp-backend-3-harness-integration.code-task.md
@@ -1,0 +1,99 @@
+# Sub-task 3: Harness Integration — Session Lifecycle and Iteration Dispatch
+
+**Parent task:** `kiro-acp-backend.code-task.md`
+**Modified files:** `src/harness/index.ts`, `src/harness/iteration.ts`, `src/harness/types.ts`
+**Depends on:** Sub-task 1 (acp-client.ts), Sub-task 2 (run-kiro.ts)
+**Estimated scope:** ~100 lines modified
+
+## Objective
+
+Wire the ACP session lifecycle into the harness run loop so that `kind: "kiro"` runs spawn a persistent session before the first iteration, dispatch prompts through ACP instead of shell commands, and clean up the session on exit.
+
+## Steps
+
+### 1. Extend `LoopContext` in `src/harness/types.ts`
+
+Add an optional session holder to the runtime context:
+
+```typescript
+// In LoopContext or as a module-level state
+kiroSession?: import("../backend/acp-client.js").AcpSession;
+```
+
+This is set after `initKiroSession()` and read by `runIteration()`. It's `undefined` for non-kiro backends.
+
+### 2. Update run lifecycle in `src/harness/index.ts`
+
+In the main `run()` function, after `buildLoopContext()`:
+
+```typescript
+if (loop.backend.kind === "kiro") {
+  loop.kiroSession = await initKiroSession({
+    command: loop.backend.command,
+    args: loop.backend.args,
+    cwd: loop.paths.projectDir,
+    trustAllTools: configGet(config, "backend.trust_all_tools", "true") !== "false",
+    agentName: configGet(config, "backend.agent", ""),
+    modelId: configGet(config, "backend.model", ""),
+  });
+}
+```
+
+After the loop ends (in the finally/cleanup path):
+
+```typescript
+if (loop.kiroSession) {
+  await terminateSession(loop.kiroSession);
+}
+```
+
+Register signal handlers (SIGINT, SIGTERM) that also terminate the session.
+
+### 3. Update iteration dispatch in `src/harness/iteration.ts`
+
+In `runIteration()`, before the existing `runProcess()` call, add a branch:
+
+```typescript
+if (loop.backend.kind === "kiro" && loop.kiroSession) {
+  const result = await runKiroIteration(
+    loop.kiroSession,
+    iter.prompt,
+    loop.backend.timeoutMs,
+  );
+  // result is already a BackendRunResult — continue with the same
+  // journal append, event extraction, and completion check flow
+  const { output, exitCode, timedOut } = result;
+  // ... rest of iteration handling identical to existing path
+}
+```
+
+The key constraint: `runKiroIteration` must return a `BackendRunResult` so the downstream flow (journal append, event extraction, completion detection) is completely unchanged.
+
+### 4. Handle the sync/async boundary
+
+The existing harness is synchronous (`execSync` in `runShellCommand`). The kiro backend is inherently async (ACP is a streaming protocol). Options:
+
+- **Option A (recommended)**: Make `runIteration` async for kiro, keep sync for pi/command. The harness `iterate()` loop already controls flow — making it async is a localized change.
+- **Option B**: Use a sync wrapper that blocks on the async ACP call (e.g. `execSync` calling a helper script). Less clean but zero harness changes.
+
+Go with Option A. The `iterate()` function and its callers need `async/await` added. The pi/command path stays synchronous within the async wrapper.
+
+### 5. Review pass support
+
+In the metareview path (`src/harness/metareview.ts` or equivalent), apply the same dispatch: if `review.kind === "kiro"`, send the review prompt through the same ACP session. The agent's conversation history provides natural continuity — no separate session needed.
+
+### Acceptance Criteria
+
+- `autoloops run autocode -b kiro "task"` spawns `kiro-cli acp` once, creates a session, and reuses it across all iterations
+- Each iteration sends the projected prompt via `session/prompt` and collects the text response
+- Journal entries (`iteration.start`, `backend.start`, `backend.finish`, `iteration.finish`) are written identically to other backends
+- Event extraction from the output works — `autoloops emit` calls in the agent's tool output are detected
+- The kiro process is terminated on loop completion, failure, SIGINT, or SIGTERM
+- Review iterations go through the same ACP session
+- The pi and command backends are completely unchanged — no regressions
+
+## Metadata
+
+- **Complexity**: Medium
+- **Parent Task**: `kiro-acp-backend.code-task.md`
+- **Depends On**: Sub-task 1, Sub-task 2

--- a/.agents/tasks/kiro-acp-backend/kiro-acp-backend-4-config-parallel-docs.code-task.md
+++ b/.agents/tasks/kiro-acp-backend/kiro-acp-backend-4-config-parallel-docs.code-task.md
@@ -1,0 +1,100 @@
+# Sub-task 4: Configuration, Parallel Branch Support, and Documentation
+
+**Parent task:** `kiro-acp-backend.code-task.md`
+**Modified files:** `src/harness/config-helpers.ts`, `src/harness/parallel.ts` (or `wave.ts`), `docs/configuration.md`, `docs/cli.md`
+**Depends on:** Sub-task 1 (acp-client.ts), Sub-task 3 (harness integration)
+**Estimated scope:** ~80 lines modified, ~40 lines docs
+
+## Objective
+
+Add kiro-specific configuration keys, ensure parallel branches each get their own ACP session, and document the new backend.
+
+## Steps
+
+### 1. Configuration keys
+
+In `src/harness/config-helpers.ts` (or wherever config is read in `reloadLoop()`), read the new keys:
+
+```typescript
+const trustAllTools = truthy(configGet(config, "backend.trust_all_tools", "true"));
+const agentName = configGet(config, "backend.agent", "");
+const modelId = configGet(config, "backend.model", "");
+```
+
+These are passed to `initKiroSession()` during session creation (sub-task 3). They are only relevant when `backend.kind === "kiro"`.
+
+### 2. Parallel branch support
+
+In the parallel wave execution path (branch supervisor/launcher), each branch currently inherits the parent's backend spec and spawns its own process. For kiro:
+
+- Each branch must spawn its own `kiro-cli acp` process and create its own ACP session
+- The branch's `BackendSpec` carries `kind: "kiro"`, so the branch harness (`run_parallel_branch_cli` or equivalent) initializes its own session via the same `initKiroSession()` path
+- Branch timeout should send `session/cancel` before killing the process
+- On branch completion, `terminateSession()` cleans up the branch's ACP process
+
+This should work naturally if the harness integration (sub-task 3) correctly initializes/terminates sessions based on `backend.kind` — each branch run goes through the same lifecycle.
+
+Verify that the branch launch path in `src/harness/wave.ts` (or `parallel.ts`) passes the backend spec through to the branch's loop context.
+
+### 3. Update `docs/configuration.md`
+
+Add to the Backend section:
+
+```markdown
+| `backend.kind` | string | `"pi"` | Backend type. `"pi"` for the Pi adapter, `"kiro"` for the Kiro ACP agent, `"command"` for arbitrary commands. |
+| `backend.trust_all_tools` | bool | `true` | Auto-approve all tool calls in kiro backend. Set to `false` to reject tool calls (headless mode has no approval UI). |
+| `backend.agent` | string | `""` | Kiro agent name (maps to ACP `session/set_mode`). Empty uses the default agent. |
+| `backend.model` | string | `""` | Model ID override (maps to ACP `session/set_model`). Empty uses the agent's default model. |
+```
+
+Add a "Kiro backend mode" section explaining:
+- Persistent session across iterations (conversation history accumulates)
+- Tool approval behavior
+- How `backend.agent` and `backend.model` map to ACP operations
+- Parallel branches get independent sessions
+
+Kind auto-detection update: if `command` is or ends with `kiro-cli`, kind is `"kiro"`.
+
+### 4. Update `docs/cli.md`
+
+In the `-b` flag description:
+
+```markdown
+| `-b <backend>`, `--backend <backend>` | Override the backend. `pi` selects the Pi adapter. `kiro` selects the Kiro ACP agent (persistent session). `claude` adds `-p --dangerously-skip-permissions`. Any other value is treated as a shell command. |
+```
+
+Add a kiro example:
+
+```bash
+autoloops run autocode -b kiro "Fix the login bug"
+autoloops run autocode -b kiro -- --model claude-sonnet-4
+```
+
+### 5. Preset example
+
+Update `presets/autocode/autoloops.toml` with a commented-out kiro configuration:
+
+```toml
+# Kiro ACP backend (persistent agent session):
+# backend.kind = "kiro"
+# backend.command = "kiro-cli"
+# backend.args = ["acp"]
+# backend.trust_all_tools = true
+# backend.agent = ""
+# backend.model = ""
+```
+
+### Acceptance Criteria
+
+- `backend.trust_all_tools`, `backend.agent`, and `backend.model` are read from config and passed to session creation
+- Parallel branches each spawn their own `kiro-cli acp` process with an independent session
+- Branch timeout sends `session/cancel` before process termination
+- `docs/configuration.md` documents all new keys with the kiro backend section
+- `docs/cli.md` documents `-b kiro` with examples
+- Existing pi/command backends are unaffected by the new config keys (they're ignored when kind != kiro)
+
+## Metadata
+
+- **Complexity**: Medium
+- **Parent Task**: `kiro-acp-backend.code-task.md`
+- **Depends On**: Sub-task 1, Sub-task 3

--- a/.agents/tasks/kiro-acp-backend/kiro-acp-backend.code-task.md
+++ b/.agents/tasks/kiro-acp-backend/kiro-acp-backend.code-task.md
@@ -1,0 +1,199 @@
+# Task: Kiro ACP Backend — First-Class Backend with Agent Support
+
+## Description
+
+Add `kiro` as a first-class backend kind in autoloop, communicating with `kiro-cli acp` over the Agent Client Protocol (ACP) — a JSON-RPC 2.0 protocol over stdio. Unlike the existing `pi` and `command` backends which shell out per iteration, the `kiro` backend maintains a persistent ACP session across the entire run, sending prompts via `session/prompt` and receiving streamed responses via `session/notification`. This enables agent features like tool approval, MCP server passthrough, session persistence, and model switching mid-run.
+
+## Background
+
+### Current backend architecture
+
+Autoloop has two backend kinds today:
+
+- `pi` — Shells out to the Pi adapter (`src/pi-adapter.ts`) each iteration. The adapter invokes `pi -p --mode json --no-session`, parses the NDJSON stream, and extracts the final text output. Stateless between iterations.
+- `command` — Shells out to an arbitrary command each iteration, passing the prompt as a CLI arg or via stdin. Captures stdout. Stateless between iterations.
+
+Both are invoked via `buildBackendShellCommand()` in `src/backend/index.ts`, which wraps the child process in a shell script with signal handling. The harness calls `runProcess()` synchronously per iteration and reads the output.
+
+Key files:
+- `src/backend/types.ts` — `BackendSpec`, `BackendRunResult`, `BackendCommandContext`
+- `src/backend/index.ts` — `buildBackendShellCommand()`, `runBackendCommand()`, `normalizeProviderKind()`
+- `src/backend/run-pi.ts` — `buildPiAdapterInvocation()`
+- `src/backend/run-command.ts` — `buildCommandInvocation()`, `runShellCommand()`
+- `src/pi-adapter.ts` — Python bridge script, prompt resolution, NDJSON parsing
+- `src/harness/iteration.ts` — `runIteration()` calls `runProcess()` and reads output
+- `src/harness/types.ts` — `LoopContext.backend`, `BackendSpec` shape
+- `src/commands/run.ts` — `-b` flag parsing, `backendOverrideSpec()`
+
+### Kiro ACP protocol
+
+Kiro CLI exposes an ACP agent via `kiro-cli acp` (stdin/stdout JSON-RPC 2.0). The protocol flow:
+
+1. `initialize` — handshake, exchange capabilities
+2. `session/new` — create a session (returns `sessionId`, available models, modes)
+3. `session/prompt` — send a prompt (returns `PromptResponse` with `stopReason`)
+4. `session/notification` — streamed updates: `agent_message_chunk`, `tool_call`, `tool_call_update`, `available_commands_update`
+5. `session/cancel` — interrupt current turn
+6. `session/set_mode` — switch agent config
+7. `session/set_model` — change model
+
+The ACP SDK (`@agentclientprotocol/sdk`) provides `ClientSideConnection` for managing the JSON-RPC transport over stdio streams.
+
+Key difference from existing backends: ACP is a persistent, bidirectional session — not a one-shot shell command. The agent process stays alive across iterations, maintaining conversation history, tool permissions, and MCP server connections.
+
+## Reference Documentation
+
+- ACP protocol spec: https://agentclientprotocol.com/get-started/introduction
+- ACP SDK (npm): `@agentclientprotocol/sdk`
+- Autoloop backend module: `src/backend/`
+- Autoloop harness iteration: `src/harness/iteration.ts`
+- Autoloop CLI run command: `src/commands/run.ts`
+- Autoloop configuration: `docs/configuration.md`
+
+## Technical Requirements
+
+### 1. ACP client module (`src/backend/acp-client.ts`)
+
+Create a persistent ACP client that manages the `kiro-cli acp` child process:
+
+- Spawn `kiro-cli acp` (or configured command) as a child process with stdio pipes
+- Implement the ACP handshake (`initialize`)
+- Create a session (`session/new` with `cwd` and optional `mcpServers`)
+- Send prompts (`session/prompt`) and collect the full agent response text from streamed `agent_message_chunk` notifications
+- Handle `tool_call` / `tool_call_update` notifications (log them; auto-approve in trust-all mode)
+- Handle `session/cancel` for timeout-based interruption
+- Handle process lifecycle: spawn on first iteration, reuse across iterations, terminate on loop end
+- Parse NDJSON from stdout, route JSON-RPC notifications vs responses
+- Capture the assembled text output as a string (matching `BackendRunResult.output` contract)
+
+### 2. ACP backend runner (`src/backend/run-kiro.ts`)
+
+Create the iteration-level runner that the harness calls:
+
+```typescript
+export interface KiroSessionState {
+  process: ChildProcess;
+  connection: AcpClientConnection;
+  sessionId: string;
+}
+
+export async function runKiroIteration(
+  state: KiroSessionState,
+  prompt: string,
+  timeoutMs: number,
+): Promise<BackendRunResult>
+```
+
+- Send the prompt via `session/prompt`
+- Collect `agent_message_chunk` text deltas until `stopReason: EndTurn` or `stopReason: Cancelled`
+- On timeout: send `session/cancel`, wait briefly, return `timedOut: true`
+- On error: capture error text, return `exitCode: 1`
+- Return assembled text as `output`, matching the `BackendRunResult` interface
+
+### 3. Session lifecycle management
+
+- `initKiroSession(spec: BackendSpec, cwd: string): Promise<KiroSessionState>` — spawn process, initialize, create session
+- `terminateKiroSession(state: KiroSessionState): Promise<void>` — graceful shutdown (SIGTERM, wait, SIGKILL fallback)
+- The harness must call `initKiroSession` before the first iteration and `terminateKiroSession` after the loop ends (success, failure, or signal)
+- Store `KiroSessionState` on `LoopContext` or as a module-level singleton scoped to the run
+
+### 4. Backend kind registration
+
+Update `src/backend/index.ts`:
+- Add `"kiro"` as a recognized backend kind alongside `"pi"` and `"command"`
+- In `normalizeProviderKind()`: detect `kiro-cli` or `kiro` command → return `"kiro"`
+- In `buildBackendShellCommand()`: for `kind === "kiro"`, skip shell wrapping — the ACP client handles process management directly
+
+Update `src/commands/run.ts`:
+- In `backendOverrideSpec()`: add `"kiro"` case:
+  ```typescript
+  if (backend === "kiro") {
+    return { kind: "kiro", command: "kiro-cli", args: ["acp"], prompt_mode: "acp" };
+  }
+  ```
+
+### 5. Harness integration
+
+Update `src/harness/iteration.ts` (`runIteration`):
+- Before the existing `runProcess()` call, check `loop.backend.kind === "kiro"`
+- If kiro: call `runKiroIteration()` instead of `runProcess(buildBackendShellCommand(...))`
+- The kiro path must still produce a `BackendRunResult` with `output`, `exitCode`, `timedOut` so the rest of the iteration flow (journal append, event extraction, completion check) works unchanged
+
+Update `src/harness/index.ts` (run lifecycle):
+- After `buildLoopContext()`, if `backend.kind === "kiro"`, call `initKiroSession()`
+- After the loop ends, call `terminateKiroSession()`
+- On SIGINT/SIGTERM, ensure the kiro process is cleaned up
+
+### 6. Configuration
+
+Add to `docs/configuration.md` and support in config parsing:
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `backend.kind` | string | `"pi"` | Now accepts `"kiro"` in addition to `"pi"` and `"command"` |
+| `backend.trust_all_tools` | bool | `true` | Auto-approve all tool calls (default true for headless loop operation) |
+| `backend.agent` | string | `""` | Kiro agent name to use (maps to `session/set_mode`). Empty = default agent. |
+| `backend.model` | string | `""` | Model ID override (maps to `session/set_model`). Empty = agent default. |
+
+### 7. Review (metareview) support
+
+The review pass should also work with the kiro backend:
+- Reuse the same ACP session (same process, same session ID) for review iterations
+- The review prompt is sent as a normal `session/prompt` — the agent's conversation history provides continuity
+- Alternatively, if review isolation is needed, create a second ACP session within the same process
+
+### 8. Parallel branch support
+
+For parallel waves, each branch needs its own ACP session:
+- Branch runs should spawn their own `kiro-cli acp` process (independent session)
+- The branch's `BackendSpec` should carry `kind: "kiro"` so the branch harness initializes its own session
+- Branch timeout should trigger `session/cancel` before process termination
+
+## Dependencies
+
+- `@agentclientprotocol/sdk` npm package (for `ClientSideConnection`, `ndJsonStream`, protocol types)
+- `kiro-cli` binary available on PATH (or configured via `backend.command`)
+
+## Implementation Approach
+
+1. Start with the ACP client module — get `initialize` → `session/new` → `session/prompt` → collect response working as a standalone script
+2. Wire it into the backend module as `kind: "kiro"` with the `-b kiro` CLI flag
+3. Integrate session lifecycle into the harness run loop
+4. Add tool approval handling (default: trust all for headless operation)
+5. Add configuration keys and documentation
+6. Test with a real `kiro-cli acp` process against a simple preset
+
+## Acceptance Criteria
+
+1. `autoloops run autocode -b kiro "Fix the bug"` spawns `kiro-cli acp`, creates a session, and runs the loop with prompts sent via ACP
+2. The agent process persists across iterations — conversation history accumulates naturally
+3. Tool calls are auto-approved by default (`trust_all_tools: true`)
+4. Timeout triggers `session/cancel` and returns `timedOut: true`
+5. Backend errors (process crash, ACP error) return `exitCode: 1` with error text
+6. The kiro process is cleaned up on loop completion, failure, or signal
+7. `backend.agent` switches the agent mode via `session/set_mode` at session creation
+8. `backend.model` overrides the model via `session/set_model` at session creation
+9. Parallel branches each get their own independent ACP session
+10. Review iterations work through the same ACP session
+11. Journal entries, event extraction, and completion detection work identically to other backends
+12. `autoloops inspect output <N>` shows the agent's text response for each iteration
+13. Existing `pi` and `command` backends are completely unchanged
+
+## Sub-tasks
+
+| # | Path | Title | Depends On | Complexity |
+|---|------|-------|------------|------------|
+| 1 | `kiro-acp-backend-1-acp-client.code-task.md` | ACP Client Module | None | Medium |
+| 2 | `kiro-acp-backend-2-backend-registration.code-task.md` | Backend Kind Registration and CLI Flag | 1 | Small |
+| 3 | `kiro-acp-backend-3-harness-integration.code-task.md` | Harness Integration — Session Lifecycle and Iteration Dispatch | 1, 2 | Medium |
+| 4 | `kiro-acp-backend-4-config-parallel-docs.code-task.md` | Configuration, Parallel Branch Support, and Documentation | 1, 3 | Medium |
+
+## Execution Order
+
+Sub-tasks 1 and 2 can be developed in sequence (2 depends on 1's types). Sub-task 3 depends on both. Sub-task 4 depends on 1 and 3 but can be partially worked in parallel with 3 (docs and config reading are independent of the harness wiring).
+
+## Metadata
+
+- **Complexity**: Large
+- **Labels**: backend, acp, kiro, agent-protocol, integration
+- **Required Skills**: TypeScript, JSON-RPC, child process management, ACP protocol, autoloop harness internals

--- a/.pi/agents/supervisor.md
+++ b/.pi/agents/supervisor.md
@@ -1,0 +1,33 @@
+---
+name: supervisor
+# tools: read,write,edit,bash,grep,find,ls
+# model:
+# standalone: true
+---
+
+<!-- ═══════════════════════════════════════════════════════════════════
+  Project-Specific Supervisor Guidance
+
+  This file is COMPOSED with the base supervisor prompt shipped in the
+  taskplane package. Your content here is appended after the base prompt.
+
+  The base prompt (maintained by taskplane) handles:
+  - Supervisor identity and standing orders
+  - Recovery action classification and autonomy levels
+  - Audit trail format and rules
+  - Batch monitoring, failure handling, operator communication
+  - Orchestrator tool reference (orch_status, orch_pause, etc.)
+  - Startup checklist and operational knowledge
+
+  Add project-specific supervisor rules below. Common examples:
+  - Run linter before integration ("always run `npm run lint` after merge")
+  - CI dashboard URL for failure triage
+  - PR template or label conventions
+  - Project-specific recovery procedures
+  - Team notification preferences (Slack, etc.)
+  - Custom health check commands
+
+  To override frontmatter values (tools, model), uncomment and edit above.
+  To use this file as a FULLY STANDALONE prompt (ignoring the base),
+  uncomment `standalone: true` above and write the complete prompt below.
+═══════════════════════════════════════════════════════════════════ -->

--- a/.pi/taskplane.json
+++ b/.pi/taskplane.json
@@ -1,0 +1,9 @@
+{
+  "migrations": {
+    "applied": {
+      "add-supervisor-local-template-v1": {
+        "appliedAt": "2026-04-03T19:09:22.069Z"
+      }
+    }
+  }
+}

--- a/1
+++ b/1
@@ -1,0 +1,5 @@
+error: unexpected argument '2' found
+
+Usage: kiro-cli-chat chat [OPTIONS] [INPUT]
+
+For more information, try '--help'.

--- a/PROMPT.md
+++ b/PROMPT.md
@@ -1,0 +1,17 @@
+❯ autoloop run autoqa -b kiro "qa the acp changes that landed"
+[autoloops] [info] loop start run_id=run-mnnjjs3r-d3a0 max_iterations=100
+file:///Users/mobrienv/Code/autoloop/dist/backend/kiro-bridge.js:42
+        throw new Error("Failed to init kiro session: " + result.error);
+              ^
+
+Error: Failed to init kiro session: unknown command: undefined
+    at initKiroSession (file:///Users/mobrienv/Code/autoloop/dist/backend/kiro-bridge.js:42:15)
+    at Module.run (file:///Users/mobrienv/Code/autoloop/dist/harness/index.js:38:28)
+    at dispatchRun (file:///Users/mobrienv/Code/autoloop/dist/commands/run.js:28:13)
+    at dispatch (file:///Users/mobrienv/Code/autoloop/dist/main.js:31:13)
+    at main (file:///Users/mobrienv/Code/autoloop/dist/main.js:19:5)
+    at file:///Users/mobrienv/Code/autoloop/dist/main.js:116:1
+    at ModuleJob.run (node:internal/modules/esm/module_job:413:25)
+    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:660:26)
+
+Node.js v24.12.0

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -47,7 +47,7 @@ If the preset argument is missing, the CLI exits with a usage error. If the argu
 
 | Flag | Description |
 |------|-------------|
-| `-b <backend>`, `--backend <backend>` | Override the backend. `pi` selects the built-in Pi adapter. `claude` (or a path ending in `/claude`) adds `-p --dangerously-skip-permissions`. Config-based Claude command backends receive the same injection automatically. Any other value is treated as a shell command. |
+| `-b <backend>`, `--backend <backend>` | Override the backend. `pi` selects the built-in Pi adapter. `kiro` selects the Kiro ACP backend (persistent session via `kiro-cli acp`). `claude` (or a path ending in `/claude`) adds `-p --dangerously-skip-permissions`. Config-based Claude command backends receive the same injection automatically. Any other value is treated as a shell command. |
 | `-p <preset>`, `--preset <preset>` | Resolve a bundled preset name (for example `autocode`) or use an explicit custom preset directory. Useful when you want the prompt to start with path-like text or avoid positional ambiguity. |
 | `-v`, `--verbose` | Enable verbose logging. |
 | `--chain <steps>` | Run an inline chain instead of a single loop. `steps` is a comma-separated list of preset names (e.g. `autocode,autoqa,autoresearch`). |
@@ -57,6 +57,7 @@ If the preset argument is missing, the CLI exits with a usage error. If the argu
 ```bash
 autoloop run autocode
 autoloop run autocode "Fix the login bug"
+autoloop run autocode -b kiro "Fix the login bug"
 autoloop run --preset autocode "Fix the login bug"
 autoloop run . "Fix the login bug" -b pi
 autoloop run . --chain autocode,autoqa "Implement the approved change and validate it"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,13 +50,16 @@ Prompt resolution order: CLI prompt override > `event_loop.prompt` > `event_loop
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `backend.kind` | string | `"pi"` | Backend type. `"pi"` for the Pi adapter (the only supported real adapter). `"command"` for mock/test backends. Auto-detected from `backend.command` if empty or unrecognized. |
+| `backend.kind` | string | `"pi"` | Backend type. `"pi"` for the Pi adapter. `"kiro"` for the Kiro ACP backend (persistent session over Agent Client Protocol). `"command"` for mock/test backends. Auto-detected from `backend.command` if empty or unrecognized. |
 | `backend.command` | string | `"pi"` | Executable to invoke. For `kind = "pi"`, this is the Pi binary path. For `kind = "command"`, any executable. |
 | `backend.timeout_ms` | int | `300000` | Timeout per backend invocation in milliseconds (default 5 minutes). |
 | `backend.args` | list | `[]` | Extra flags appended after the built-in Pi arguments (`-p --mode json --no-session`). Example: `["--model", "anthropic/claude-sonnet-4"]`. |
 | `backend.prompt_mode` | string | `"arg"` | How the prompt is passed to the backend. `"arg"` passes it as a command-line argument. `"stdin"` passes it on standard input. |
+| `backend.trust_all_tools` | bool | `true` | Auto-approve all tool permission requests. Kiro backend only. |
+| `backend.agent` | string | `""` | Agent name to set via ACP `setSessionMode`. Kiro backend only. |
+| `backend.model` | string | `""` | Model ID to set via ACP `unstable_setSessionModel`. Kiro backend only. |
 
-Kind auto-detection: if `kind` is empty or unrecognized, the harness checks whether `command` is or ends with `pi`. If so, kind is `"pi"`; otherwise `"command"`.
+Kind auto-detection: if `kind` is empty or unrecognized, the harness checks whether `command` is or ends with `pi` (→ `"pi"`); otherwise `"command"`. The `"kiro"` kind is not auto-detected — set `backend.kind = "kiro"` explicitly, or use `-b kiro`.
 
 ### Review (metareview)
 
@@ -168,6 +171,23 @@ backend.command = "./examples/mock-backend.sh"
 ```
 
 Command mode invokes the executable directly and captures stdout. It is not a supported production adapter — use Pi for real loops.
+
+## Kiro backend
+
+The kiro backend communicates with `kiro-cli acp` over the Agent Client Protocol (ACP) — a persistent, bidirectional JSON-RPC 2.0 session over stdio. Unlike `pi` and `command` backends which shell out per iteration, the kiro backend maintains a single child process across the entire run. Session state (conversation history, tool permissions) accumulates across iterations.
+
+```toml
+backend.kind = "kiro"
+backend.command = "kiro-cli"
+backend.args = ["acp"]
+backend.trust_all_tools = true
+# backend.agent = "gpu-dev"
+# backend.model = "anthropic/claude-sonnet-4"
+```
+
+Or use the CLI flag: `autoloop run autocode -b kiro`.
+
+The `trust_all_tools` key (default `true`) auto-approves all tool permission requests from the agent. Set to `false` to reject tool calls. The `agent` and `model` keys are optional — when set, they configure the ACP session mode and model at initialization.
 
 ## Preset patterns
 

--- a/docs/rfcs/kiro-agent-role-mapping.md
+++ b/docs/rfcs/kiro-agent-role-mapping.md
@@ -1,0 +1,250 @@
+# RFC: Kiro Agent Role Mapping
+
+**Slug:** `kiro-agent-role-mapping`
+**Status:** Draft
+**Date:** 2026-04-06
+
+## Summary
+
+Add an optional `agent` field to topology roles so each role in a loop can run with a different kiro agent (mode). Users override role→agent mappings via CLI flags, project config, or user config — without editing builtin presets.
+
+## Motivation
+
+Today `backend.agent` sets a single global kiro agent for the entire loop. But roles have fundamentally different jobs — a `builder` role benefits from `gpu-coder` while a `critic` role benefits from `gpu-reviewer`. Forcing one agent across all roles wastes the specialization that kiro agents provide.
+
+## Design
+
+### 1. Topology: `agent` field on roles
+
+Add an optional `agent` string to the `Role` interface and parse it from `topology.toml`:
+
+```toml
+# topology.toml — preset author sets defaults
+[[role]]
+id = "builder"
+agent = "gpu-coder"
+emits = ["review.ready", "build.blocked"]
+prompt_file = "roles/build.md"
+
+[[role]]
+id = "critic"
+agent = "gpu-reviewer"
+emits = ["review.passed", "review.rejected"]
+prompt_file = "roles/critic.md"
+```
+
+Roles without `agent` inherit the global `backend.agent` fallback.
+
+### 2. Config override: `[agents]` section
+
+Users override per-role agents in `autoloops.toml` or `~/.config/autoloop/config.toml`:
+
+```toml
+# autoloops.toml or user config
+[agents]
+builder = "gpu-coder"
+critic = "gpu-reviewer"
+planner = "gpu-multiagent-planner"
+```
+
+Flat dot-notation also works: `agents.builder = "gpu-coder"`.
+
+### 3. CLI override: `--agent-map`
+
+```bash
+autoloop run autocode -b kiro --agent-map builder=gpu-coder,critic=gpu-reviewer "task"
+```
+
+Parsed as CSV of `role=agent` pairs. Stored in `RunOptions.agentMap` and passed through to `LoopContext`.
+
+### 4. Resolution order
+
+For each role, the resolved agent is the first non-empty value from:
+
+1. CLI `--agent-map` for that role ID
+2. Project config `[agents]` section for that role ID
+3. User config `[agents]` section for that role ID
+4. Topology `[[role]]` `agent` field (preset default)
+5. Global `backend.agent`
+6. Empty string (no mode switch — kiro uses its default)
+
+Steps 2–3 are handled automatically by the existing `config.loadLayered()` + `deepMerge` — the `[agents]` section merges like any other config section. Step 1 is applied on top in `reloadLoop()`.
+
+### 5. Per-iteration mode switching
+
+The mode switch happens in `runIteration()`, before the backend call:
+
+```
+iterate(loop, iteration)
+  → reloadLoop(loop)           // re-reads config, resolves agent mappings onto roles
+  → runIteration(loop, iter)
+    → buildIterationContext()   // determines allowedRoles from routing
+    → resolveIterationAgent()   // NEW: pick agent from suggested role(s)
+    → setKiroModeSync()         // NEW: call setSessionMode if agent changed
+    → runKiroIterationSync()    // existing prompt call
+```
+
+**Agent selection logic** (`resolveIterationAgent`):
+- If exactly 1 role is suggested → use that role's `agent`
+- If multiple roles are suggested → use the first suggested role's `agent`
+- If no roles or no topology → use global `backend.agent` fallback
+- If resolved agent equals the current session agent → skip the `setSessionMode` call
+
+### 6. Worker protocol extension
+
+Add a `set_mode` command to the kiro-worker SharedArrayBuffer protocol:
+
+```typescript
+// kiro-worker.ts — new command handler
+case "set_mode": {
+  if (!session) return { ok: false, error: "no session" };
+  await session.connection.setSessionMode({
+    sessionId: session.sessionId,
+    modeId: cmd.modeId,
+  });
+  return { ok: true };
+}
+```
+
+```typescript
+// kiro-bridge.ts — new sync wrapper
+export function setKiroModeSync(handle: KiroSessionHandle, modeId: string): void {
+  const result = sendCommand(handle, { type: "set_mode", modeId });
+  if (!result.ok) throw new Error("Failed to set kiro mode: " + result.error);
+}
+```
+
+### 7. Changes to existing interfaces
+
+**`Role` interface** (topology.ts):
+```typescript
+export interface Role {
+  id: string;
+  prompt: string;
+  promptFile: string;
+  emits: string[];
+  agent: string;  // NEW — resolved agent/mode ID, empty = inherit fallback
+}
+```
+
+**`LoopContext`** (harness/types.ts) — add to `store`:
+```typescript
+store: {
+  ...existing,
+  kiro_current_agent: string;  // tracks current session mode to avoid redundant switches
+}
+```
+
+**`RunOptions`** (harness/types.ts):
+```typescript
+export interface RunOptions {
+  ...existing,
+  agentMap?: Record<string, string>;  // CLI --agent-map overrides
+}
+```
+
+### 8. Agent mapping resolution in `reloadLoop()`
+
+In `config-helpers.ts`, after profile fragments are applied:
+
+```typescript
+// Resolve agent mappings: CLI > config [agents] section > topology default
+const configAgents = readAgentsConfig(cfg);  // reads [agents] section
+const cliAgents = loop.runtime.agentMap ?? {};
+const mergedAgents = { ...configAgents, ...cliAgents };
+finalTopology = {
+  ...finalTopology,
+  roles: applyAgentMappings(finalTopology.roles, mergedAgents, globalAgent),
+};
+```
+
+Where `applyAgentMappings` sets each role's `agent` field:
+- If `mergedAgents[role.id]` exists → use it
+- Else if `role.agent` is non-empty (from topology.toml) → keep it
+- Else → set to `globalAgent` (from `backend.agent`)
+
+Note: use `||` not `??` for fallthrough — `role.agent` is `""` (not null), so `??` would not fall through to the global agent.
+
+### 9. Prompt rendering
+
+The topology role deck already renders role metadata. Add agent to the display when set:
+
+```
+Role deck:
+- role `builder`
+  agent: gpu-coder
+  emits: review.ready, build.blocked
+  prompt: You are the builder.
+```
+
+This gives the model visibility into which agent is active for each role.
+
+## Non-kiro backends
+
+When `backend.kind` is not `"kiro"`, the `agent` field is parsed and stored but the mode-switch call is skipped. The field is inert — no errors, no warnings. This keeps topology files portable across backends.
+
+## Backward compatibility
+
+- Loops without `agent` fields work exactly as before — no agent field means no mode switching
+- `backend.agent` continues to work as the global fallback
+- Existing presets don't need changes (agent fields are optional)
+- Non-kiro backends ignore agent fields silently
+
+## Example: autocode with agents
+
+```toml
+# presets/autocode/topology.toml
+name = "autocode"
+completion = "task.complete"
+
+[[role]]
+id = "planner"
+agent = "gpu-multiagent-planner"
+emits = ["tasks.ready"]
+prompt_file = "roles/planner.md"
+
+[[role]]
+id = "builder"
+agent = "gpu-coder"
+emits = ["review.ready", "build.blocked"]
+prompt_file = "roles/build.md"
+
+[[role]]
+id = "critic"
+agent = "gpu-reviewer"
+emits = ["review.passed", "review.rejected"]
+prompt_file = "roles/critic.md"
+
+[[role]]
+id = "finalizer"
+agent = "gpu-multiagent-ops"
+emits = ["queue.advance", "finalization.failed", "task.complete"]
+prompt_file = "roles/finalizer.md"
+```
+
+User override without editing the preset:
+```toml
+# ~/.config/autoloop/config.toml
+[agents]
+builder = "gpu-dev"
+critic = "gpu-dev"
+```
+
+Or one-off from CLI:
+```bash
+autoloop run autocode -b kiro --agent-map builder=gpu-dev "implement feature X"
+```
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `src/topology.ts` | Add `agent` to `Role` interface, parse from TOML |
+| `src/harness/types.ts` | Add `agentMap` to `RunOptions`, `kiro_current_agent` to store |
+| `src/harness/config-helpers.ts` | Read `[agents]` config, apply mappings in `reloadLoop()` |
+| `src/harness/iteration.ts` | Resolve iteration agent, call `setKiroModeSync` before prompt |
+| `src/backend/kiro-bridge.ts` | Add `setKiroModeSync()` |
+| `src/backend/kiro-worker.ts` | Add `set_mode` command handler |
+| `src/commands/run.ts` | Parse `--agent-map` flag |
+| `docs/topology.md` | Document `agent` field |
+| `docs/configuration.md` | Document `[agents]` section |

--- a/kiro-loop.sh
+++ b/kiro-loop.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec kiro-cli chat --trust-all-tools --agent gpu-dev --no-interactive "$@"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@mobrienv/autoloop",
       "version": "0.1.4",
       "dependencies": {
+        "@agentclientprotocol/sdk": "^0.18.0",
         "@hono/node-server": "^1.19.12",
         "@iarna/toml": "^2.2.5",
         "hono": "^4.12.10"
@@ -22,11 +23,20 @@
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "playwright": "^1.59.1",
-        "typescript": "^5.7.0",
+        "typescript": "^5.9.3",
         "vitest": "^3.0.0"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@agentclientprotocol/sdk": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.18.0.tgz",
+      "integrity": "sha512-JQGEi3EetQ38DLPpYxxnnz1fyo1/3qQEkKfUmj4JfiOJCEtjGWQ0nl54IH4LZceO7zIOrtUUxc+2cJRQbBOChA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -172,9 +182,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -192,9 +199,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -212,9 +216,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -232,9 +233,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1240,6 +1238,7 @@
       "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1645,9 +1644,9 @@
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
     },
@@ -1873,6 +1872,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
       "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2588,13 +2588,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2787,6 +2780,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2885,6 +2879,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -3048,13 +3043,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3093,6 +3081,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/wrap-ansi/node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
@@ -3125,6 +3120,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -60,10 +60,11 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "playwright": "^1.59.1",
-    "typescript": "^5.7.0",
+    "typescript": "^5.9.3",
     "vitest": "^3.0.0"
   },
   "dependencies": {
+    "@agentclientprotocol/sdk": "^0.18.0",
     "@hono/node-server": "^1.19.12",
     "@iarna/toml": "^2.2.5",
     "hono": "^4.12.10"

--- a/presets/autocode/autoloops.toml
+++ b/presets/autocode/autoloops.toml
@@ -20,3 +20,11 @@ harness.instructions_file = "harness.md"
 core.state_dir = ".autoloop"
 core.journal_file = ".autoloop/journal.jsonl"
 core.memory_file = ".autoloop/memory.jsonl"
+
+# Kiro backend (persistent ACP session):
+# backend.kind = "kiro"
+# backend.command = "kiro-cli"
+# backend.args = ["acp"]
+# backend.trust_all_tools = true
+# backend.agent = ""
+# backend.model = ""

--- a/src/agent-map.ts
+++ b/src/agent-map.ts
@@ -1,0 +1,75 @@
+/**
+ * Loads and resolves per-role agent mappings from agents.toml.
+ *
+ * Resolution order:
+ *   1. preset.<name>.<role>  (role-specific)
+ *   2. preset.<name>.default (preset default)
+ *   3. defaults.agent        (global fallback)
+ *   4. undefined              (caller falls back to backend.agent)
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import TOML from "@iarna/toml";
+
+export interface AgentMap {
+  globalDefault: string;
+  presets: Record<string, PresetAgentMap>;
+}
+
+export interface PresetAgentMap {
+  defaultAgent: string;
+  roles: Record<string, string>;
+}
+
+export function loadAgentMap(projectDir: string): AgentMap | null {
+  const path = join(projectDir, "agents.toml");
+  if (!existsSync(path)) return null;
+  const text = readFileSync(path, "utf-8");
+  const parsed = TOML.parse(text) as Record<string, unknown>;
+  return buildAgentMap(parsed);
+}
+
+export function resolveRoleAgent(
+  agentMap: AgentMap | null,
+  presetName: string,
+  roleId: string,
+): string | undefined {
+  if (!agentMap) return undefined;
+
+  const preset = agentMap.presets[presetName];
+  if (preset) {
+    const roleAgent = preset.roles[roleId];
+    if (roleAgent) return roleAgent;
+    if (preset.defaultAgent) return preset.defaultAgent;
+  }
+
+  return agentMap.globalDefault || undefined;
+}
+
+function buildAgentMap(parsed: Record<string, unknown>): AgentMap {
+  const defaults = parsed["defaults"] as Record<string, unknown> | undefined;
+  const globalDefault = typeof defaults?.["agent"] === "string" ? defaults["agent"] : "";
+
+  const presets: Record<string, PresetAgentMap> = {};
+  const presetSection = parsed["preset"] as Record<string, unknown> | undefined;
+  if (presetSection) {
+    for (const [name, value] of Object.entries(presetSection)) {
+      if (typeof value === "object" && value !== null) {
+        presets[name] = buildPresetAgentMap(value as Record<string, unknown>);
+      }
+    }
+  }
+
+  return { globalDefault, presets };
+}
+
+function buildPresetAgentMap(section: Record<string, unknown>): PresetAgentMap {
+  const defaultAgent = typeof section["default"] === "string" ? section["default"] : "";
+  const roles: Record<string, string> = {};
+  for (const [key, value] of Object.entries(section)) {
+    if (key !== "default" && typeof value === "string") {
+      roles[key] = value;
+    }
+  }
+  return { defaultAgent, roles };
+}

--- a/src/backend/acp-client.ts
+++ b/src/backend/acp-client.ts
@@ -15,7 +15,10 @@ export interface AcpSession {
   connection: acp.ClientSideConnection;
   process: ChildProcess;
   textBuffer: string;
+  stderrBuffer: string;
   options: AcpClientOptions;
+  /** Resolves when the child process exits — used to race against hanging prompts */
+  closed: Promise<{ code: number | null; signal: string | null }>;
 }
 
 export interface AcpPromptResult {
@@ -30,15 +33,11 @@ export async function initAcpSession(opts: AcpClientOptions): Promise<AcpSession
     stdio: ["pipe", "pipe", "pipe"],
     cwd: opts.cwd,
     env: process.env,
+    detached: true, // create process group so we can kill the tree with process.kill(-pid)
   });
 
   if (!child.stdout || !child.stdin) {
     throw new Error("Failed to create ACP process stdio streams");
-  }
-
-  // Buffer stderr for diagnostics
-  if (child.stderr) {
-    child.stderr.on("data", () => {});
   }
 
   const session: AcpSession = {
@@ -46,8 +45,22 @@ export async function initAcpSession(opts: AcpClientOptions): Promise<AcpSession
     connection: null as unknown as acp.ClientSideConnection,
     process: child,
     textBuffer: "",
+    stderrBuffer: "",
     options: opts,
+    closed: null as unknown as Promise<{ code: number | null; signal: string | null }>,
   };
+
+  // Buffer stderr for diagnostics
+  if (child.stderr) {
+    child.stderr.on("data", (chunk: Buffer) => {
+      session.stderrBuffer += chunk.toString();
+    });
+  }
+
+  // Track process exit so hanging prompts can bail out
+  session.closed = new Promise((resolve) => {
+    child.on("close", (code, signal) => resolve({ code, signal }));
+  });
 
   // Build transport: manual NDJSON parsing on stdout (more reliable), SDK serialization on stdin
   const stdin = child.stdin;
@@ -79,7 +92,16 @@ export async function initAcpSession(opts: AcpClientOptions): Promise<AcpSession
     for (const line of lines) {
       const trimmed = line.trim();
       if (trimmed) {
-        try { msgController.enqueue(JSON.parse(trimmed)); } catch { /* skip malformed */ }
+        try {
+          const msg = JSON.parse(trimmed);
+          // Filter kiro-cli private notifications — the ACP SDK doesn't know about
+          // _kiro.dev/* methods and responds with -32601 "Method not found".
+          // These are private kiro-cli extensions the ACP SDK does not handle.
+          if (msg.method && typeof msg.method === "string" && msg.method.startsWith("_kiro.dev/")) {
+            continue;
+          }
+          msgController.enqueue(msg);
+        } catch { /* skip malformed */ }
       }
     }
   });
@@ -144,6 +166,30 @@ export async function sendAcpPrompt(
 ): Promise<AcpPromptResult> {
   session.textBuffer = "";
 
+  // Retry with backoff if agent isn't idle yet
+  const maxAttempts = 3;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await sendAcpPromptOnce(session, prompt, timeoutMs);
+    } catch (err: any) {
+      if (err.message?.includes("not idle") && attempt < maxAttempts) {
+        await new Promise((r) => setTimeout(r, attempt * 2000));
+        continue;
+      }
+      throw err;
+    }
+  }
+  // unreachable, but satisfies TS
+  return { output: session.textBuffer, stopReason: "end_turn", timedOut: false, error: "retry exhausted" };
+}
+
+async function sendAcpPromptOnce(
+  session: AcpSession,
+  prompt: string,
+  timeoutMs: number,
+): Promise<AcpPromptResult> {
+  session.textBuffer = "";
+
   let timedOut = false;
   let timer: ReturnType<typeof setTimeout> | undefined;
 
@@ -155,6 +201,13 @@ export async function sendAcpPrompt(
     }, timeoutMs);
   });
 
+  // Detect process crash mid-prompt
+  const crashPromise = session.closed.then(({ code, signal }) => {
+    const stderr = session.stderrBuffer.trim();
+    const detail = stderr ? `\n${stderr}` : "";
+    throw new Error(`kiro-cli exited unexpectedly: code=${code} signal=${signal}${detail}`);
+  });
+
   try {
     const response = await Promise.race([
       session.connection.prompt({
@@ -162,6 +215,7 @@ export async function sendAcpPrompt(
         prompt: [{ type: "text", text: prompt }],
       }),
       timeoutPromise,
+      crashPromise,
     ]);
     clearTimeout(timer);
     return { output: session.textBuffer, stopReason: response.stopReason, timedOut: false };
@@ -178,12 +232,21 @@ export async function terminateAcpSession(session: AcpSession): Promise<void> {
   const child = session.process;
   if (!child.pid || child.killed) return;
 
+  // Cancel any in-flight turn before killing
+  try { session.connection.cancel({ sessionId: session.sessionId }); } catch { /* may not have a session */ }
+
+  // Kill the entire process tree — MCP servers run in their own process groups
+  // and won't die from just killing the parent.
+  const pid = child.pid;
+  try { process.kill(-pid, "SIGTERM"); } catch { /* process group may not exist */ }
   child.kill("SIGTERM");
+
   const exited = await Promise.race([
     new Promise<boolean>((resolve) => child.on("exit", () => resolve(true))),
     new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 3000)),
   ]);
   if (!exited && !child.killed) {
+    try { process.kill(-pid, "SIGKILL"); } catch { /* already dead */ }
     child.kill("SIGKILL");
   }
 }

--- a/src/backend/acp-client.ts
+++ b/src/backend/acp-client.ts
@@ -1,0 +1,189 @@
+import * as acp from "@agentclientprotocol/sdk";
+import { spawn, type ChildProcess } from "node:child_process";
+
+export interface AcpClientOptions {
+  command: string;
+  args: string[];
+  cwd: string;
+  trustAllTools: boolean;
+  agentName?: string;
+  modelId?: string;
+}
+
+export interface AcpSession {
+  sessionId: string;
+  connection: acp.ClientSideConnection;
+  process: ChildProcess;
+  textBuffer: string;
+  options: AcpClientOptions;
+}
+
+export interface AcpPromptResult {
+  output: string;
+  stopReason: acp.StopReason;
+  timedOut: boolean;
+  error?: string;
+}
+
+export async function initAcpSession(opts: AcpClientOptions): Promise<AcpSession> {
+  const child = spawn(opts.command, opts.args, {
+    stdio: ["pipe", "pipe", "pipe"],
+    cwd: opts.cwd,
+    env: process.env,
+  });
+
+  if (!child.stdout || !child.stdin) {
+    throw new Error("Failed to create ACP process stdio streams");
+  }
+
+  // Buffer stderr for diagnostics
+  if (child.stderr) {
+    child.stderr.on("data", () => {});
+  }
+
+  const session: AcpSession = {
+    sessionId: "",
+    connection: null as unknown as acp.ClientSideConnection,
+    process: child,
+    textBuffer: "",
+    options: opts,
+  };
+
+  // Build transport: manual NDJSON parsing on stdout (more reliable), SDK serialization on stdin
+  const stdin = child.stdin;
+  const stdout = child.stdout;
+
+  const writable = new WritableStream<Uint8Array>({
+    async write(chunk) {
+      if (stdin.destroyed || stdin.writableEnded) return;
+      return new Promise<void>((resolve, reject) => {
+        stdin.write(chunk, (err) => (err ? reject(err) : resolve()));
+      });
+    },
+    close() { stdin.end(); },
+    abort(reason) { stdin.destroy(reason instanceof Error ? reason : new Error(String(reason))); },
+  });
+
+  let buffer = "";
+  const decoder = new TextDecoder();
+  let msgController: ReadableStreamDefaultController<unknown>;
+  const parsedMessages = new ReadableStream<unknown>({
+    start(controller) { msgController = controller; },
+    cancel() { stdout.destroy(); },
+  });
+
+  stdout.on("data", (chunk: Buffer) => {
+    buffer += decoder.decode(chunk, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() || "";
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed) {
+        try { msgController.enqueue(JSON.parse(trimmed)); } catch { /* skip malformed */ }
+      }
+    }
+  });
+  stdout.on("end", () => {
+    if (buffer.trim()) {
+      try { msgController.enqueue(JSON.parse(buffer.trim())); } catch { /* skip */ }
+    }
+    msgController.close();
+  });
+  stdout.on("error", (err) => { msgController.error(err); });
+
+  // Use ndJsonStream only for writable serialization; readable is our manual parser
+  const dummyReadable = new ReadableStream<Uint8Array>({ start() {} });
+  const ndJson = acp.ndJsonStream(writable, dummyReadable);
+  const stream: acp.Stream = { readable: parsedMessages as ReadableStream<acp.AnyMessage>, writable: ndJson.writable };
+
+  const client: acp.Client = {
+    async requestPermission(params: acp.RequestPermissionRequest): Promise<acp.RequestPermissionResponse> {
+      if (opts.trustAllTools && params.options?.length) {
+        const allow = params.options.find(o => o.kind === "allow_always") ?? params.options.find(o => o.kind === "allow_once");
+        if (allow) return { outcome: { outcome: "selected", optionId: allow.optionId } };
+      }
+      return { outcome: { outcome: "cancelled" } };
+    },
+    async sessionUpdate(params: acp.SessionNotification): Promise<void> {
+      const { update } = params;
+      if (!update) return;
+      if (update.sessionUpdate === "agent_message_chunk" && update.content?.type === "text") {
+        session.textBuffer += update.content.text;
+      }
+    },
+  };
+
+  session.connection = new acp.ClientSideConnection(() => client, stream);
+
+  // Initialize
+  await session.connection.initialize({
+    protocolVersion: acp.PROTOCOL_VERSION,
+    clientCapabilities: {},
+    clientInfo: { name: "autoloop", version: "0.1.0" },
+  });
+
+  // Create session
+  const result = await session.connection.newSession({ cwd: opts.cwd, mcpServers: [] });
+  session.sessionId = result.sessionId;
+
+  // Optionally set mode/model
+  if (opts.agentName) {
+    await session.connection.setSessionMode({ sessionId: session.sessionId, modeId: opts.agentName });
+  }
+  if (opts.modelId) {
+    await session.connection.unstable_setSessionModel({ sessionId: session.sessionId, modelId: opts.modelId });
+  }
+
+  return session;
+}
+
+export async function sendAcpPrompt(
+  session: AcpSession,
+  prompt: string,
+  timeoutMs: number,
+): Promise<AcpPromptResult> {
+  session.textBuffer = "";
+
+  let timedOut = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      timedOut = true;
+      session.connection.cancel({ sessionId: session.sessionId });
+      reject(new Error("ACP prompt timed out"));
+    }, timeoutMs);
+  });
+
+  try {
+    const response = await Promise.race([
+      session.connection.prompt({
+        sessionId: session.sessionId,
+        prompt: [{ type: "text", text: prompt }],
+      }),
+      timeoutPromise,
+    ]);
+    clearTimeout(timer);
+    return { output: session.textBuffer, stopReason: response.stopReason, timedOut: false };
+  } catch (err) {
+    clearTimeout(timer);
+    if (timedOut) {
+      return { output: session.textBuffer, stopReason: "cancelled", timedOut: true };
+    }
+    return { output: session.textBuffer, stopReason: "end_turn", timedOut: false, error: String(err) };
+  }
+}
+
+export async function terminateAcpSession(session: AcpSession): Promise<void> {
+  const child = session.process;
+  if (!child.pid || child.killed) return;
+
+  child.kill("SIGTERM");
+  const exited = await Promise.race([
+    new Promise<boolean>((resolve) => child.on("exit", () => resolve(true))),
+    new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 3000)),
+  ]);
+  if (!exited && !child.killed) {
+    child.kill("SIGKILL");
+  }
+}

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -16,6 +16,7 @@ export function normalizeBackendLabel(command: string): string {
   const base = basename(command);
   if (base === "claude") return "claude";
   if (base === "pi") return "pi";
+  if (base === "kiro-cli") return "kiro";
   return base || command;
 }
 
@@ -48,6 +49,7 @@ export function normalizeProviderKind(spec: {
   args: string[];
 }): string {
   if (spec.kind === "pi") return "pi";
+  if (spec.kind === "kiro") return "kiro";
   if (mockBackend(spec.command, spec.args)) return "mock";
   return spec.kind || "command";
 }

--- a/src/backend/kiro-bridge.ts
+++ b/src/backend/kiro-bridge.ts
@@ -84,6 +84,14 @@ export function runKiroIterationSync(
   };
 }
 
+export function setKiroSessionMode(handle: KiroSessionHandle, agentName: string): void {
+  const result = sendCommand(handle, { type: "set_mode", agentName });
+  if (!result.ok) {
+    // Non-fatal: log but don't crash the loop
+    process.stderr.write(`[autoloop] warning: failed to set kiro agent mode "${agentName}": ${result.error}\n`);
+  }
+}
+
 export function terminateKiroSession(handle: KiroSessionHandle): void {
   sendCommand(handle, { type: "terminate" });
   // Signal shutdown

--- a/src/backend/kiro-bridge.ts
+++ b/src/backend/kiro-bridge.ts
@@ -39,6 +39,7 @@ function sendCommand(handle: KiroSessionHandle, cmd: unknown): any {
   const len = new DataView(handle.dataBuffer).getUint32(0);
   const resultJson = decoder.decode(data.slice(4, 4 + len));
   Atomics.store(control, 0, 0); // reset for next command
+  Atomics.notify(control, 0);  // wake worker waiting on Atomics.wait(control, 0, 2)
   return JSON.parse(resultJson);
 }
 

--- a/src/backend/kiro-bridge.ts
+++ b/src/backend/kiro-bridge.ts
@@ -1,0 +1,93 @@
+/**
+ * Synchronous bridge to the kiro ACP worker thread.
+ * Uses SharedArrayBuffer + Atomics to block the main thread
+ * while the worker processes async ACP operations.
+ */
+import { Worker } from "node:worker_threads";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { AcpClientOptions } from "./acp-client.js";
+import type { BackendRunResult } from "./types.js";
+
+const DATA_BUFFER_SIZE = 4 * 1024 * 1024; // 4 MB for prompt/response data
+
+export interface KiroSessionHandle {
+  worker: Worker;
+  controlBuffer: SharedArrayBuffer;
+  dataBuffer: SharedArrayBuffer;
+}
+
+function sendCommand(handle: KiroSessionHandle, cmd: unknown): any {
+  const control = new Int32Array(handle.controlBuffer);
+  const data = new Uint8Array(handle.dataBuffer);
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+
+  // Write command
+  const json = encoder.encode(JSON.stringify(cmd));
+  new DataView(handle.dataBuffer).setUint32(0, json.length);
+  data.set(json, 4);
+
+  // Signal worker
+  Atomics.store(control, 0, 1);
+  Atomics.notify(control, 0);
+
+  // Block until worker signals result (control[0] = 2)
+  Atomics.wait(control, 0, 1);
+
+  // Read result
+  const len = new DataView(handle.dataBuffer).getUint32(0);
+  const resultJson = decoder.decode(data.slice(4, 4 + len));
+  Atomics.store(control, 0, 0); // reset for next command
+  return JSON.parse(resultJson);
+}
+
+export function initKiroSession(opts: AcpClientOptions): KiroSessionHandle {
+  const controlBuffer = new SharedArrayBuffer(4);
+  const dataBuffer = new SharedArrayBuffer(DATA_BUFFER_SIZE);
+  const control = new Int32Array(controlBuffer);
+  Atomics.store(control, 0, 0);
+
+  const workerPath = join(fileURLToPath(import.meta.url), "..", "kiro-worker.js");
+  const worker = new Worker(workerPath, {
+    workerData: { controlBuffer, dataBuffer },
+  });
+
+  const handle: KiroSessionHandle = { worker, controlBuffer, dataBuffer };
+  const result = sendCommand(handle, { type: "init", opts });
+  if (!result.ok) throw new Error("Failed to init kiro session: " + result.error);
+  return handle;
+}
+
+export function runKiroIterationSync(
+  handle: KiroSessionHandle,
+  prompt: string,
+  timeoutMs: number,
+): BackendRunResult {
+  const result = sendCommand(handle, { type: "prompt", prompt, timeoutMs });
+  if (!result.ok) {
+    return {
+      output: result.error || "",
+      exitCode: 1,
+      timedOut: false,
+      providerKind: "kiro",
+      errorCategory: "non_zero_exit",
+    };
+  }
+  return {
+    output: result.output || "",
+    exitCode: result.error ? 1 : 0,
+    timedOut: result.timedOut || false,
+    providerKind: "kiro",
+    errorCategory: result.timedOut ? "timeout" : result.error ? "non_zero_exit" : "none",
+  };
+}
+
+export function terminateKiroSession(handle: KiroSessionHandle): void {
+  sendCommand(handle, { type: "terminate" });
+  // Signal shutdown
+  const control = new Int32Array(handle.controlBuffer);
+  Atomics.store(control, 0, 3);
+  Atomics.notify(control, 0);
+  handle.worker.terminate();
+}

--- a/src/backend/kiro-worker.ts
+++ b/src/backend/kiro-worker.ts
@@ -73,5 +73,9 @@ async function handleCommand(cmd: any): Promise<unknown> {
     writeResult(result);
     Atomics.store(control, 0, 2); // signal result ready
     Atomics.notify(control, 0);
+
+    // Wait for main thread to acknowledge (reset to 0) before looping,
+    // otherwise we'd immediately re-enter and read stale data.
+    Atomics.wait(control, 0, 2);
   }
 })();

--- a/src/backend/kiro-worker.ts
+++ b/src/backend/kiro-worker.ts
@@ -1,0 +1,77 @@
+/**
+ * Worker thread that holds a persistent ACP session.
+ * Communicates with the main thread via SharedArrayBuffer + Atomics.
+ *
+ * Protocol:
+ *   Main → Worker: write JSON command to dataBuffer, signal controlBuffer[0] = 1
+ *   Worker → Main: write JSON result to dataBuffer, signal controlBuffer[0] = 2
+ *   Commands: { type: "init", opts } | { type: "prompt", prompt, timeoutMs } | { type: "terminate" }
+ */
+import { parentPort, workerData } from "node:worker_threads";
+import { initAcpSession, sendAcpPrompt, terminateAcpSession } from "./acp-client.js";
+import type { AcpSession } from "./acp-client.js";
+
+const { controlBuffer, dataBuffer } = workerData as {
+  controlBuffer: SharedArrayBuffer;
+  dataBuffer: SharedArrayBuffer;
+};
+
+const control = new Int32Array(controlBuffer);
+const data = new Uint8Array(dataBuffer);
+const decoder = new TextDecoder();
+const encoder = new TextEncoder();
+
+let session: AcpSession | null = null;
+
+function readCommand(): unknown {
+  const len = new DataView(dataBuffer).getUint32(0);
+  const json = decoder.decode(data.slice(4, 4 + len));
+  return JSON.parse(json);
+}
+
+function writeResult(result: unknown): void {
+  const json = encoder.encode(JSON.stringify(result));
+  new DataView(dataBuffer).setUint32(0, json.length);
+  data.set(json, 4);
+}
+
+async function handleCommand(cmd: any): Promise<unknown> {
+  switch (cmd.type) {
+    case "init": {
+      session = await initAcpSession(cmd.opts);
+      return { ok: true, sessionId: session.sessionId };
+    }
+    case "prompt": {
+      if (!session) return { ok: false, error: "no session" };
+      const result = await sendAcpPrompt(session, cmd.prompt, cmd.timeoutMs);
+      return { ok: true, ...result };
+    }
+    case "terminate": {
+      if (session) await terminateAcpSession(session);
+      session = null;
+      return { ok: true };
+    }
+    default:
+      return { ok: false, error: "unknown command: " + cmd.type };
+  }
+}
+
+(async () => {
+  while (true) {
+    // Wait for main thread to signal a command (control[0] = 1)
+    Atomics.wait(control, 0, 0);
+    if (Atomics.load(control, 0) === 3) break; // shutdown signal
+
+    const cmd = readCommand();
+    let result: unknown;
+    try {
+      result = await handleCommand(cmd);
+    } catch (err: unknown) {
+      result = { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+
+    writeResult(result);
+    Atomics.store(control, 0, 2); // signal result ready
+    Atomics.notify(control, 0);
+  }
+})();

--- a/src/backend/kiro-worker.ts
+++ b/src/backend/kiro-worker.ts
@@ -46,6 +46,15 @@ async function handleCommand(cmd: any): Promise<unknown> {
       const result = await sendAcpPrompt(session, cmd.prompt, cmd.timeoutMs);
       return { ok: true, ...result };
     }
+    case "set_mode": {
+      if (!session) return { ok: false, error: "no session" };
+      try {
+        await session.connection.setSessionMode({ sessionId: session.sessionId, modeId: cmd.agentName });
+        return { ok: true };
+      } catch (err: unknown) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) };
+      }
+    }
     case "terminate": {
       if (session) await terminateAcpSession(session);
       session = null;

--- a/src/backend/run-kiro.ts
+++ b/src/backend/run-kiro.ts
@@ -1,0 +1,18 @@
+import type { AcpSession } from "./acp-client.js";
+import { sendAcpPrompt } from "./acp-client.js";
+import type { BackendRunResult } from "./types.js";
+
+export async function runKiroIteration(
+  session: AcpSession,
+  prompt: string,
+  timeoutMs: number,
+): Promise<BackendRunResult> {
+  const result = await sendAcpPrompt(session, prompt, timeoutMs);
+  return {
+    output: result.output,
+    exitCode: result.error ? 1 : 0,
+    timedOut: result.timedOut,
+    providerKind: "kiro",
+    errorCategory: result.timedOut ? "timeout" : result.error ? "non_zero_exit" : "none",
+  };
+}

--- a/src/chains/load.ts
+++ b/src/chains/load.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import TOML from "@iarna/toml";
 import * as config from "../config.js";
@@ -46,11 +46,13 @@ export function resolvePresetDir(name: string, projectDir: string): string {
   if (existsSync(candidate)) return candidate;
   const cwdCandidate = join(".", `presets/${name}`);
   if (existsSync(cwdCandidate)) return cwdCandidate;
+  const userCandidate = join(config.userPresetsDir(), name);
+  if (existsSync(userCandidate)) return userCandidate;
   return name;
 }
 
 export function listKnownPresets(): string[] {
-  return [
+  const builtIn = [
     "autocode",
     "autosimplify",
     "autoideas",
@@ -66,6 +68,18 @@ export function listKnownPresets(): string[] {
     "automerge",
     "autopr",
   ];
+  const userDir = config.userPresetsDir();
+  if (!existsSync(userDir)) return builtIn;
+  try {
+    const entries = readdirSync(userDir, { withFileTypes: true });
+    const userNames = entries
+      .filter((e) => e.isDirectory() && config.projectHasConfig(join(userDir, e.name)))
+      .map((e) => e.name)
+      .filter((n) => !builtIn.includes(n));
+    return [...builtIn, ...userNames];
+  } catch {
+    return builtIn;
+  }
 }
 
 export function getPresetDescription(name: string, projectDir: string): string {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -301,6 +301,9 @@ function backendOverrideSpec(backend: string): Record<string, unknown> {
   if (backend === "pi") {
     return { kind: "pi", command: "pi", args: [], prompt_mode: "arg" };
   }
+  if (backend === "kiro" || backend === "kiro-cli") {
+    return { kind: "kiro", command: "kiro-cli", args: ["acp"], prompt_mode: "acp" };
+  }
   if (claudeBackend(backend)) {
     return {
       kind: "command",

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,6 +26,11 @@ export function userConfigPath(): string {
   return join(xdgHome, "autoloop", "config.toml");
 }
 
+export function userPresetsDir(): string {
+  const xdgHome = process.env["XDG_CONFIG_HOME"] || join(homedir(), ".config");
+  return join(xdgHome, "autoloop", "presets");
+}
+
 export function hasUserConfig(): boolean {
   return existsSync(userConfigPath());
 }
@@ -231,6 +236,8 @@ function resolveBundledPresetDir(name: string, bundleRoot: string): string {
   if (projectHasConfig(bundleCandidate)) return bundleCandidate;
   const cwdCandidate = join(".", `presets/${name}`);
   if (projectHasConfig(cwdCandidate)) return cwdCandidate;
+  const userCandidate = join(userPresetsDir(), name);
+  if (projectHasConfig(userCandidate)) return userCandidate;
   return "";
 }
 

--- a/src/harness/config-helpers.ts
+++ b/src/harness/config-helpers.ts
@@ -6,6 +6,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { basename, join, resolve } from "node:path";
+import { loadAgentMap } from "../agent-map.js";
 import * as config from "../config.js";
 import { presetCategory, resolveIsolationMode } from "../isolation/resolve.js";
 import { createRunScopedDir } from "../isolation/run-scope.js";
@@ -431,6 +432,7 @@ export function reloadLoop(loop: LoopContext): LoopContext {
         kiro_model: config.get(cfg, "backend.model", ""),
       } : {}),
     },
+    agentMap: loadAgentMap(pd),
   };
   return applyRuntimeModeOverrides(updated);
 }

--- a/src/harness/config-helpers.ts
+++ b/src/harness/config-helpers.ts
@@ -92,6 +92,7 @@ export function installRuntimeTools(loop: LoopContext): void {
 
 export function resolveProcessKind(kind: string, command: string): string {
   if (kind === "pi") return "pi";
+  if (kind === "kiro") return "kiro";
   if (kind === "command") return "command";
   return piBinary(command) ? "pi" : "command";
 }
@@ -422,7 +423,14 @@ export function reloadLoop(loop: LoopContext): LoopContext {
     paths: loop.paths,
     runtime: loop.runtime,
     launch: loop.launch,
-    store: loop.store,
+    store: {
+      ...loop.store,
+      ...(backend.kind === "kiro" ? {
+        kiro_trust_all_tools: config.get(cfg, "backend.trust_all_tools", "true") !== "false",
+        kiro_agent: config.get(cfg, "backend.agent", ""),
+        kiro_model: config.get(cfg, "backend.model", ""),
+      } : {}),
+    },
   };
   return applyRuntimeModeOverrides(updated);
 }

--- a/src/harness/index.ts
+++ b/src/harness/index.ts
@@ -1,5 +1,10 @@
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
+import type { AcpClientOptions } from "../backend/acp-client.js";
+import {
+  initKiroSession,
+  terminateKiroSession,
+} from "../backend/kiro-bridge.js";
 import * as config from "../config.js";
 import { registryStart, registryStop } from "../registry/harness.js";
 import { cleanWorktrees } from "../worktree/clean.js";
@@ -48,13 +53,6 @@ import {
 } from "./parallel.js";
 import { renderRunScratchpadFull } from "./scratchpad.js";
 import { stopMaxIterations } from "./stop.js";
-import { registryStart } from "../registry/harness.js";
-import { updateStatus as updateWorktreeStatus, readMeta } from "../worktree/meta.js";
-import { mergeWorktree } from "../worktree/merge.js";
-import { cleanWorktrees } from "../worktree/clean.js";
-import { initKiroSession, terminateKiroSession } from "../backend/kiro-bridge.js";
-import type { AcpClientOptions } from "../backend/acp-client.js";
-import * as config from "../config.js";
 import type { LoopContext, RunOptions, RunSummary } from "./types.js";
 
 export type { LoopContext, RunOptions, RunSummary };

--- a/src/harness/index.ts
+++ b/src/harness/index.ts
@@ -48,6 +48,13 @@ import {
 } from "./parallel.js";
 import { renderRunScratchpadFull } from "./scratchpad.js";
 import { stopMaxIterations } from "./stop.js";
+import { registryStart } from "../registry/harness.js";
+import { updateStatus as updateWorktreeStatus, readMeta } from "../worktree/meta.js";
+import { mergeWorktree } from "../worktree/merge.js";
+import { cleanWorktrees } from "../worktree/clean.js";
+import { initKiroSession, terminateKiroSession } from "../backend/kiro-bridge.js";
+import type { AcpClientOptions } from "../backend/acp-client.js";
+import * as config from "../config.js";
 import type { LoopContext, RunOptions, RunSummary } from "./types.js";
 
 export type { LoopContext, RunOptions, RunSummary };
@@ -95,7 +102,28 @@ export function run(
     "info",
     `loop start run_id=${loop.runtime.runId} max_iterations=${loop.limits.maxIterations}`,
   );
-  const summary = iterate(loop, 1);
+
+  // Initialize kiro ACP session if backend is kiro
+  if (loop.backend.kind === "kiro") {
+    const acpOpts: AcpClientOptions = {
+      command: loop.backend.command,
+      args: loop.backend.args,
+      cwd: loop.paths.workDir,
+      trustAllTools: loop.store.kiro_trust_all_tools !== false,
+      agentName: (loop.store.kiro_agent as string) || undefined,
+      modelId: (loop.store.kiro_model as string) || undefined,
+    };
+    loop.kiroSession = initKiroSession(acpOpts);
+  }
+
+  let summary: RunSummary;
+  try {
+    summary = iterate(loop, 1);
+  } finally {
+    if (loop.kiroSession) {
+      terminateKiroSession(loop.kiroSession);
+    }
+  }
 
   // Clean up signal handlers on normal exit
   process.removeListener("SIGINT", onSignal);
@@ -355,6 +383,7 @@ function resolveJournalAndRun(
 
 function iterate(loop: LoopContext, iteration: number): RunSummary {
   const liveLoop = reloadLoop(loop);
+  liveLoop.kiroSession = loop.kiroSession;
   installRuntimeTools(liveLoop);
   const reviewed = maybeRunMetareview(liveLoop, iteration);
 

--- a/src/harness/iteration.ts
+++ b/src/harness/iteration.ts
@@ -1,12 +1,9 @@
+import {
+  runKiroIterationSync,
+  setKiroSessionMode,
+} from "../backend/kiro-bridge.js";
 import { registryProgress } from "../registry/harness.js";
 import { listText } from "../utils.js";
-import { readRunLines, extractTopic, extractField, extractIteration } from "./journal.js";
-import { invalidEvent, systemTopic, parallelTriggerTopic, appendInvalidEvent } from "./emit.js";
-import { buildIterationContext } from "./prompt.js";
-import type { IterationContext } from "./prompt.js";
-import type { LoopContext, RunSummary } from "./types.js";
-import { runKiroIterationSync } from "../backend/kiro-bridge.js";
-import { executeParallelWave, continueAfterParallelJoin, stopAfterParallelWave } from "./wave.js";
 import {
   log,
   printBackendOutputTail,
@@ -57,9 +54,29 @@ export function runIteration(
   log(loop, "debug", `backend start command=${loop.backend.command}`);
 
   const startEpoch = Math.floor(Date.now() / 1000);
-  const { output, exitCode, timedOut } = loop.backend.kind === "kiro" && loop.kiroSession
-    ? runKiroIterationSync(loop.kiroSession, iter.prompt, loop.backend.timeoutMs)
-    : runProcess(buildBackendCommand(loop, iter), loop.backend.timeoutMs, loop.backend.kind);
+
+  // Switch Kiro session agent mode per-role if agents.toml provides a mapping
+  if (iter.roleAgent && loop.backend.kind === "kiro" && loop.kiroSession) {
+    log(
+      loop,
+      "debug",
+      `switching kiro agent to "${iter.roleAgent}" for role "${iter.allowedRoles[0]}"`,
+    );
+    setKiroSessionMode(loop.kiroSession, iter.roleAgent);
+  }
+
+  const { output, exitCode, timedOut } =
+    loop.backend.kind === "kiro" && loop.kiroSession
+      ? runKiroIterationSync(
+          loop.kiroSession,
+          iter.prompt,
+          loop.backend.timeoutMs,
+        )
+      : runProcess(
+          buildBackendCommand(loop, iter),
+          loop.backend.timeoutMs,
+          loop.backend.kind,
+        );
   const elapsedS = Math.floor(Date.now() / 1000) - startEpoch;
 
   appendBackendFinish(loop, iter, output, exitCode, timedOut);

--- a/src/harness/iteration.ts
+++ b/src/harness/iteration.ts
@@ -1,5 +1,12 @@
 import { registryProgress } from "../registry/harness.js";
 import { listText } from "../utils.js";
+import { readRunLines, extractTopic, extractField, extractIteration } from "./journal.js";
+import { invalidEvent, systemTopic, parallelTriggerTopic, appendInvalidEvent } from "./emit.js";
+import { buildIterationContext } from "./prompt.js";
+import type { IterationContext } from "./prompt.js";
+import type { LoopContext, RunSummary } from "./types.js";
+import { runKiroIterationSync } from "../backend/kiro-bridge.js";
+import { executeParallelWave, continueAfterParallelJoin, stopAfterParallelWave } from "./wave.js";
 import {
   log,
   printBackendOutputTail,
@@ -50,11 +57,9 @@ export function runIteration(
   log(loop, "debug", `backend start command=${loop.backend.command}`);
 
   const startEpoch = Math.floor(Date.now() / 1000);
-  const { output, exitCode, timedOut } = runProcess(
-    buildBackendCommand(loop, iter),
-    loop.backend.timeoutMs,
-    loop.backend.kind,
-  );
+  const { output, exitCode, timedOut } = loop.backend.kind === "kiro" && loop.kiroSession
+    ? runKiroIterationSync(loop.kiroSession, iter.prompt, loop.backend.timeoutMs)
+    : runProcess(buildBackendCommand(loop, iter), loop.backend.timeoutMs, loop.backend.kind);
   const elapsedS = Math.floor(Date.now() / 1000) - startEpoch;
 
   appendBackendFinish(loop, iter, output, exitCode, timedOut);

--- a/src/harness/metareview.ts
+++ b/src/harness/metareview.ts
@@ -5,6 +5,7 @@ import { appendEvent, readRunLines } from "./journal.js";
 import { buildReviewCommand, runProcess } from "./parallel.js";
 import { renderReviewPromptText } from "./prompt.js";
 import type { LoopContext } from "./types.js";
+import { runKiroIterationSync } from "../backend/kiro-bridge.js";
 
 export function maybeRunMetareview(
   loop: LoopContext,
@@ -12,7 +13,9 @@ export function maybeRunMetareview(
 ): LoopContext {
   if (shouldRunMetareview(loop, iteration)) {
     runMetareviewReview(loop, iteration);
-    return reloadLoop(loop);
+    const reloaded = reloadLoop(loop);
+    reloaded.kiroSession = loop.kiroSession;
+    return reloaded;
   }
   return loop;
 }
@@ -54,11 +57,13 @@ export function runMetareviewReview(
       jsonField("timeout_ms", String(loop.review.timeoutMs)),
   );
 
-  const { output, exitCode, timedOut } = runProcess(
-    buildReviewCommand(loop, iteration, reviewPrompt),
-    loop.review.timeoutMs,
-    loop.review.kind,
-  );
+  const { output, exitCode, timedOut } = loop.review.kind === "kiro" && loop.kiroSession
+    ? runKiroIterationSync(loop.kiroSession, reviewPrompt, loop.review.timeoutMs)
+    : runProcess(
+        buildReviewCommand(loop, iteration, reviewPrompt),
+        loop.review.timeoutMs,
+        loop.review.kind,
+      );
 
   appendEvent(
     loop.paths.journalFile,

--- a/src/harness/prompt.ts
+++ b/src/harness/prompt.ts
@@ -12,6 +12,7 @@ import {
   routingTopic,
   systemTopic,
 } from "./emit.js";
+import { resolveRoleAgent } from "../agent-map.js";
 import type { LoopContext } from "./index.js";
 import {
   extractField,
@@ -32,6 +33,7 @@ export interface IterationContext {
   scratchpadText: string;
   memoryText: string;
   prompt: string;
+  roleAgent: string;
 }
 
 interface DerivedRunContext {
@@ -85,6 +87,8 @@ export function buildIterationContext(
 ): IterationContext {
   const runLines = readRunLines(loop.paths.journalFile, loop.runtime.runId);
   const derived = deriveRunContext(loop, runLines);
+  const activeRole = derived.routing.allowedRoles.length === 1 ? derived.routing.allowedRoles[0] : "";
+  const roleAgent = resolveRoleAgent(loop.agentMap, loop.launch.preset, activeRole) || "";
 
   return {
     iteration,
@@ -96,6 +100,7 @@ export function buildIterationContext(
     scratchpadText: derived.scratchpadText,
     memoryText: derived.memoryText,
     prompt: renderIterationPromptText(loop, iteration, derived),
+    roleAgent,
   };
 }
 

--- a/src/harness/types.ts
+++ b/src/harness/types.ts
@@ -1,4 +1,5 @@
 import type * as topo from "../topology.js";
+import type { KiroSessionHandle } from "../backend/kiro-bridge.js";
 
 export type TriggerSource = "cli" | "chain" | "branch";
 
@@ -69,6 +70,7 @@ export interface LoopContext {
   };
   launch: LaunchMetadata;
   store: Record<string, unknown>;
+  kiroSession?: KiroSessionHandle;
 }
 
 export interface RunOptions {

--- a/src/harness/types.ts
+++ b/src/harness/types.ts
@@ -1,5 +1,6 @@
 import type * as topo from "../topology.js";
 import type { KiroSessionHandle } from "../backend/kiro-bridge.js";
+import type { AgentMap } from "../agent-map.js";
 
 export type TriggerSource = "cli" | "chain" | "branch";
 
@@ -70,6 +71,7 @@ export interface LoopContext {
   };
   launch: LaunchMetadata;
   store: Record<string, unknown>;
+  agentMap: AgentMap | null;
   kiroSession?: KiroSessionHandle;
 }
 

--- a/test/agent-map.test.ts
+++ b/test/agent-map.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadAgentMap, resolveRoleAgent } from "../src/agent-map.js";
+
+function tmpDir(): string {
+  const dir = join(tmpdir(), "agent-map-test-" + Math.random().toString(36).slice(2));
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe("loadAgentMap", () => {
+  it("returns null when agents.toml does not exist", () => {
+    expect(loadAgentMap(tmpDir())).toBeNull();
+  });
+
+  it("parses agents.toml with defaults and presets", () => {
+    const dir = tmpDir();
+    writeFileSync(join(dir, "agents.toml"), `
+[defaults]
+agent = "gpu-dev"
+
+[preset.autocode]
+default = "gpu-dev"
+planner = "gpu-multiagent-planner"
+builder = "gpu-coder"
+critic = "gpu-reviewer"
+`);
+    const map = loadAgentMap(dir);
+    expect(map).not.toBeNull();
+    expect(map!.globalDefault).toBe("gpu-dev");
+    expect(map!.presets["autocode"].defaultAgent).toBe("gpu-dev");
+    expect(map!.presets["autocode"].roles["planner"]).toBe("gpu-multiagent-planner");
+    expect(map!.presets["autocode"].roles["builder"]).toBe("gpu-coder");
+    expect(map!.presets["autocode"].roles["critic"]).toBe("gpu-reviewer");
+  });
+});
+
+describe("resolveRoleAgent", () => {
+  const map = {
+    globalDefault: "gpu-dev",
+    presets: {
+      autocode: {
+        defaultAgent: "gpu-minimal",
+        roles: { planner: "gpu-multiagent-planner", builder: "gpu-coder" },
+      },
+    },
+  };
+
+  it("resolves role-specific agent", () => {
+    expect(resolveRoleAgent(map, "autocode", "planner")).toBe("gpu-multiagent-planner");
+    expect(resolveRoleAgent(map, "autocode", "builder")).toBe("gpu-coder");
+  });
+
+  it("falls back to preset default for unmapped role", () => {
+    expect(resolveRoleAgent(map, "autocode", "critic")).toBe("gpu-minimal");
+  });
+
+  it("falls back to global default for unknown preset", () => {
+    expect(resolveRoleAgent(map, "autofix", "diagnoser")).toBe("gpu-dev");
+  });
+
+  it("returns undefined when no agent map", () => {
+    expect(resolveRoleAgent(null, "autocode", "planner")).toBeUndefined();
+  });
+
+  it("returns undefined when global default is empty and preset not found", () => {
+    const emptyMap = { globalDefault: "", presets: {} };
+    expect(resolveRoleAgent(emptyMap, "autocode", "planner")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Summary

Add Kiro as a backend for autoloop via the [Agent Client Protocol](https://github.com/anthropics/agent-client-protocol) SDK. This enables running autoloop harness loops against `kiro-cli` with persistent sessions, synchronous dispatch, and per-role agent mapping.

### Motivation

Autoloop currently supports shell-based backends. Kiro uses the Agent Client Protocol (ACP) for structured agent communication. This PR bridges the two by implementing a full ACP client layer with a synchronous worker-thread architecture that fits autoloop's synchronous iteration model.

### Architecture

```
Main thread                    Worker thread
┌──────────────┐              ┌──────────────────┐
│ kiro-bridge  │◄─Atomics────►│  kiro-worker     │
│ (sync calls) │  SharedArray │  (async ACP ops)  │
└──────┬───────┘  Buffer      └────────┬──────────┘
       │                               │
       │                        ┌──────▼──────────┐
       │                        │  acp-client      │
       │                        │  (NDJSON/stdio)  │
       │                        └──────┬──────────┘
       │                               │
       │                        ┌──────▼──────────┐
       │                        │  kiro-cli        │
       │                        │  (child process) │
       └───────────────────────►└─────────────────┘
```

- **`acp-client.ts`** — ACP session lifecycle (init, prompt, terminate) over NDJSON/stdio transport. Spawns `kiro-cli` as a child process, manages the `@agentclientprotocol/sdk` `ClientSideConnection`, and auto-approves tool permissions.
- **`kiro-worker.ts`** — Worker thread that holds the persistent ACP session. Communicates with the main thread via `SharedArrayBuffer` + `Atomics` protocol.
- **`kiro-bridge.ts`** — Synchronous bridge exposing `init`/`prompt`/`terminate` to the main thread by blocking on Atomics signals from the worker.
- **`run-kiro.ts`** — Maps ACP prompt results to autoloop's `BackendRunResult` interface.
- **`agent-map.ts`** — Loads `agents.toml` to resolve per-role agent names (e.g., mapping `collector` → `gpu-research`, `publisher` → `gpu-dev`). Resolution: role-specific → preset default → global default → `backend.agent`.

### Harness integration

- Session lifecycle wired into `run()` — init before loop, terminate in `finally`
- Session persists across `reloadLoop` (hot-reload)
- `iteration.ts` dispatches to `runKiroIterationSync` for kiro process kind
- `metareview.ts` dispatches review through the sync bridge for kiro kind
- `config-helpers.ts` recognizes `'kiro'` in `resolveProcessKind()`

### Additional changes

- **User presets directory**: `~/.config/autoloop/presets/` is now scanned alongside bundled and cwd presets
- **CLI**: `-b kiro` / `-b kiro-cli` backend override added
- **Config keys**: `backend.trust_all_tools`, `backend.agent`, `backend.model`
- **Docs**: Updated `cli.md`, `configuration.md`, and added RFC at `docs/rfcs/kiro-agent-role-mapping.md`
- **Dependency**: `@agentclientprotocol/sdk ^0.18.0`

### Session hardening (commit `6a319a2`)

- Track stderr buffer and process exit on `AcpSession` for crash detection
- Race pending prompts against process close to surface `kiro-cli` crashes
- Retry with backoff when agent is not idle
- Kill entire process group on terminate to clean up MCP server children
- Send courtesy cancel before killing to avoid orphaned turns
- Fix worker/bridge race: wait for main thread ack before re-entering loop

### Testing

- 765/765 tests pass (80 test files)
- `npm run build` clean (tsc exit 0)
- New unit tests for `agent-map.ts` in `test/agent-map.test.ts`
- **Note**: `skipLibCheck: true` is set — SDK field names were manually cross-referenced against `@agentclientprotocol/sdk` type definitions

### Commits

1. `13c50cd` feat(backend): Add ACP client module, kiro backend registration, and CLI flag
2. `95830e5` feat(harness): Wire kiro ACP session lifecycle and sync iteration dispatch
3. `6a319a2` fix: Harden ACP session lifecycle and worker synchronization
4. `ad4029e` docs: Add kiro backend configuration and CLI documentation
5. `19a7217` feat(presets): Scan ~/.config/autoloop/presets/ for user presets
6. `9896031` feat: Add Kiro agent role mapping