### PR TITLE
fix(sdk): repoint test helpers + mock-backend at packages/cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "provenance": true
   },
   "scripts": {
-    "build": "tsc",
+    "build": "npm run build -w @mobrienv/autoloop-core && npm run build -w @mobrienv/autoloop-harness && npm run build -w @mobrienv/autoloop-cli && tsc",
     "lint": "biome check src/ test/",
     "lint:fix": "biome check --write src/ test/",
     "format": "biome format src/ test/",

--- a/src/testing/mock-backend.ts
+++ b/src/testing/mock-backend.ts
@@ -12,8 +12,7 @@
 
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
 
 interface Fixture {
   output: string;
@@ -53,9 +52,8 @@ function loadFixture(): Fixture {
 }
 
 function emitEvent(event: string, payload: string): void {
-  const currentFile = fileURLToPath(import.meta.url);
-  const distDir = dirname(dirname(currentFile));
-  const mainEntry = resolve(distDir, "main.js");
+  const require = createRequire(import.meta.url);
+  const mainEntry = require.resolve("@mobrienv/autoloop-cli");
 
   try {
     execFileSync(process.execPath, [mainEntry, "emit", event, payload], {

--- a/test/helpers/runtime.ts
+++ b/test/helpers/runtime.ts
@@ -10,7 +10,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 export const ROOT = resolve(import.meta.dirname, "../..");
-export const DIST_ENTRY = resolve(ROOT, "dist/main.js");
+export const DIST_ENTRY = resolve(ROOT, "packages/cli/dist/main.js");
 export const MOCK_BACKEND = resolve(ROOT, "dist/testing/mock-backend.js");
 export const FIXTURES_DIR = resolve(ROOT, "test/fixtures/backend");
 export const PRESET_FIXTURE_DIR = resolve(


### PR DESCRIPTION
## Summary

Three regressions from phase 2.6 (CLI extracted to `packages/cli`) that left the integration-test layer pointing at the old root `dist/main.js`:

- **`src/testing/mock-backend.ts`** — `emitEvent()` resolved `dist/main.js` from its compiled location to invoke `autoloop emit`. Post-2.6 that path is gone, so emits silently failed and the harness never recorded `event.invalid`. Now uses `createRequire(import.meta.url).resolve("@mobrienv/autoloop-cli")`.
- **`test/helpers/runtime.ts`** — `DIST_ENTRY` pointed at the same stale path, breaking ~32 integration tests that spawn the CLI via `runCli` / `inspectCli`. Now points at `packages/cli/dist/main.js`.
- **Root `npm run build`** — was just `tsc`, which fails on a clean checkout because the workspace `dist/` outputs that satisfy the type imports don't exist yet. `npm run build --workspaces` doesn't run in topological order, so chain `core → harness → cli` explicitly before root `tsc`.

## Validation

Full suite goes from **36 failed / 945** → **0 failed / 945** locally. SDK embed smoke (1.10) stays green; lint unchanged (3 pre-existing warnings).

## Test plan

- [ ] CI green on this PR
- [ ] Fresh checkout → `npm install && npm run build` succeeds without manual workspace pre-builds
- [ ] `npm test` passes including `test/integration/emit-validation.test.ts` and the invalid-event tests in `test/integration/run-loop.test.ts`

https://claude.ai/code/session_01EuarYiwiCbWpHGteFBC2BT

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuarYiwiCbWpHGteFBC2BT)_