### PR TITLE
feat(chains): add per-step backend override in chains.toml

### DIFF
--- a/docs/guides/per-step-backend.md
+++ b/docs/guides/per-step-backend.md
@@ -1,0 +1,71 @@
+# Per-step backend override in chains
+
+`chains.toml` supports two forms for declaring the steps of a chain.
+
+## Simple form (unchanged)
+
+```toml
+[[chain]]
+name = "autocode-then-gate"
+steps = ["autocode", "regression-gate"]
+```
+
+Every step uses the backend configured by the preset's own `autoloops.toml`,
+optionally overridden by the CLI `-b` flag.
+
+## Structured form with per-step backend
+
+```toml
+[[chain]]
+name = "plan-then-build"
+
+[[chain.step]]
+preset = "autocode-planner"
+backend = { args = ["--model", "anthropic/claude-opus-4", "--thinking", "high"] }
+
+[[chain.step]]
+preset = "autocode"
+backend = { args = ["--model", "anthropic/claude-haiku-4"] }
+
+[[chain.step]]
+preset = "regression-gate"
+# no backend override — uses the preset's autoloops.toml default
+```
+
+The motivating use case: run a **planner** step on a smarter/slower model and a
+**builder** step on a faster/cheaper model.
+
+## Allowed `backend` keys
+
+Each step's `backend` table may contain any subset of:
+
+| key           | meaning                                             |
+|---------------|-----------------------------------------------------|
+| `kind`        | `"command"` / `"pi"` / `"kiro"`                     |
+| `command`     | backend executable name                             |
+| `args`        | array of CLI args (e.g. `--model`, `--thinking`)    |
+| `prompt_mode` | `"arg"` / `"stdin"` / `"acp"`                       |
+| `timeout_ms`  | per-invocation timeout (forward-compat)             |
+
+Unknown keys are rejected with a clear error.
+
+## Precedence
+
+Highest to lowest:
+
+1. `[[chain.step]].backend` (this feature)
+2. CLI `-b <backend>` flag
+3. Preset `autoloops.toml` `[backend]` section
+
+## Mixing forms
+
+`steps = [...]` and `[[chain.step]]` **cannot** be used on the same `[[chain]]`
+entry. Doing so raises a `cannot define both` error at load time. Different
+chains in the same file may use different forms.
+
+## Scope
+
+Per-step backend override is supported for static chains declared in
+`chains.toml`. Inline chains (`--chain foo,bar`) and dynamic chains spawned at
+runtime via `DynamicChainSpec` are string-only and do not carry per-step
+backends.

--- a/docs/guides/per-step-backend.md
+++ b/docs/guides/per-step-backend.md
@@ -45,7 +45,7 @@ Each step's `backend` table may contain any subset of:
 | `command`     | backend executable name                             |
 | `args`        | array of CLI args (e.g. `--model`, `--thinking`)    |
 | `prompt_mode` | `"arg"` / `"stdin"` / `"acp"`                       |
-| `timeout_ms`  | per-invocation timeout (forward-compat)             |
+| `timeout_ms`  | per-invocation timeout                              |
 
 Unknown keys are rejected with a clear error.
 

--- a/src/chains/load.ts
+++ b/src/chains/load.ts
@@ -4,7 +4,24 @@ import TOML from "@iarna/toml";
 import * as config from "../config.js";
 import { parseStringList } from "../utils.js";
 import { defaultBudget, parseBudgetFromToml } from "./budget.js";
-import type { Budget, ChainSpec, ChainStep, ChainsConfig } from "./types.js";
+import type {
+  Budget,
+  ChainSpec,
+  ChainStep,
+  ChainsConfig,
+  StepBackendOverride,
+} from "./types.js";
+
+// Keys accepted inside a per-step `backend = { ... }` table. Matches the subset
+// that src/harness/config-helpers.ts::readBackendConfig reads from overrides,
+// plus timeout_ms (forward-compat; currently read from cfg only).
+const ALLOWED_BACKEND_OVERRIDE_KEYS = new Set([
+  "kind",
+  "command",
+  "args",
+  "prompt_mode",
+  "timeout_ms",
+]);
 
 export function load(projectDir: string): ChainsConfig {
   const path = join(projectDir, "chains.toml");
@@ -132,20 +149,40 @@ function loadExisting(path: string, projectDir: string): ChainsConfig {
   return parseChainsFromToml(parsed as Record<string, unknown>, projectDir);
 }
 
-function parseChainsFromToml(
+export function parseChainsFromToml(
   parsed: Record<string, unknown>,
   projectDir: string,
 ): ChainsConfig {
   const rawChains = (parsed.chain ?? []) as Array<{
     name?: string;
     steps?: string[];
+    step?: Array<{ preset?: string; backend?: Record<string, unknown> }>;
   }>;
   const chains = rawChains
     .filter((c) => typeof c.name === "string" && c.name !== "")
-    .map((c) => ({
-      name: c.name as string,
-      steps: resolveSteps(c.steps ?? [], projectDir),
-    }));
+    .map((c) => {
+      const name = c.name as string;
+      const hasStringSteps = Array.isArray(c.steps) && c.steps.length > 0;
+      const hasStructured = Array.isArray(c.step) && c.step.length > 0;
+
+      if (hasStringSteps && hasStructured) {
+        throw new Error(
+          `chain "${name}": cannot define both 'steps = [...]' and '[[chain.step]]'. ` +
+            `Pick one form (prefer [[chain.step]] if you need per-step backend overrides).`,
+        );
+      }
+
+      if (hasStructured) {
+        return {
+          name,
+          steps: resolveStructuredSteps(c.step ?? [], projectDir, name),
+        };
+      }
+      return {
+        name,
+        steps: resolveSteps(c.steps ?? [], projectDir),
+      };
+    });
 
   const budget = parseBudgetFromToml(parsed.budget);
   return { chains, budget };
@@ -156,4 +193,59 @@ function resolveSteps(stepNames: string[], projectDir: string): ChainStep[] {
     name,
     presetDir: resolvePresetDir(name, projectDir),
   }));
+}
+
+function resolveStructuredSteps(
+  rawSteps: Array<{ preset?: string; backend?: Record<string, unknown> }>,
+  projectDir: string,
+  chainName: string,
+): ChainStep[] {
+  return rawSteps.map((raw, idx) => {
+    const preset = raw.preset;
+    if (typeof preset !== "string" || preset === "") {
+      throw new Error(
+        `chain "${chainName}" step ${idx + 1}: missing required 'preset' field`,
+      );
+    }
+    const step: ChainStep = {
+      name: preset,
+      presetDir: resolvePresetDir(preset, projectDir),
+    };
+    if (raw.backend !== undefined) {
+      step.backendOverride = validateBackendOverride(
+        raw.backend,
+        chainName,
+        preset,
+      );
+    }
+    return step;
+  });
+}
+
+function validateBackendOverride(
+  backend: unknown,
+  chainName: string,
+  preset: string,
+): StepBackendOverride {
+  if (
+    backend === null ||
+    typeof backend !== "object" ||
+    Array.isArray(backend)
+  ) {
+    throw new Error(
+      `chain "${chainName}" step "${preset}": 'backend' must be a table`,
+    );
+  }
+  const entries = Object.entries(backend as Record<string, unknown>);
+  const unknown = entries
+    .map(([k]) => k)
+    .filter((k) => !ALLOWED_BACKEND_OVERRIDE_KEYS.has(k));
+  if (unknown.length > 0) {
+    throw new Error(
+      `chain "${chainName}" step "${preset}": unknown backend keys: ${unknown.join(
+        ", ",
+      )}. Allowed: ${[...ALLOWED_BACKEND_OVERRIDE_KEYS].join(", ")}`,
+    );
+  }
+  return Object.fromEntries(entries);
 }

--- a/src/chains/load.ts
+++ b/src/chains/load.ts
@@ -12,9 +12,9 @@ import type {
   StepBackendOverride,
 } from "./types.js";
 
-// Keys accepted inside a per-step `backend = { ... }` table. Matches the subset
-// that src/harness/config-helpers.ts::readBackendConfig reads from overrides,
-// plus timeout_ms (forward-compat; currently read from cfg only).
+// Keys accepted inside a per-step `backend = { ... }` table. Must match the
+// subset that src/harness/config-helpers.ts::readBackendConfig reads from
+// overrides.
 const ALLOWED_BACKEND_OVERRIDE_KEYS = new Set([
   "kind",
   "command",

--- a/src/chains/run.ts
+++ b/src/chains/run.ts
@@ -186,10 +186,20 @@ function runSteps(
 
   const category = presetCategory(stepName, projectDir);
   const suppressWorktree = category === "planning" && runOptions.worktree;
+  // Precedence: step.backendOverride > runOptions.backendOverride (CLI -b) >
+  // preset autoloops.toml defaults. Shallow-merge is intentional — keys set by
+  // the step (e.g. args, command) fully replace the CLI-level value for that key,
+  // matching the behavior of readBackendConfig().
+  const mergedBackendOverride =
+    step.backendOverride !== undefined
+      ? { ...(runOptions.backendOverride ?? {}), ...step.backendOverride }
+      : runOptions.backendOverride;
+
   const stepOptions: harness.RunOptions = {
     ...runOptions,
     workDir: stepWorkDir,
     trigger: "chain",
+    backendOverride: mergedBackendOverride,
     ...(suppressWorktree ? { worktree: undefined, noWorktree: true } : {}),
   };
   const prompt = stepNum === 1 ? (runOptions.prompt ?? null) : null;

--- a/src/chains/types.ts
+++ b/src/chains/types.ts
@@ -1,7 +1,7 @@
 /**
  * Per-step backend override. Shape mirrors the subset of keys consumed by
  * readBackendConfig() in src/harness/config-helpers.ts: command, kind, args,
- * prompt_mode. timeout_ms is accepted but currently only honored from config.
+ * prompt_mode, timeout_ms. All keys are honored when provided.
  *
  * Precedence at merge time: step.backendOverride > runOptions.backendOverride
  * (CLI -b flag) > preset autoloops.toml defaults.

--- a/src/chains/types.ts
+++ b/src/chains/types.ts
@@ -1,6 +1,17 @@
+/**
+ * Per-step backend override. Shape mirrors the subset of keys consumed by
+ * readBackendConfig() in src/harness/config-helpers.ts: command, kind, args,
+ * prompt_mode. timeout_ms is accepted but currently only honored from config.
+ *
+ * Precedence at merge time: step.backendOverride > runOptions.backendOverride
+ * (CLI -b flag) > preset autoloops.toml defaults.
+ */
+export type StepBackendOverride = Record<string, unknown>;
+
 export interface ChainStep {
   name: string;
   presetDir: string;
+  backendOverride?: StepBackendOverride;
 }
 
 export interface ChainSpec {

--- a/src/harness/config-helpers.ts
+++ b/src/harness/config-helpers.ts
@@ -153,6 +153,25 @@ export function processListOverride(
   return Array.isArray(val) ? (val as string[]) : fallback;
 }
 
+export function processIntOverride(
+  override: Record<string, unknown>,
+  key: string,
+  fallback: number,
+): number {
+  const val = override[key];
+  if (val !== undefined) {
+    if (typeof val !== "number" || !Number.isInteger(val)) {
+      throw new Error(
+        `backend override "${key}" must be an integer, got ${
+          typeof val === "number" ? val : typeof val
+        }`,
+      );
+    }
+    return val;
+  }
+  return fallback;
+}
+
 export function claudeBackend(command: string): boolean {
   return command === "claude" || command.endsWith("/claude");
 }
@@ -511,7 +530,11 @@ function readBackendConfig(
       config.get(cfg, "backend.prompt_mode", "arg"),
     ),
   );
-  const timeoutMs = config.getInt(cfg, "backend.timeout_ms", 300000);
+  const timeoutMs = processIntOverride(
+    bo,
+    "timeout_ms",
+    config.getInt(cfg, "backend.timeout_ms", 300000),
+  );
   return { kind, command, args, promptMode, timeoutMs };
 }
 

--- a/test/chains/load.test.ts
+++ b/test/chains/load.test.ts
@@ -129,6 +129,21 @@ describe("parseChainsFromToml — per-step backend override", () => {
     );
   });
 
+  it("accepts timeout_ms as a backend override key", () => {
+    const parsed = {
+      chain: [
+        {
+          name: "timeout-chain",
+          step: [{ preset: "autocode", backend: { timeout_ms: 60000 } }],
+        },
+      ],
+    };
+    const cfg = parseChainsFromToml(parsed, bundleRoot);
+    expect(cfg.chains[0].steps[0].backendOverride).toEqual({
+      timeout_ms: 60000,
+    });
+  });
+
   it("rejects a chain that mixes 'steps' and '[[chain.step]]'", () => {
     const parsed = {
       chain: [

--- a/test/chains/load.test.ts
+++ b/test/chains/load.test.ts
@@ -4,6 +4,7 @@ import {
   getPresetDescription,
   listKnownPresets,
   listPresetsWithDescriptions,
+  parseChainsFromToml,
   validatePresetVocabulary,
 } from "../../src/chains/load.js";
 
@@ -56,5 +57,103 @@ describe("automerge preset", () => {
       bundleRoot,
     );
     expect(result.ok).toBe(true);
+  });
+});
+
+describe("parseChainsFromToml — per-step backend override", () => {
+  it("back-compat: string-list steps parse unchanged with no overrides", () => {
+    const parsed = {
+      chain: [{ name: "simple", steps: ["autocode", "autoreview"] }],
+    };
+    const cfg = parseChainsFromToml(parsed, bundleRoot);
+    expect(cfg.chains).toHaveLength(1);
+    const c = cfg.chains[0];
+    expect(c.name).toBe("simple");
+    expect(c.steps.map((s) => s.name)).toEqual(["autocode", "autoreview"]);
+    for (const s of c.steps) expect(s.backendOverride).toBeUndefined();
+  });
+
+  it("parses structured [[chain.step]] form with per-step backend override", () => {
+    const parsed = {
+      chain: [
+        {
+          name: "plan-then-build",
+          step: [
+            {
+              preset: "autocode",
+              backend: {
+                args: [
+                  "--model",
+                  "anthropic/claude-opus-4",
+                  "--thinking",
+                  "high",
+                ],
+              },
+            },
+            {
+              preset: "autoreview",
+              backend: { args: ["--model", "anthropic/claude-haiku-4"] },
+            },
+            { preset: "automerge" },
+          ],
+        },
+      ],
+    };
+    const cfg = parseChainsFromToml(parsed, bundleRoot);
+    const steps = cfg.chains[0].steps;
+    expect(steps.map((s) => s.name)).toEqual([
+      "autocode",
+      "autoreview",
+      "automerge",
+    ]);
+    expect(steps[0].backendOverride).toEqual({
+      args: ["--model", "anthropic/claude-opus-4", "--thinking", "high"],
+    });
+    expect(steps[1].backendOverride).toEqual({
+      args: ["--model", "anthropic/claude-haiku-4"],
+    });
+    expect(steps[2].backendOverride).toBeUndefined();
+  });
+
+  it("rejects unknown backend keys with a clear error", () => {
+    const parsed = {
+      chain: [
+        {
+          name: "bad",
+          step: [{ preset: "autocode", backend: { bogus: "x" } }],
+        },
+      ],
+    };
+    expect(() => parseChainsFromToml(parsed, bundleRoot)).toThrow(
+      /unknown backend keys: bogus/,
+    );
+  });
+
+  it("rejects a chain that mixes 'steps' and '[[chain.step]]'", () => {
+    const parsed = {
+      chain: [
+        {
+          name: "conflicted",
+          steps: ["autocode"],
+          step: [{ preset: "autoreview" }],
+        },
+      ],
+    };
+    expect(() => parseChainsFromToml(parsed, bundleRoot)).toThrow(
+      /cannot define both/,
+    );
+  });
+
+  it("allows both forms to coexist across different chains in the same file", () => {
+    const parsed = {
+      chain: [
+        { name: "old", steps: ["autocode"] },
+        { name: "new", step: [{ preset: "autoreview" }] },
+      ],
+    };
+    const cfg = parseChainsFromToml(parsed, bundleRoot);
+    expect(cfg.chains.map((c) => c.name)).toEqual(["old", "new"]);
+    expect(cfg.chains[0].steps[0].name).toBe("autocode");
+    expect(cfg.chains[1].steps[0].name).toBe("autoreview");
   });
 });

--- a/test/harness/config-helpers.test.ts
+++ b/test/harness/config-helpers.test.ts
@@ -5,6 +5,8 @@ import { describe, expect, it } from "vitest";
 import {
   buildLoopContext,
   injectClaudePermissions,
+  processIntOverride,
+  reloadLoop,
   resolveProcessKind,
 } from "../../src/harness/config-helpers.js";
 import type { RunRecord } from "../../src/registry/types.js";
@@ -514,5 +516,60 @@ describe("global journal behavior", () => {
     expect(loop.runtime.isolationMode).toBe("run-scoped");
     expect(loop.paths.journalFile).not.toContain("/runs/");
     expect(loop.paths.journalFile).toMatch(/journal\.jsonl$/);
+  });
+});
+
+describe("processIntOverride", () => {
+  it("returns the override value when it is a number", () => {
+    expect(
+      processIntOverride({ timeout_ms: 60000 }, "timeout_ms", 300000),
+    ).toBe(60000);
+  });
+
+  it("falls back when the key is absent", () => {
+    expect(processIntOverride({}, "timeout_ms", 300000)).toBe(300000);
+  });
+
+  it("falls back when the value is undefined", () => {
+    expect(
+      processIntOverride({ timeout_ms: undefined }, "timeout_ms", 300000),
+    ).toBe(300000);
+  });
+
+  it("throws when the value is a string", () => {
+    expect(() =>
+      processIntOverride({ timeout_ms: "60000" }, "timeout_ms", 300000),
+    ).toThrow(/backend override "timeout_ms" must be an integer/);
+  });
+
+  it("throws when the value is a float", () => {
+    expect(() =>
+      processIntOverride({ timeout_ms: 3.14 }, "timeout_ms", 300000),
+    ).toThrow(/backend override "timeout_ms" must be an integer/);
+  });
+});
+
+describe("buildLoopContext with backendOverride.timeout_ms", () => {
+  it("applies timeout_ms from backendOverride", () => {
+    const projectDir = makeProject("event_loop.max_iterations = 1\n");
+    const loop = buildLoopContext(projectDir, "test", "node dist/main.js", {
+      workDir: projectDir,
+      backendOverride: { timeout_ms: 60000 },
+    });
+
+    expect(loop.backend.timeoutMs).toBe(60000);
+  });
+
+  it("applies timeout_ms from step backendOverride over CLI override", () => {
+    const projectDir = makeProject("event_loop.max_iterations = 1\n");
+    const loop = buildLoopContext(projectDir, "test", "node dist/main.js", {
+      workDir: projectDir,
+      backendOverride: { timeout_ms: 300000 },
+    });
+
+    loop.runtime.backendOverride = { timeout_ms: 60000 };
+    const reloaded = reloadLoop(loop);
+
+    expect(reloaded.backend.timeoutMs).toBe(60000);
   });
 });


### PR DESCRIPTION
Add a new [[chain.step]] array-of-tables form to chains.toml that lets each step specify its own backend override (kind, command, args, prompt_mode, timeout_ms). The existing string-list form (steps = [...]) continues to work unchanged; both forms may coexist across different chains but cannot be mixed on a single chain entry.

Precedence (highest to lowest):
  1. [[chain.step]].backend (this change)
  2. CLI -b flag
  3. preset autoloops.toml default

Motivating use case: run a planner step on a smarter/slower model and a builder step on a faster/cheaper model via pi --model / --thinking args.

- src/chains/types.ts: add optional backendOverride to ChainStep
- src/chains/load.ts: parse new [[chain.step]] form, validate backend keys against an allow-list, error on mixing forms, export parseChainsFromToml for testability
- src/chains/run.ts: shallow-merge step.backendOverride onto runOptions.backendOverride (step wins over CLI)
- test/chains/load.test.ts: 5 new tests (back-compat, structured form, unknown-key rejection, mixing-form error, coexistence)
- docs/guides/per-step-backend.md: new doc page

Out of scope: inline chains (--chain foo,bar) and DynamicChainSpec remain string-only.