### PR TITLE
fix: triage autoloop open queue

### DIFF
--- a/packages/cli/test/commands/run-chain-options.test.ts
+++ b/packages/cli/test/commands/run-chain-options.test.ts
@@ -72,6 +72,26 @@ describe("runInlineChain option propagation", () => {
     expect(runOptions.automerge).toBe(true);
   });
 
+  it("forwards -b backend override through to chains.runChain", () => {
+    dispatchRun(
+      ["--chain", "autocode,autoqa", "-b", "pi", "."],
+      [],
+      ".",
+      "autoloop",
+    );
+
+    expect(chains.runChain).toHaveBeenCalledTimes(1);
+    const callArgs = vi.mocked(chains.runChain).mock.calls[0];
+    const runOptions = callArgs[3];
+
+    expect(runOptions.backendOverride).toEqual({
+      kind: "pi",
+      command: "pi",
+      args: [],
+      prompt_mode: "arg",
+    });
+  });
+
   it("automerge sugar uses chain-compatible projectDir, not preset path", () => {
     // Simulate: autoloop run autocode --automerge --worktree
     // The bundleRoot is "." so defaultChainProjectDir should resolve to "."

--- a/packages/harness/src/config-helpers.ts
+++ b/packages/harness/src/config-helpers.ts
@@ -41,10 +41,20 @@ import {
 import { emitToolScript, piAdapterScript } from "./tools.js";
 import type { LoopContext, RunOptions } from "./types.js";
 
+const DEFAULT_PROMPT =
+  "Do the task and publish the completion event when finished.";
+
+export interface ResolvePromptOptions {
+  workDir?: string;
+  stateDir?: string;
+  baseStateDir?: string;
+}
+
 export function resolvePrompt(
   projectDir: string,
   cfg: config.Config,
   override: string | null,
+  options: ResolvePromptOptions = {},
 ): string {
   if (override !== null) return override;
   const inlinePrompt = config.get(cfg, "event_loop.prompt", "");
@@ -54,7 +64,22 @@ export function resolvePrompt(
     const fullPath = join(projectDir, promptFile);
     if (existsSync(fullPath)) return readFileSync(fullPath, "utf-8");
   }
-  return "Do the task and publish the completion event when finished.";
+  if (!existingPlanFile(options)) {
+    const promptDir =
+      tryResolveGitRoot(options.workDir ?? projectDir) ??
+      options.workDir ??
+      projectDir;
+    const rootPrompt = join(promptDir, "PROMPT.md");
+    if (existsSync(rootPrompt)) return readFileSync(rootPrompt, "utf-8");
+  }
+  return DEFAULT_PROMPT;
+}
+
+function existingPlanFile(options: ResolvePromptOptions): boolean {
+  const dirs = [options.stateDir, options.baseStateDir].filter(
+    (dir): dir is string => Boolean(dir),
+  );
+  return dirs.some((dir) => existsSync(join(dir, "plan.md")));
 }
 
 export function resolveReviewPrompt(
@@ -458,7 +483,11 @@ export function reloadLoop(loop: LoopContext): LoopContext {
   };
 
   const updated: LoopContext = {
-    objective: resolvePrompt(pd, cfg, loop.runtime.promptOverride),
+    objective: resolvePrompt(pd, cfg, loop.runtime.promptOverride, {
+      workDir: wd,
+      stateDir: loop.paths.stateDir,
+      baseStateDir: loop.paths.baseStateDir,
+    }),
     topology: updatedTopology,
     limits: {
       maxIterations: config.getInt(cfg, "event_loop.max_iterations", 3),

--- a/packages/harness/src/metareview.ts
+++ b/packages/harness/src/metareview.ts
@@ -62,7 +62,8 @@ export function shouldRunMetareview(
   iteration: number,
 ): boolean {
   if (!loop.review.enabled) return false;
-  if (iteration === 1 && loop.review.adversarialFirst) return true;
+  if (iteration <= 1) return false;
+  if (iteration === 2 && loop.review.adversarialFirst) return true;
   return iteration > 1 && (iteration - 1) % loop.review.every === 0;
 }
 

--- a/packages/harness/src/parallel.ts
+++ b/packages/harness/src/parallel.ts
@@ -352,6 +352,8 @@ export function appendBackendStart(
       ", " +
       jsonField("command", iter.backend.command) +
       ", " +
+      jsonField("args", joinCsv(iter.backend.args)) +
+      ", " +
       jsonField("prompt_mode", iter.backend.promptMode) +
       ", " +
       jsonField("timeout_ms", String(iter.backend.timeoutMs)),

--- a/packages/harness/test/harness/config-helpers.test.ts
+++ b/packages/harness/test/harness/config-helpers.test.ts
@@ -120,6 +120,85 @@ describe("injectClaudePermissions", () => {
 });
 
 describe("buildLoopContext", () => {
+  it("auto-discovers PROMPT.md from the work directory when no prompt is provided", () => {
+    const projectDir = makeProject("event_loop.max_iterations = 1\n");
+    const workDir = mkdtempSync(join(tmpdir(), "autoloop-ts-prompt-work-"));
+    writeFileSync(join(workDir, "PROMPT.md"), "Implement the root task\n");
+
+    const loop = buildLoopContext(projectDir, null, "node dist/main.js", {
+      workDir,
+    });
+
+    expect(loop.objective).toBe("Implement the root task\n");
+  });
+
+  it("prefers an explicit prompt over work directory PROMPT.md", () => {
+    const projectDir = makeProject("event_loop.max_iterations = 1\n");
+    const workDir = mkdtempSync(join(tmpdir(), "autoloop-ts-prompt-work-"));
+    writeFileSync(join(workDir, "PROMPT.md"), "Root prompt\n");
+
+    const loop = buildLoopContext(
+      projectDir,
+      "Explicit prompt",
+      "node dist/main.js",
+      { workDir },
+    );
+
+    expect(loop.objective).toBe("Explicit prompt");
+  });
+
+  it("prefers configured inline prompt over work directory PROMPT.md", () => {
+    const projectDir = makeProject(
+      [
+        "event_loop.max_iterations = 1",
+        'event_loop.prompt = "Configured prompt"',
+      ].join("\n"),
+    );
+    const workDir = mkdtempSync(join(tmpdir(), "autoloop-ts-prompt-work-"));
+    writeFileSync(join(workDir, "PROMPT.md"), "Root prompt\n");
+
+    const loop = buildLoopContext(projectDir, null, "node dist/main.js", {
+      workDir,
+    });
+
+    expect(loop.objective).toBe("Configured prompt");
+  });
+
+  it("prefers configured prompt_file over work directory PROMPT.md", () => {
+    const projectDir = makeProject(
+      [
+        "event_loop.max_iterations = 1",
+        'event_loop.prompt_file = "task.md"',
+      ].join("\n"),
+      { files: { "task.md": "Configured file prompt\n" } },
+    );
+    const workDir = mkdtempSync(join(tmpdir(), "autoloop-ts-prompt-work-"));
+    writeFileSync(join(workDir, "PROMPT.md"), "Root prompt\n");
+
+    const loop = buildLoopContext(projectDir, null, "node dist/main.js", {
+      workDir,
+    });
+
+    expect(loop.objective).toBe("Configured file prompt\n");
+  });
+
+  it("does not replace an existing in-flight plan with work directory PROMPT.md", () => {
+    const projectDir = makeProject("event_loop.max_iterations = 1\n");
+    const workDir = mkdtempSync(join(tmpdir(), "autoloop-ts-prompt-work-"));
+    const stateDir = join(workDir, ".autoloop");
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(join(stateDir, "plan.md"), "Existing plan\n");
+    writeFileSync(join(workDir, "PROMPT.md"), "Root prompt\n");
+
+    const loop = buildLoopContext(projectDir, null, "node dist/main.js", {
+      workDir,
+    });
+
+    expect(loop.objective).toBe(
+      "Do the task and publish the completion event when finished.",
+    );
+  });
+
   it("injects Claude permissions for config-defined Claude backends", () => {
     const projectDir = makeProject(
       [

--- a/packages/harness/test/harness/metareview.test.ts
+++ b/packages/harness/test/harness/metareview.test.ts
@@ -2,11 +2,16 @@ import { shouldRunMetareview } from "@mobrienv/autoloop-harness/metareview";
 import type { LoopContext } from "@mobrienv/autoloop-harness/types";
 import { describe, expect, it } from "vitest";
 
-function makeLoop(enabled: boolean, every: number): LoopContext {
+function makeLoop(
+  enabled: boolean,
+  every: number,
+  adversarialFirst = false,
+): LoopContext {
   return {
     review: {
       enabled,
       every,
+      adversarialFirst,
       kind: "command",
       command: "echo",
       args: [],
@@ -24,6 +29,14 @@ describe("shouldRunMetareview", () => {
 
   it("returns false on iteration 1 even if enabled", () => {
     expect(shouldRunMetareview(makeLoop(true, 1), 1)).toBe(false);
+  });
+
+  it("returns false on iteration 1 even when adversarial first review is enabled", () => {
+    expect(shouldRunMetareview(makeLoop(true, 4, true), 1)).toBe(false);
+  });
+
+  it("runs adversarial first review before iteration 2 so iteration 1 output exists", () => {
+    expect(shouldRunMetareview(makeLoop(true, 4, true), 2)).toBe(true);
   });
 
   it("returns true on iteration 2 with every=1", () => {

--- a/packages/harness/test/harness/parallel.test.ts
+++ b/packages/harness/test/harness/parallel.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import type { Role } from "@mobrienv/autoloop-core/topology";
 import {
   appendBackendStart,
   type BranchLaunch,
@@ -14,7 +14,7 @@ import {
 } from "@mobrienv/autoloop-harness/parallel";
 import { buildIterationContext } from "@mobrienv/autoloop-harness/prompt";
 import type { LoopContext } from "@mobrienv/autoloop-harness/types";
-import type { Role } from "@mobrienv/autoloop-core/topology";
+import { describe, expect, it } from "vitest";
 
 describe("csvFieldList", () => {
   it("extracts comma-separated values from a JSON field", () => {
@@ -416,11 +416,12 @@ describe("appendBackendStart honors iter.backend", () => {
     expect(startLine).toBeDefined();
     expect(startLine).toContain('"backend_kind": "command"');
     expect(startLine).toContain('"command": "claude"');
+    expect(startLine).toContain('"args": "--global-flag"');
     expect(startLine).toContain('"prompt_mode": "stdin"');
     expect(startLine).toContain('"timeout_ms": "2000"');
   });
 
-  it("writes iter.backend.* fields when role overrides kind/command/promptMode/timeoutMs", () => {
+  it("writes iter.backend.* fields when role overrides kind/command/args/promptMode/timeoutMs", () => {
     const loop = makeBackendExecLoop("append-role", {
       roles: [
         {
@@ -430,6 +431,7 @@ describe("appendBackendStart honors iter.backend", () => {
           emits: ["review.ready"],
           backendKind: "pi",
           backendCommand: "pi-runner",
+          backendArgs: ["--role-flag", "fast"],
           backendPromptMode: "arg",
           backendTimeoutMs: 9999,
         },
@@ -445,9 +447,11 @@ describe("appendBackendStart honors iter.backend", () => {
     expect(startLine).toBeDefined();
     expect(startLine).toContain('"backend_kind": "pi"');
     expect(startLine).toContain('"command": "pi-runner"');
+    expect(startLine).toContain('"args": "--role-flag,fast"');
     expect(startLine).toContain('"prompt_mode": "arg"');
     expect(startLine).toContain('"timeout_ms": "9999"');
     expect(startLine).not.toContain('"backend_kind": "command"');
+    expect(startLine).not.toContain('"args": "--global-flag"');
     expect(startLine).not.toContain('"timeout_ms": "2000"');
   });
 });

--- a/test/integration/dev-dispatcher.test.ts
+++ b/test/integration/dev-dispatcher.test.ts
@@ -23,8 +23,12 @@ function runExpectFail(args: string[]): { stderr: string; code: number } {
       env: { ...process.env },
     });
     throw new Error("expected non-zero exit");
-  } catch (err: any) {
-    return { stderr: err.stderr ?? "", code: err.status ?? 1 };
+  } catch (err: unknown) {
+    const execError = err as { stderr?: string | Buffer; status?: number };
+    return {
+      stderr: String(execError.stderr ?? ""),
+      code: execError.status ?? 1,
+    };
   }
 }
 

--- a/test/integration/run-metadata.test.ts
+++ b/test/integration/run-metadata.test.ts
@@ -27,9 +27,9 @@ describe("integration: launch metadata in loop.start journal event", () => {
       .split("\n")
       .find((line) => line.includes('"topic": "loop.start"'));
 
-    expect(loopStartLine).toBeTruthy();
+    if (!loopStartLine) throw new Error("missing loop.start journal event");
 
-    const parsed = JSON.parse(loopStartLine!) as Record<string, unknown>;
+    const parsed = JSON.parse(loopStartLine) as Record<string, unknown>;
     const fields = parsed.fields as Record<string, unknown>;
 
     // preset is basename of the temp project dir (e.g. autoloop-run-metadata-XXXX)
@@ -58,7 +58,9 @@ describe("integration: launch metadata in loop.start journal event", () => {
       .split("\n")
       .find((line) => line.includes('"topic": "loop.start"'));
 
-    const parsed = JSON.parse(loopStartLine!) as Record<string, unknown>;
+    if (!loopStartLine) throw new Error("missing loop.start journal event");
+
+    const parsed = JSON.parse(loopStartLine) as Record<string, unknown>;
     const fields = parsed.fields as Record<string, unknown>;
 
     expect(fields.max_iterations).toBe("5");


### PR DESCRIPTION
## Summary

- fixes backend truth in `backend.start` journal events by recording effective per-iteration backend args
- prevents adversarial metareview from firing before iteration 1 has produced output
- auto-discovers repo-root `PROMPT.md` for no-prompt autocode runs when no in-flight plan exists
- adds regression coverage for the stale inline-chain `-b` PR behavior
- cleans two pre-existing lint warnings encountered during the full check gate

## Triage notes

- Supersedes draft PR #9 with the current monorepo path and `iter.backend.args` semantics, which are correct for per-role backend overrides.
- PR #10's runtime behavior is already present on current `main`; this PR adds the missing regression test for `-b` inline-chain propagation.

Fixes #2
Fixes #12
Fixes #13

## Test plan

- `npx vitest run packages/harness/test/harness/parallel.test.ts packages/harness/test/harness/metareview.test.ts packages/harness/test/harness/config-helpers.test.ts packages/cli/test/commands/run-chain-options.test.ts`
- `npm run check`
