### PR TITLE
fix: resolve git root from workdir for all worktree operations

### DIFF
--- a/src/commands/worktree.ts
+++ b/src/commands/worktree.ts
@@ -124,9 +124,9 @@ function doMerge(
 ): void {
   const metaDir = join(stateDir, "worktrees", runId);
   const result = mergeWorktree({
-    mainProjectDir: projectDir,
     metaDir,
     strategy,
+    workDir: projectDir,
   });
 
   if (result.success) {
@@ -148,11 +148,11 @@ function doClean(
   opts: { runId?: string; all?: boolean; force?: boolean },
 ): void {
   const result = cleanWorktrees({
-    mainProjectDir: projectDir,
     mainStateDir: stateDir,
     runId: opts.runId,
     all: opts.all,
     force: opts.force,
+    workDir: projectDir,
   });
 
   if (result.removed.length === 0) {

--- a/src/harness/config-helpers.ts
+++ b/src/harness/config-helpers.ts
@@ -21,7 +21,11 @@ import {
   splitCsv,
   uniqueGeneratedId,
 } from "../utils.js";
-import { createWorktree } from "../worktree/create.js";
+import {
+  createWorktree,
+  resolveGitRoot,
+  tryResolveGitRoot,
+} from "../worktree/create.js";
 import {
   extractField,
   extractIteration,
@@ -232,9 +236,10 @@ export function buildLoopContext(
   const resolvedProjectDir = absolutePath(projectDir);
   const resolvedWorkDir = absolutePath(runOptions.workDir || ".");
   const cfg = config.loadProject(resolvedProjectDir);
+  const stateDirAnchor = tryResolveGitRoot(resolvedWorkDir) ?? resolvedWorkDir;
   const stateDir = join(
-    resolvedWorkDir,
-    config.get(cfg, "core.state_dir", ".miniloop"),
+    stateDirAnchor,
+    config.get(cfg, "core.state_dir", ".autoloop"),
   );
   const journalFile = config.resolveJournalFileIn(
     resolvedProjectDir,
@@ -284,16 +289,20 @@ export function buildLoopContext(
   let worktreeMetaDir = "";
 
   if (isolation.mode === "worktree") {
+    const gitRoot = resolveGitRoot(resolvedWorkDir);
     const branchPrefix = config.get(cfg, "worktree.branch_prefix", "autoloop");
     const mergeStrategy =
       runOptions.mergeStrategy ||
       config.get(cfg, "worktree.merge_strategy", "squash");
     const wt = createWorktree({
-      mainProjectDir: resolvedProjectDir,
-      mainStateDir: stateDir,
+      mainStateDir: join(
+        gitRoot,
+        config.get(cfg, "core.state_dir", ".autoloop"),
+      ),
       runId,
       branchPrefix,
       mergeStrategy,
+      workDir: resolvedWorkDir,
     });
     effectiveWorkDir = wt.worktreePath;
     worktreeBranch = wt.branch;
@@ -301,7 +310,7 @@ export function buildLoopContext(
     worktreeMetaDir = wt.metaDir;
     effectiveStateDir = join(
       wt.worktreePath,
-      config.get(cfg, "core.state_dir", ".miniloop"),
+      config.get(cfg, "core.state_dir", ".autoloop"),
     );
   }
 

--- a/src/harness/index.ts
+++ b/src/harness/index.ts
@@ -192,9 +192,9 @@ export function run(
           | "rebase";
         try {
           mergeWorktree({
-            mainProjectDir: loop.paths.mainProjectDir,
             metaDir: loop.paths.worktreeMetaDir,
             strategy,
+            workDir: loop.paths.workDir,
           });
           log(
             loop,
@@ -216,10 +216,10 @@ export function run(
       if (shouldClean) {
         try {
           cleanWorktrees({
-            mainProjectDir: loop.paths.mainProjectDir,
             mainStateDir: loop.paths.baseStateDir,
             runId: loop.runtime.runId,
             force: cleanupPolicy === "always",
+            workDir: loop.paths.workDir,
           });
           log(loop, "info", `worktree cleaned for run ${loop.runtime.runId}`);
         } catch (err: unknown) {

--- a/src/worktree/clean.ts
+++ b/src/worktree/clean.ts
@@ -4,15 +4,16 @@ import { join } from "node:path";
 import { isProcessAlive } from "../loops/health.js";
 import { getRun } from "../registry/read.js";
 import { shellQuote } from "../utils.js";
+import { resolveGitRoot } from "./create.js";
 import type { WorktreeStatus } from "./meta.js";
 import { isOrphanWorktree, readMeta, updateStatus } from "./meta.js";
 
 export interface CleanOpts {
-  mainProjectDir: string;
   mainStateDir: string;
   runId?: string;
   all?: boolean;
   force?: boolean;
+  workDir: string;
 }
 
 export interface CleanResult {
@@ -27,7 +28,8 @@ const TERMINAL_STATUSES: ReadonlySet<WorktreeStatus> = new Set([
 ]);
 
 export function cleanWorktrees(opts: CleanOpts): CleanResult {
-  const { mainProjectDir, mainStateDir, force = false } = opts;
+  const { mainStateDir, force = false, workDir } = opts;
+  const gitRoot = resolveGitRoot(workDir);
   const worktreesDir = join(mainStateDir, "worktrees");
 
   if (!existsSync(worktreesDir)) return { removed: [], skipped: [] };
@@ -84,7 +86,7 @@ export function cleanWorktrees(opts: CleanOpts): CleanResult {
         execSync(
           `git worktree remove ${shellQuote(meta.worktree_path)}${forceFlag}`,
           {
-            cwd: mainProjectDir,
+            cwd: gitRoot,
             stdio: "pipe",
           },
         );
@@ -102,7 +104,7 @@ export function cleanWorktrees(opts: CleanOpts): CleanResult {
     try {
       const deleteFlag = force ? "-D" : "-d";
       execSync(`git branch ${deleteFlag} ${shellQuote(meta.branch)}`, {
-        cwd: mainProjectDir,
+        cwd: gitRoot,
         stdio: "pipe",
       });
     } catch {

--- a/src/worktree/create.ts
+++ b/src/worktree/create.ts
@@ -1,17 +1,17 @@
 import { execSync } from "node:child_process";
-import { rmSync } from "node:fs";
+import { realpathSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { shellQuote } from "../utils.js";
 import type { WorktreeMeta } from "./meta.js";
 import { metaDirForRun, writeMeta } from "./meta.js";
 
 export interface CreateWorktreeOpts {
-  mainProjectDir: string;
   mainStateDir: string;
   runId: string;
   branchPrefix?: string;
   baseBranch?: string;
   mergeStrategy?: string;
+  workDir: string;
 }
 
 export interface CreateWorktreeResult {
@@ -22,20 +22,21 @@ export interface CreateWorktreeResult {
 
 export function createWorktree(opts: CreateWorktreeOpts): CreateWorktreeResult {
   const {
-    mainProjectDir,
     mainStateDir,
     runId,
+    workDir,
     branchPrefix = "autoloop",
     mergeStrategy = "squash",
   } = opts;
 
-  const baseBranch = opts.baseBranch ?? detectBaseBranch(mainProjectDir);
+  const gitRoot = resolveGitRoot(workDir);
+  const baseBranch = opts.baseBranch ?? detectBaseBranch(gitRoot);
   const branch = `${branchPrefix}/${runId}`;
   const metaDir = metaDirForRun(mainStateDir, runId);
   const worktreePath = join(metaDir, "tree");
 
   // Fail fast if branch already exists
-  if (branchExists(mainProjectDir, branch)) {
+  if (branchExists(gitRoot, branch)) {
     throw new Error(
       `branch "${branch}" already exists; cannot create worktree for run ${runId}`,
     );
@@ -45,7 +46,7 @@ export function createWorktree(opts: CreateWorktreeOpts): CreateWorktreeResult {
     execSync(
       `git worktree add ${shellQuote(worktreePath)} -b ${shellQuote(branch)}`,
       {
-        cwd: mainProjectDir,
+        cwd: gitRoot,
         stdio: "pipe",
       },
     );
@@ -74,6 +75,31 @@ export function createWorktree(opts: CreateWorktreeOpts): CreateWorktreeResult {
   writeMeta(metaDir, meta);
 
   return { worktreePath, branch, metaDir };
+}
+
+export function resolveGitRoot(cwd: string): string {
+  try {
+    const result = execSync("git rev-parse --show-toplevel", {
+      cwd,
+      encoding: "utf-8",
+      stdio: "pipe",
+    }).trim();
+    return realpathSync(result);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `autoloop run --worktree requires the current directory to be inside a git repository. ` +
+        `git rev-parse --show-toplevel failed in ${cwd}: ${msg}`,
+    );
+  }
+}
+
+export function tryResolveGitRoot(cwd: string): string | undefined {
+  try {
+    return resolveGitRoot(cwd);
+  } catch {
+    return undefined;
+  }
 }
 
 function detectBaseBranch(projectDir: string): string {

--- a/src/worktree/merge.ts
+++ b/src/worktree/merge.ts
@@ -1,5 +1,6 @@
 import { execSync } from "node:child_process";
 import { shellQuote } from "../utils.js";
+import { resolveGitRoot } from "./create.js";
 import type { WorktreeMeta } from "./meta.js";
 import { readMeta, updateStatus } from "./meta.js";
 
@@ -7,9 +8,9 @@ const DEFAULT_GIT_NAME = "autoloop";
 const DEFAULT_GIT_EMAIL = "autoloop@local";
 
 export interface MergeOpts {
-  mainProjectDir: string;
   metaDir: string;
   strategy?: "squash" | "merge" | "rebase";
+  workDir: string;
 }
 
 export interface MergeResult {
@@ -19,7 +20,8 @@ export interface MergeResult {
 }
 
 export function mergeWorktree(opts: MergeOpts): MergeResult {
-  const { mainProjectDir, metaDir, strategy = "squash" } = opts;
+  const { metaDir, strategy = "squash", workDir } = opts;
+  const gitRoot = resolveGitRoot(workDir);
 
   const meta = readMeta(metaDir);
   if (!meta) throw new Error(`no worktree meta found in ${metaDir}`);
@@ -28,24 +30,24 @@ export function mergeWorktree(opts: MergeOpts): MergeResult {
 
   const baseBranch = meta.base_branch;
   const branch = meta.branch;
-  const gitEnv = resolveGitEnv(mainProjectDir);
+  const gitEnv = resolveGitEnv(gitRoot);
 
   // Checkout base branch
-  exec(mainProjectDir, `git checkout ${shellQuote(baseBranch)}`, gitEnv);
+  exec(gitRoot, `git checkout ${shellQuote(baseBranch)}`, gitEnv);
 
   try {
     if (strategy === "squash") {
-      exec(mainProjectDir, `git merge --squash ${shellQuote(branch)}`, gitEnv);
+      exec(gitRoot, `git merge --squash ${shellQuote(branch)}`, gitEnv);
       exec(
-        mainProjectDir,
+        gitRoot,
         `git commit --no-edit -m ${shellQuote(`merge worktree ${meta.run_id} (squash)`)}`,
         gitEnv,
       );
     } else if (strategy === "rebase") {
-      exec(mainProjectDir, `git rebase ${shellQuote(branch)}`, gitEnv);
+      exec(gitRoot, `git rebase ${shellQuote(branch)}`, gitEnv);
     } else {
       exec(
-        mainProjectDir,
+        gitRoot,
         `git merge --no-ff ${shellQuote(branch)} -m ${shellQuote(`merge worktree ${meta.run_id}`)}`,
         gitEnv,
       );
@@ -53,12 +55,12 @@ export function mergeWorktree(opts: MergeOpts): MergeResult {
   } catch (err: unknown) {
     // Attempt to detect conflicts and abort
     const msg = err instanceof Error ? err.message : String(err);
-    const conflicts = detectConflicts(mainProjectDir);
+    const conflicts = detectConflicts(gitRoot);
     try {
       if (strategy === "rebase") {
-        exec(mainProjectDir, "git rebase --abort", gitEnv);
+        exec(gitRoot, "git rebase --abort", gitEnv);
       } else {
-        exec(mainProjectDir, "git merge --abort", gitEnv);
+        exec(gitRoot, "git merge --abort", gitEnv);
       }
     } catch {
       /* abort best-effort */

--- a/test/harness/automerge-chain.test.ts
+++ b/test/harness/automerge-chain.test.ts
@@ -25,10 +25,15 @@ vi.mock("../../src/worktree/create.js", () => ({
     branch: "autoloop/fake-run",
     metaDir: "/tmp/fake-meta",
   })),
+  resolveGitRoot: vi.fn((cwd: string) => cwd),
 }));
 
 vi.mock("../../src/worktree/clean.js", () => ({
   cleanWorktrees: vi.fn(),
+}));
+
+vi.mock("../../src/worktree/merge.js", () => ({
+  mergeWorktree: vi.fn(),
 }));
 
 vi.mock("../../src/harness/iteration.js", () => ({

--- a/test/worktree/clean.test.ts
+++ b/test/worktree/clean.test.ts
@@ -31,16 +31,16 @@ describe("cleanWorktrees", () => {
     const stateDir = join(repo, ".autoloop");
 
     const wt = createWorktree({
-      mainProjectDir: repo,
       mainStateDir: stateDir,
       runId: "run-clean1",
+      workDir: repo,
     });
 
     updateStatus(wt.metaDir, "merged");
 
     const result = cleanWorktrees({
-      mainProjectDir: repo,
       mainStateDir: stateDir,
+      workDir: repo,
     });
 
     expect(result.removed).toContain("run-clean1");
@@ -52,14 +52,14 @@ describe("cleanWorktrees", () => {
     const stateDir = join(repo, ".autoloop");
 
     createWorktree({
-      mainProjectDir: repo,
       mainStateDir: stateDir,
       runId: "run-running",
+      workDir: repo,
     });
 
     const result = cleanWorktrees({
-      mainProjectDir: repo,
       mainStateDir: stateDir,
+      workDir: repo,
     });
 
     expect(result.removed).toEqual([]);
@@ -71,16 +71,16 @@ describe("cleanWorktrees", () => {
     const stateDir = join(repo, ".autoloop");
 
     const wt = createWorktree({
-      mainProjectDir: repo,
       mainStateDir: stateDir,
       runId: "run-force",
+      workDir: repo,
     });
 
     const result = cleanWorktrees({
-      mainProjectDir: repo,
       mainStateDir: stateDir,
       runId: "run-force",
       force: true,
+      workDir: repo,
     });
 
     expect(result.removed).toContain("run-force");
@@ -92,22 +92,22 @@ describe("cleanWorktrees", () => {
     const stateDir = join(repo, ".autoloop");
 
     createWorktree({
-      mainProjectDir: repo,
       mainStateDir: stateDir,
       runId: "run-keep",
+      workDir: repo,
     });
 
     const wt2 = createWorktree({
-      mainProjectDir: repo,
       mainStateDir: stateDir,
       runId: "run-remove",
+      workDir: repo,
     });
     updateStatus(wt2.metaDir, "failed");
 
     const result = cleanWorktrees({
-      mainProjectDir: repo,
       mainStateDir: stateDir,
       runId: "run-remove",
+      workDir: repo,
     });
 
     expect(result.removed).toContain("run-remove");
@@ -119,8 +119,8 @@ describe("cleanWorktrees", () => {
     const stateDir = join(repo, ".autoloop");
 
     const result = cleanWorktrees({
-      mainProjectDir: repo,
       mainStateDir: stateDir,
+      workDir: repo,
     });
 
     expect(result.removed).toEqual([]);

--- a/test/worktree/create.test.ts
+++ b/test/worktree/create.test.ts
@@ -1,9 +1,9 @@
 import { execSync } from "node:child_process";
-import { existsSync, mkdtempSync } from "node:fs";
+import { existsSync, mkdtempSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { createWorktree } from "../../src/worktree/create.js";
+import { createWorktree, resolveGitRoot } from "../../src/worktree/create.js";
 import { readMeta } from "../../src/worktree/meta.js";
 
 function makeGitRepo(): string {
@@ -28,9 +28,9 @@ describe("createWorktree", () => {
     const stateDir = join(repo, ".autoloop");
 
     const result = createWorktree({
-      mainProjectDir: repo,
       mainStateDir: stateDir,
       runId: "run-test1",
+      workDir: repo,
     });
 
     // Worktree directory exists and is a git working tree
@@ -55,10 +55,10 @@ describe("createWorktree", () => {
     const stateDir = join(repo, ".autoloop");
 
     const result = createWorktree({
-      mainProjectDir: repo,
       mainStateDir: stateDir,
       runId: "run-custom",
       branchPrefix: "wt",
+      workDir: repo,
     });
 
     expect(result.branch).toBe("wt/run-custom");
@@ -70,17 +70,17 @@ describe("createWorktree", () => {
 
     // Create first worktree
     createWorktree({
-      mainProjectDir: repo,
       mainStateDir: stateDir,
       runId: "run-dup",
+      workDir: repo,
     });
 
     // Second attempt with same runId should fail due to branch collision
     expect(() =>
       createWorktree({
-        mainProjectDir: repo,
         mainStateDir: stateDir,
         runId: "run-dup",
+        workDir: repo,
       }),
     ).toThrow(/already exists/);
   });
@@ -90,13 +90,39 @@ describe("createWorktree", () => {
     const stateDir = join(repo, ".autoloop");
 
     const result = createWorktree({
-      mainProjectDir: repo,
       mainStateDir: stateDir,
       runId: "run-merge",
       mergeStrategy: "rebase",
+      workDir: repo,
     });
 
     const meta = readMeta(result.metaDir);
     expect(meta?.merge_strategy).toBe("rebase");
+  });
+});
+
+describe("resolveGitRoot", () => {
+  it("resolves git root from within a repo", () => {
+    const repo = makeGitRepo();
+    const subDir = join(repo, "subdir");
+    execSync("mkdir -p subdir", { cwd: repo, stdio: "pipe" });
+
+    const resolved = resolveGitRoot(subDir);
+    expect(resolved).toBe(realpathSync(repo));
+  });
+
+  it("returns the same canonical path regardless of subdirectory depth", () => {
+    const repo = makeGitRepo();
+    execSync("mkdir -p a/b/c", { cwd: repo, stdio: "pipe" });
+
+    expect(resolveGitRoot(repo)).toBe(resolveGitRoot(join(repo, "a/b/c")));
+  });
+
+  it("throws when called outside a git repo", () => {
+    const nonGitDir = mkdtempSync(join(tmpdir(), "autoloop-ts-non-git-"));
+
+    expect(() => resolveGitRoot(nonGitDir)).toThrow(
+      /requires the current directory to be inside a git repository/,
+    );
   });
 });

--- a/test/worktree/lifecycle.test.ts
+++ b/test/worktree/lifecycle.test.ts
@@ -46,7 +46,7 @@ describe("worktree lifecycle: merge-strategy and cleanup", () => {
     const stateDir = join(repo, ".autoloop");
 
     const wt = createWorktree({
-      mainProjectDir: repo,
+      workDir: repo,
       mainStateDir: stateDir,
       runId: "run-strategy",
       mergeStrategy: "rebase",
@@ -61,7 +61,7 @@ describe("worktree lifecycle: merge-strategy and cleanup", () => {
     const stateDir = join(repo, ".autoloop");
 
     const wt = createWorktree({
-      mainProjectDir: repo,
+      workDir: repo,
       mainStateDir: stateDir,
       runId: "run-automerge",
       mergeStrategy: "squash",
@@ -72,17 +72,17 @@ describe("worktree lifecycle: merge-strategy and cleanup", () => {
 
     // Simulate automerge
     const mergeResult = mergeWorktree({
-      mainProjectDir: repo,
       metaDir: wt.metaDir,
       strategy: "squash",
+      workDir: repo,
     });
     expect(mergeResult.success).toBe(true);
 
     // Simulate cleanup (on_success policy — run succeeded)
     const cleanResult = cleanWorktrees({
-      mainProjectDir: repo,
       mainStateDir: stateDir,
       runId: "run-automerge",
+      workDir: repo,
     });
     expect(cleanResult.removed).toContain("run-automerge");
     expect(existsSync(wt.worktreePath)).toBe(false);
@@ -93,7 +93,7 @@ describe("worktree lifecycle: merge-strategy and cleanup", () => {
     const stateDir = join(repo, ".autoloop");
 
     const wt = createWorktree({
-      mainProjectDir: repo,
+      workDir: repo,
       mainStateDir: stateDir,
       runId: "run-keep",
     });
@@ -112,7 +112,7 @@ describe("worktree lifecycle: merge-strategy and cleanup", () => {
     const stateDir = join(repo, ".autoloop");
 
     const wt = createWorktree({
-      mainProjectDir: repo,
+      workDir: repo,
       mainStateDir: stateDir,
       runId: "run-never-clean",
     });
@@ -129,7 +129,7 @@ describe("worktree lifecycle: merge-strategy and cleanup", () => {
     const stateDir = join(repo, ".autoloop");
 
     const wt = createWorktree({
-      mainProjectDir: repo,
+      workDir: repo,
       mainStateDir: stateDir,
       runId: "run-always-clean",
     });
@@ -138,10 +138,10 @@ describe("worktree lifecycle: merge-strategy and cleanup", () => {
 
     // cleanup=always with force removes failed worktrees
     const cleanResult = cleanWorktrees({
-      mainProjectDir: repo,
       mainStateDir: stateDir,
       runId: "run-always-clean",
       force: true,
+      workDir: repo,
     });
     expect(cleanResult.removed).toContain("run-always-clean");
     expect(existsSync(wt.worktreePath)).toBe(false);
@@ -152,7 +152,7 @@ describe("worktree lifecycle: merge-strategy and cleanup", () => {
     const stateDir = join(repo, ".autoloop");
 
     const wt = createWorktree({
-      mainProjectDir: repo,
+      workDir: repo,
       mainStateDir: stateDir,
       runId: "run-fail-noclean",
     });
@@ -161,9 +161,9 @@ describe("worktree lifecycle: merge-strategy and cleanup", () => {
 
     // on_success policy: should clean terminal-status worktrees (failed is terminal)
     const cleanResult = cleanWorktrees({
-      mainProjectDir: repo,
       mainStateDir: stateDir,
       runId: "run-fail-noclean",
+      workDir: repo,
     });
     // clean.ts removes failed worktrees since they're terminal status
     expect(cleanResult.removed).toContain("run-fail-noclean");

--- a/test/worktree/merge.test.ts
+++ b/test/worktree/merge.test.ts
@@ -86,9 +86,9 @@ describe("mergeWorktree", () => {
     const stateDir = join(repo, ".autoloop");
 
     const wt = createWorktree({
-      mainProjectDir: repo,
       mainStateDir: stateDir,
       runId: "run-merge1",
+      workDir: repo,
     });
 
     // Add a file in the worktree
@@ -99,8 +99,8 @@ describe("mergeWorktree", () => {
 
     const headIdentity = withMissingGitIdentity(() => {
       const result = mergeWorktree({
-        mainProjectDir: repo,
         metaDir: wt.metaDir,
+        workDir: repo,
       });
 
       expect(result.success).toBe(true);
@@ -122,10 +122,10 @@ describe("mergeWorktree", () => {
     const stateDir = join(repo, ".autoloop");
 
     const wt = createWorktree({
-      mainProjectDir: repo,
       mainStateDir: stateDir,
       runId: "run-merge2",
       mergeStrategy: "merge",
+      workDir: repo,
     });
 
     addFileAndCommit(wt.worktreePath, "feature2.txt", "world", "add feature2");
@@ -133,9 +133,9 @@ describe("mergeWorktree", () => {
 
     const headIdentity = withMissingGitIdentity(() => {
       const result = mergeWorktree({
-        mainProjectDir: repo,
         metaDir: wt.metaDir,
         strategy: "merge",
+        workDir: repo,
       });
 
       expect(result.success).toBe(true);
@@ -153,13 +153,16 @@ describe("mergeWorktree", () => {
     const stateDir = join(repo, ".autoloop");
 
     const wt = createWorktree({
-      mainProjectDir: repo,
       mainStateDir: stateDir,
       runId: "run-running",
+      workDir: repo,
     });
 
     expect(() =>
-      mergeWorktree({ mainProjectDir: repo, metaDir: wt.metaDir }),
+      mergeWorktree({
+        metaDir: wt.metaDir,
+        workDir: repo,
+      }),
     ).toThrow(/still running/);
   });
 
@@ -168,17 +171,20 @@ describe("mergeWorktree", () => {
     const stateDir = join(repo, ".autoloop");
 
     const wt = createWorktree({
-      mainProjectDir: repo,
       mainStateDir: stateDir,
       runId: "run-alrmerged",
+      workDir: repo,
     });
 
     addFileAndCommit(wt.worktreePath, "f.txt", "x", "add f");
     updateStatus(wt.metaDir, "completed");
-    mergeWorktree({ mainProjectDir: repo, metaDir: wt.metaDir });
+    mergeWorktree({ metaDir: wt.metaDir, workDir: repo });
 
     expect(() =>
-      mergeWorktree({ mainProjectDir: repo, metaDir: wt.metaDir }),
+      mergeWorktree({
+        metaDir: wt.metaDir,
+        workDir: repo,
+      }),
     ).toThrow(/already merged/);
   });
 
@@ -190,9 +196,9 @@ describe("mergeWorktree", () => {
     addFileAndCommit(repo, "shared.txt", "main content", "add shared on main");
 
     const wt = createWorktree({
-      mainProjectDir: repo,
       mainStateDir: stateDir,
       runId: "run-conflict",
+      workDir: repo,
     });
 
     // Modify the same file differently in the worktree
@@ -215,8 +221,8 @@ describe("mergeWorktree", () => {
 
     // Checkout back to base to set up for merge
     const result = mergeWorktree({
-      mainProjectDir: repo,
       metaDir: wt.metaDir,
+      workDir: repo,
     });
 
     expect(result.success).toBe(false);


### PR DESCRIPTION
## What was wrong
  autoloop run --worktree ran git worktree add with cwd set to the preset directory — the installed npm package path — not the user's repo. Two failure modes depending on where the package
  lived:

  Silent hijack: if the install path was inside another git clone (e.g. nvm itself is a git clone, so npm i -g under nvm puts the package inside nvm's repo), git worktree add happily created
   a worktree of that unrelated repo at a path inside the user's project. git log in the "worktree" showed nvm's commits. The branch autoloop/<run-id> was created in nvm's repo. The agent
  launched against that worktree got confused, started editing the real project via absolute paths, and uncommitted edits leaked into the user's main working tree.

  Clean failure: if the install path wasn't inside any git repo (e.g. bun add -g to ~/.bun/install/global/), the command died with fatal: not a git repository. Correct error, wrong place to
  look.

  The same wrong cwd poisoned base-branch detection too, so meta.json recorded garbage like base_branch: "HEAD" (common because most global installs are detached).

## What this fixes

  Adds resolveGitRoot(), which calls git rev-parse --show-toplevel from the user's actual work directory and normalizes the result through realpathSync (so callers don't trip over macOS
  /private/var/... vs /var/... path drift). Every git operation in create.ts, clean.ts, and merge.ts now runs with cwd: gitRoot instead of the preset dir.

  stateDir is now anchored at the git root for every run, not just worktree mode. Invoking autoloop from a subdirectory no longer buries .autoloop/ inside your build output.

  If --worktree is invoked outside a git repo, it fails fast with a clear message naming --worktree and git instead of the cryptic git error.

  Drive-by cleanups bundled in: drops the now-unused mainProjectDir field from CreateWorktreeOpts / MergeOpts / CleanOpts, and harmonizes the core.state_dir default on .autoloop (an old
  .miniloop fallback was lingering).

  Tests cover happy path, no-git-repo failure, and path stability across subdirectory depths.

## whats in the PR

- Add resolveGitRoot() to find the actual git repo root via git rev-parse --show-toplevel, normalized through realpathSync so callers can compare paths without /private-prefix drift on macOS
- Add tryResolveGitRoot() for the non-worktree stateDir anchor (falls back to workDir when not in a git repo)
- Use git root (not preset dir) for all git worktree operations in create.ts, clean.ts, and merge.ts
- Anchor stateDir at git root for every run, not only worktree mode, so invoking from a subdirectory places .autoloop/ at the repo root
- Drop unused mainProjectDir from CreateWorktreeOpts / MergeOpts / CleanOpts now that gitRoot drives every git call
- Harmonize core.state_dir default on .autoloop (the old .miniloop fallback was left over from the rename)
- Fail fast with a clear error when --worktree is invoked outside a git repo
- Strengthen resolveGitRoot tests: assert canonical-path equality and path stability across subdirectory depths