### PR TITLE
fix(harness): record backend args in journal backend.start events

### DIFF
--- a/src/harness/parallel.ts
+++ b/src/harness/parallel.ts
@@ -339,6 +339,8 @@ export function appendBackendStart(
       ", " +
       jsonField("command", loop.backend.command) +
       ", " +
+      jsonField("args", joinCsv(loop.backend.args)) +
+      ", " +
       jsonField("prompt_mode", loop.backend.promptMode) +
       ", " +
       jsonField("timeout_ms", String(loop.backend.timeoutMs)),

--- a/test/harness/automerge-chain.test.ts
+++ b/test/harness/automerge-chain.test.ts
@@ -26,6 +26,7 @@ vi.mock("../../src/worktree/create.js", () => ({
     metaDir: "/tmp/fake-meta",
   })),
   resolveGitRoot: vi.fn((cwd: string) => cwd),
+  tryResolveGitRoot: vi.fn((cwd: string) => cwd),
 }));
 
 vi.mock("../../src/worktree/clean.js", () => ({


### PR DESCRIPTION
## Summary

The journal's `appendLoopStart` and registry already recorded the effective backend args (e.g., `--dangerously-skip-permissions`), but the per-iteration `backend.start` event omitted them. This made it impossible to confirm from the journal alone whether a specific run was using the permission-skipping path or not.

This adds `jsonField("args", joinCsv(loop.backend.args))` to the `appendBackendStart()` function, making the `backend.start` event consistent with:
- The loop-start metadata (which already includes `backend_args`)
- Registry records (which store `backend_args: string[]`)
- Wave launch events (which already include `backend_args`)

## Validation

- ✅ `npm install && npx tsc --noEmit` passes clean
- ✅ All 19 parallel.test.ts tests pass
- ✅ No behavioral changes — only adds a field to journal output

## Environment

- autoloop-ts (TypeScript/Node.js)

Closes #2
