### PR TITLE
fix(chains): propagate -b backend override to inline chain steps

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -341,5 +341,6 @@ function chainableOptions(opts: RunOptions): Record<string, unknown> {
     mergeStrategy: opts.mergeStrategy,
     automerge: opts.automerge || undefined,
     keepWorktree: opts.keepWorktree || undefined,
+    backendOverride: Object.keys(opts.backendOverride).length > 0 ? opts.backendOverride : undefined,
   };
 }

--- a/test/commands/run-chain-options.test.ts
+++ b/test/commands/run-chain-options.test.ts
@@ -93,6 +93,37 @@ describe("runInlineChain option propagation", () => {
     ]);
   });
 
+  it("forwards -b backend override through to chains.runChain", () => {
+    dispatchRun(
+      ["--chain", "autocode,autoqa", "-b", "pi", "."],
+      [],
+      ".",
+      "autoloop",
+    );
+
+    expect(chains.runChain).toHaveBeenCalledTimes(1);
+    const callArgs = vi.mocked(chains.runChain).mock.calls[0];
+    const runOptions = callArgs[3];
+
+    expect(runOptions.backendOverride).toBeDefined();
+    expect(runOptions.backendOverride.kind).toBe("pi");
+  });
+
+  it("omits backendOverride when -b is not specified", () => {
+    dispatchRun(
+      ["--chain", "autocode,autoqa", "."],
+      [],
+      ".",
+      "autoloop",
+    );
+
+    expect(chains.runChain).toHaveBeenCalledTimes(1);
+    const callArgs = vi.mocked(chains.runChain).mock.calls[0];
+    const runOptions = callArgs[3];
+
+    expect(runOptions.backendOverride).toBeUndefined();
+  });
+
   it("forwards --no-worktree through to chains.runChain", () => {
     dispatchRun(
       ["--chain", "autocode,autoqa", "--no-worktree", "."],


### PR DESCRIPTION
When using `--chain` with `-b <backend>`, the backend override was dropped because `chainableOptions()` didn't include `backendOverride`. This caused all chain steps to fall back to the default `claude` backend regardless of the `-b` flag.

The per-step backend feature (#8) only applies to `chains.toml`, not inline chains — this fix closes the gap for the CLI flag.

## Changes

- `src/commands/run.ts`: Add `backendOverride` to `chainableOptions()` return object
- `test/commands/run-chain-options.test.ts`: Add tests verifying backend override propagation (present and absent cases)