### PR TITLE
feat: add preset config override UX

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -48,6 +48,9 @@ If the preset argument is missing, the CLI exits with a usage error. If the argu
 | Flag | Description |
 |------|-------------|
 | `-b <backend>`, `--backend <backend>` | Override the backend. `pi` selects the built-in Pi adapter. `kiro` selects the Kiro ACP backend (persistent session via `kiro-cli acp`). `claude` (or a path ending in `/claude`) adds `-p --dangerously-skip-permissions`. Config-based Claude command backends receive the same injection automatically. Any other value is treated as a shell command. |
+| `--max-iterations <n>` | Override `event_loop.max_iterations` for this run only. Reapplied on hot reload. |
+| `-i <n>`, `--iterations <n>` | Alias for `--max-iterations <n>`. |
+| `--set <key=value>` | Override any config key for this run only, after all file layers. Repeatable, e.g. `--set backend.timeout_ms=900000`. |
 | `-p <preset>`, `--preset <preset>` | Resolve a bundled preset name (for example `autocode`) or use an explicit custom preset directory. Useful when you want the prompt to start with path-like text or avoid positional ambiguity. |
 | `-v`, `--verbose` | Enable verbose logging. |
 | `--chain <steps>` | Run an inline chain instead of a single loop. `steps` is a comma-separated list of preset names (e.g. `autocode,autoqa,autoresearch`). |
@@ -58,6 +61,8 @@ If the preset argument is missing, the CLI exits with a usage error. If the argu
 ```bash
 autoloop run autocode
 autoloop run autocode "Fix the login bug"
+autoloop run autocode --max-iterations 250 "Fix the login bug"
+autoloop run autocode --set backend.timeout_ms=900000 "Fix slowly"
 autoloop run autocode -b kiro "Fix the login bug"
 autoloop run --preset autocode "Fix the login bug"
 autoloop run . "Fix the login bug" -b pi

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -29,7 +29,31 @@ Lines without `=` are skipped with a warning. Blank lines and comment lines are 
 
 `autoloops.toml` > `autoloops.conf` > built-in defaults.
 
+For preset runs, scalar/config overrides are layered on top of the selected preset:
+
+1. built-in defaults
+2. user config (`~/.config/autoloop/config.toml`, or `AUTOLOOP_CONFIG`)
+3. selected preset config (`autoloops.toml` / `autoloops.conf`)
+4. user preset override (`~/.config/autoloop/overrides/<preset>.toml`)
+5. repo preset override (`<repo>/.autoloop/overrides/<preset>.toml`)
+6. run-scoped CLI override (`--max-iterations`, `--iterations`, or `--set key=value`)
+
 The CLI `-b`/`--backend` flag overrides backend settings at runtime (kind, command, args, prompt_mode) without changing the file. Extra backend arguments can be passed after `--` on the command line (e.g. `autoloop run autocode -b pi -- --model anthropic/claude-sonnet-4`). These are appended to the backend's argument list.
+
+Run-scoped config overrides are also runtime-only and are reapplied after every hot reload:
+
+```bash
+autoloop run autocode --max-iterations 250 "Fix the bug"
+autoloop run autocode --set backend.timeout_ms=900000 "Fix the slow bug"
+```
+
+Persistent preset overrides can be written without forking the preset:
+
+```bash
+autoloop config set --user --preset autocode event_loop.max_iterations=250
+autoloop config set --repo --preset autocode event_loop.max_iterations=250
+autoloop config show --preset autocode --explain
+```
 
 ## Keys
 

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,4 +1,6 @@
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { resolvePresetDir } from "@mobrienv/autoloop-core";
 import * as config from "@mobrienv/autoloop-core/config";
 
 export function dispatchConfig(args: string[]): boolean {
@@ -6,6 +8,10 @@ export function dispatchConfig(args: string[]): boolean {
 
   if (sub === "show") {
     return configShow(args.slice(1));
+  }
+
+  if (sub === "set") {
+    return configSet(args.slice(1));
   }
 
   if (sub === "path") {
@@ -25,16 +31,28 @@ export function dispatchConfig(args: string[]): boolean {
 function configShow(args: string[]): boolean {
   let projectDir = ".";
   let json = false;
+  let presetName = "";
   for (let i = 0; i < args.length; i++) {
     if ((args[i] === "--project" || args[i] === "-d") && args[i + 1]) {
       projectDir = args[i + 1];
       i++;
+    } else if (args[i] === "--preset" && args[i + 1]) {
+      presetName = args[i + 1];
+      i++;
     } else if (args[i] === "--json") {
       json = true;
+    } else if (args[i] === "--explain") {
+      // Provenance is always printed; keep --explain as the readable UX alias.
     }
   }
 
-  const { config: resolved, provenance } = config.loadLayered(projectDir);
+  const targetDir = presetName
+    ? resolvePresetDir(presetName, projectDir)
+    : projectDir;
+  const { config: resolved, provenance } = config.loadLayered(targetDir, {
+    presetName: presetName || undefined,
+    workDir: presetName ? projectDir : undefined,
+  });
 
   if (json) {
     console.log(JSON.stringify({ config: resolved, provenance }, null, 2));
@@ -62,6 +80,104 @@ function configShow(args: string[]): boolean {
   return true;
 }
 
+function configSet(args: string[]): boolean {
+  let scope: "user" | "repo" | "" = "";
+  let projectDir = ".";
+  let presetName = "";
+  let assignment = "";
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--user") {
+      scope = "user";
+    } else if (arg === "--repo") {
+      scope = "repo";
+    } else if ((arg === "--project" || arg === "-d") && args[i + 1]) {
+      projectDir = args[++i];
+    } else if (arg === "--preset" && args[i + 1]) {
+      presetName = args[++i];
+    } else if (!assignment) {
+      assignment = arg;
+    } else {
+      console.log(`unexpected config set argument: ${arg}`);
+      printConfigUsage();
+      return true;
+    }
+  }
+
+  if (!scope || !presetName || !assignment) {
+    console.log(
+      "Usage: autoloop config set (--user|--repo) --preset <name> [--project <dir>] key=value",
+    );
+    return true;
+  }
+
+  const parsed = parseAssignment(assignment);
+  if (!parsed) {
+    console.log(`invalid assignment: ${assignment}`);
+    console.log("Expected key=value, e.g. event_loop.max_iterations=250");
+    return true;
+  }
+
+  const path =
+    scope === "user"
+      ? config.userPresetOverridePath(presetName)
+      : config.repoPresetOverridePath(projectDir, presetName);
+  const current = existsSync(path)
+    ? config.stringifyValues(config.parseRawToml(readFileSync(path, "utf-8")))
+    : {};
+  const next = config.put(current, parsed.key, parsed.value);
+
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, stringifyConfigToml(next));
+  console.log(`set ${parsed.key}=${parsed.value} in ${path}`);
+  return true;
+}
+
+function stringifyConfigToml(cfg: Record<string, unknown>): string {
+  const chunks = stringifyTomlSections(cfg, []);
+  return `${chunks.join("\n\n")}\n`;
+}
+
+function stringifyTomlSections(
+  cfg: Record<string, unknown>,
+  prefix: string[],
+): string[] {
+  const scalars: string[] = [];
+  const sections: string[] = [];
+
+  for (const [key, value] of Object.entries(cfg)) {
+    if (isPlainObject(value)) {
+      sections.push(...stringifyTomlSections(value, [...prefix, key]));
+    } else {
+      scalars.push(`${key} = ${JSON.stringify(String(value))}`);
+    }
+  }
+
+  const current =
+    scalars.length === 0
+      ? []
+      : [
+          prefix.length > 0
+            ? `[${prefix.join(".")}]\n${scalars.join("\n")}`
+            : scalars.join("\n"),
+        ];
+  return [...current, ...sections];
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseAssignment(value: string): { key: string; value: string } | null {
+  const eq = value.indexOf("=");
+  if (eq <= 0) return null;
+  const key = value.slice(0, eq).trim();
+  const parsedValue = value.slice(eq + 1).trim();
+  if (!key || !parsedValue) return null;
+  return { key, value: parsedValue };
+}
+
 function configPath(): boolean {
   const path = config.userConfigPath();
   const exists = existsSync(path);
@@ -77,11 +193,18 @@ function printConfigUsage(): void {
   console.log(
     "  show              Show resolved config with provenance labels",
   );
+  console.log(
+    "  set               Write a user/repo preset override: config set (--user|--repo) --preset <name> key=value",
+  );
   console.log("  path              Print user config file path and existence");
   console.log("");
   console.log("Options (show):");
   console.log(
     "  --project <dir>   Resolve against a specific project directory",
   );
+  console.log(
+    "  --preset <name>   Resolve a preset plus preset override layers",
+  );
+  console.log("  --explain         Alias for provenance display");
   console.log("  --json            Output as JSON with config and provenance");
 }

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -15,6 +15,7 @@ interface RunOptions {
   projectDir: string;
   prompt: string | null;
   backendOverride: Record<string, unknown>;
+  configOverride: Record<string, unknown>;
   logLevel: string | null;
   chain: string | null;
   presetExplicit: boolean;
@@ -99,6 +100,7 @@ function parseRunArgs(args: string[], bundleRoot: string): RunOptions {
     projectDir: ".",
     prompt: null,
     backendOverride: {},
+    configOverride: {},
     logLevel: null,
     chain: null,
     presetExplicit: false,
@@ -129,6 +131,38 @@ function parseRunArgs(args: string[], bundleRoot: string): RunOptions {
         return options;
       }
       options.backendOverride = backendOverrideSpec(backend);
+      i += 2;
+      continue;
+    }
+    if (
+      token === "--max-iterations" ||
+      token === "--iterations" ||
+      token === "-i"
+    ) {
+      const value = args[i + 1];
+      if (!value) {
+        console.log(`missing iteration count after ${token}`);
+        options.usageError = true;
+        return options;
+      }
+      setConfigOverride(options, "event_loop.max_iterations", value);
+      i += 2;
+      continue;
+    }
+    if (token === "--set") {
+      const assignment = args[i + 1];
+      if (!assignment) {
+        console.log("missing key=value after --set");
+        options.usageError = true;
+        return options;
+      }
+      const parsed = parseConfigAssignment(assignment);
+      if (!parsed) {
+        console.log(`invalid --set assignment: ${assignment}`);
+        options.usageError = true;
+        return options;
+      }
+      setConfigOverride(options, parsed.key, parsed.value);
       i += 2;
       continue;
     }
@@ -208,21 +242,31 @@ function parseRunArgs(args: string[], bundleRoot: string): RunOptions {
       i++;
       continue;
     }
-    if (token === "-i" || token === "--iterations") {
-      console.log(
-        "unsupported flag `" +
-          token +
-          "`; set event_loop.max_iterations in the preset config",
-      );
-      options.usageError = true;
-      return options;
-    }
 
     options.positionals.push(token);
     i++;
   }
 
   return finalizeRunArgs(options, bundleRoot);
+}
+
+function setConfigOverride(
+  options: RunOptions,
+  key: string,
+  value: string,
+): void {
+  options.configOverride = config.put(options.configOverride, key, value);
+}
+
+function parseConfigAssignment(
+  assignment: string,
+): { key: string; value: string } | null {
+  const eq = assignment.indexOf("=");
+  if (eq <= 0) return null;
+  const key = assignment.slice(0, eq).trim();
+  const value = assignment.slice(eq + 1).trim();
+  if (!key || !value) return null;
+  return { key, value };
 }
 
 function finalizeRunArgs(options: RunOptions, bundleRoot: string): RunOptions {
@@ -366,6 +410,7 @@ function defaultChainProjectDir(bundleRoot: string): string {
 function chainableOptions(opts: RunOptions): Record<string, unknown> {
   return {
     backendOverride: opts.backendOverride,
+    configOverride: opts.configOverride,
     worktree: opts.worktree || undefined,
     noWorktree: opts.noWorktree || undefined,
     mergeStrategy: opts.mergeStrategy,

--- a/packages/cli/src/usage.ts
+++ b/packages/cli/src/usage.ts
@@ -41,6 +41,13 @@ export function printUsage(): void {
   console.log("  -v, --verbose    Set log level to debug");
   console.log("  -b, --backend    Override backend command");
   console.log(
+    "  --max-iterations <n>  Override event_loop.max_iterations for this run",
+  );
+  console.log("  -i, --iterations <n>  Alias for --max-iterations");
+  console.log(
+    "  --set key=value       Override any config key for this run; repeatable",
+  );
+  console.log(
     "  -p, --preset     Resolve a bundled preset name or custom preset dir",
   );
   console.log(
@@ -76,6 +83,13 @@ export function printRunUsage(): void {
   console.log("  -v, --verbose    Set log level to debug");
   console.log("  -b, --backend    Override backend command");
   console.log(
+    "  --max-iterations <n>  Override event_loop.max_iterations for this run",
+  );
+  console.log("  -i, --iterations <n>  Alias for --max-iterations");
+  console.log(
+    "  --set key=value       Override any config key for this run; repeatable",
+  );
+  console.log(
     "  -p, --preset     Resolve a bundled preset name or custom preset dir",
   );
   console.log(
@@ -102,6 +116,12 @@ export function printRunUsage(): void {
   console.log("Examples:");
   console.log("  autoloop run autocode");
   console.log('  autoloop run autocode "Fix the login bug"');
+  console.log(
+    '  autoloop run autocode --max-iterations 250 "Fix the login bug"',
+  );
+  console.log(
+    '  autoloop run autocode --set backend.timeout_ms=900000 "Fix slowly"',
+  );
   console.log('  autoloop run presets/autoqa "QA recent changes"');
   console.log('  autoloop run . "Run from current directory"');
   console.log("");
@@ -208,6 +228,12 @@ export function missingPresetError(): void {
   console.log("Examples:");
   console.log("  autoloop run autocode");
   console.log('  autoloop run autocode "Fix the login bug"');
+  console.log(
+    '  autoloop run autocode --max-iterations 250 "Fix the login bug"',
+  );
+  console.log(
+    '  autoloop run autocode --set backend.timeout_ms=900000 "Fix slowly"',
+  );
   console.log('  autoloop run presets/autoqa "QA recent changes"');
   console.log('  autoloop run . "Run from current directory"');
   console.log("");

--- a/packages/cli/test/commands/config-show.test.ts
+++ b/packages/cli/test/commands/config-show.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -29,9 +29,14 @@ afterEach(() => rmSync(TMP_BASE, { recursive: true, force: true }));
 
 describe("dispatchConfig", () => {
   const origEnv = process.env.AUTOLOOP_CONFIG;
+  const origXdg = process.env.XDG_CONFIG_HOME;
+  const origCwd = process.cwd();
   afterEach(() => {
     if (origEnv === undefined) delete process.env.AUTOLOOP_CONFIG;
     else process.env.AUTOLOOP_CONFIG = origEnv;
+    if (origXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = origXdg;
+    process.chdir(origCwd);
   });
 
   it("show prints resolved config with per-key provenance", () => {
@@ -83,6 +88,88 @@ describe("dispatchConfig", () => {
     expect(parsed.config.backend.command).toBe("claude");
     expect(parsed.provenance["backend.command"]).toContain("project");
     expect(parsed.provenance["backend.kind"]).toBe("default");
+  });
+
+  it("config set writes user-scoped preset overrides", () => {
+    process.env.AUTOLOOP_CONFIG = join(TMP_BASE, "missing-user-config.toml");
+    process.env.XDG_CONFIG_HOME = join(TMP_BASE, "xdg-set-user");
+
+    const output = captureLogs(() =>
+      dispatchConfig([
+        "set",
+        "--user",
+        "--preset",
+        "autocode",
+        "event_loop.max_iterations=250",
+      ]),
+    );
+
+    const path = join(
+      process.env.XDG_CONFIG_HOME,
+      "autoloop",
+      "overrides",
+      "autocode.toml",
+    );
+    const content = readFileSync(path, "utf-8");
+    expect(content).toContain("[event_loop]");
+    expect(content).toContain('max_iterations = "250"');
+    expect(output).toContain(path);
+  });
+
+  it("config set writes repo-scoped preset overrides", () => {
+    process.env.AUTOLOOP_CONFIG = join(TMP_BASE, "missing-repo-config.toml");
+    const repoDir = tmpDir("repo-set");
+
+    const output = captureLogs(() =>
+      dispatchConfig([
+        "set",
+        "--repo",
+        "--project",
+        repoDir,
+        "--preset",
+        "autocode",
+        "event_loop.max_iterations=300",
+      ]),
+    );
+
+    const path = join(repoDir, ".autoloop", "overrides", "autocode.toml");
+    const content = readFileSync(path, "utf-8");
+    expect(content).toContain("[event_loop]");
+    expect(content).toContain('max_iterations = "300"');
+    expect(output).toContain(path);
+  });
+
+  it("show --preset includes preset override provenance", () => {
+    process.env.AUTOLOOP_CONFIG = join(TMP_BASE, "missing-show-preset.toml");
+    process.env.XDG_CONFIG_HOME = join(TMP_BASE, "xdg-show-preset");
+    const repoDir = tmpDir("repo-show-preset");
+    mkdirSync(join(repoDir, "presets", "autocode"), { recursive: true });
+    writeFileSync(
+      join(repoDir, "presets", "autocode", "autoloops.toml"),
+      "[event_loop]\nmax_iterations = 100\n",
+    );
+    const overridePath = join(
+      repoDir,
+      ".autoloop",
+      "overrides",
+      "autocode.toml",
+    );
+    mkdirSync(join(overridePath, ".."), { recursive: true });
+    writeFileSync(overridePath, "[event_loop]\nmax_iterations = 400\n");
+
+    const output = captureLogs(() =>
+      dispatchConfig([
+        "show",
+        "--project",
+        repoDir,
+        "--preset",
+        "autocode",
+        "--explain",
+      ]),
+    );
+
+    expect(output).toContain('max_iterations = "400"');
+    expect(output).toContain("# repo override");
   });
 
   it("path prints user config path and existence", () => {

--- a/packages/cli/test/commands/run-backend-override.test.ts
+++ b/packages/cli/test/commands/run-backend-override.test.ts
@@ -48,6 +48,59 @@ afterEach(() => {
 });
 
 describe("applyGlobalBackendOverride", () => {
+  it("passes run-scoped max iteration overrides to the harness", async () => {
+    const targetDir = tmpDir("target-max-iterations");
+    writeFileSync(
+      join(targetDir, "autoloops.toml"),
+      "[event_loop]\nmax_iterations = 2\n",
+    );
+
+    await dispatchRun(
+      [targetDir, "--max-iterations", "250", "fix", "the", "bug"],
+      [],
+      targetDir,
+      "autoloop",
+    );
+
+    expect(runSpy).toHaveBeenCalledTimes(1);
+    const opts = runSpy.mock.calls[0][3];
+    expect(opts.configOverride).toMatchObject({
+      event_loop: { max_iterations: "250" },
+    });
+    expect(runSpy.mock.calls[0][1]).toBe("fix the bug");
+  });
+
+  it("supports -i/--iterations and generic --set run overrides", async () => {
+    const targetDir = tmpDir("target-set-overrides");
+    writeFileSync(
+      join(targetDir, "autoloops.toml"),
+      "[event_loop]\nmax_iterations = 2\n",
+    );
+
+    await dispatchRun(
+      [
+        targetDir,
+        "-i",
+        "300",
+        "--set",
+        "backend.timeout_ms=900000",
+        "do",
+        "work",
+      ],
+      [],
+      targetDir,
+      "autoloop",
+    );
+
+    expect(runSpy).toHaveBeenCalledTimes(1);
+    const opts = runSpy.mock.calls[0][3];
+    expect(opts.configOverride).toMatchObject({
+      event_loop: { max_iterations: "300" },
+      backend: { timeout_ms: "900000" },
+    });
+    expect(runSpy.mock.calls[0][1]).toBe("do work");
+  });
+
   it("applies cwd backend override when user config also exists", () => {
     // Set up cwd project with backend override
     const cwdDir = tmpDir("cwd-project");

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -6,7 +6,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { homedir, platform } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import {
   type Config,
   deepMerge,
@@ -40,6 +40,12 @@ export {
   stringifyValues,
 } from "@mobrienv/autoloop-core/config-schema";
 
+export interface LoadLayeredOptions {
+  presetName?: string;
+  workDir?: string;
+  cliOverride?: Config;
+}
+
 export function userConfigPath(): string {
   const envPath = process.env.AUTOLOOP_CONFIG;
   if (envPath) return envPath;
@@ -58,6 +64,27 @@ export function userPresetsDir(): string {
   return join(xdgHome, "autoloop", "presets");
 }
 
+export function userOverridesDir(): string {
+  const xdgHome = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+  return join(xdgHome, "autoloop", "overrides");
+}
+
+export function userPresetOverridePath(presetName: string): string {
+  return join(userOverridesDir(), `${basename(presetName)}.toml`);
+}
+
+export function repoPresetOverridePath(
+  workDir: string,
+  presetName: string,
+): string {
+  return join(
+    workDir,
+    ".autoloop",
+    "overrides",
+    `${basename(presetName)}.toml`,
+  );
+}
+
 export function hasUserConfig(): boolean {
   return existsSync(userConfigPath());
 }
@@ -68,7 +95,10 @@ export function loadUserConfig(): Config {
   return stringifyValues(parseRawToml(readFileSync(path, "utf-8")));
 }
 
-export function loadLayered(projectDir: string): LayeredConfig {
+export function loadLayered(
+  projectDir: string,
+  options: LoadLayeredOptions = {},
+): LayeredConfig {
   const base = defaults();
   const provenance: Provenance = {};
   recordProvenance(base, "default", provenance, "");
@@ -86,11 +116,53 @@ export function loadLayered(projectDir: string): LayeredConfig {
     recordProvenance(projectCfg, `project (${projectPath})`, provenance, "");
   }
 
+  const presetName = options.presetName || basename(projectDir);
+  const userOverridePath = userPresetOverridePath(presetName);
+  if (existsSync(userOverridePath)) {
+    const userOverride = stringifyValues(
+      parseRawToml(readFileSync(userOverridePath, "utf-8")),
+    );
+    merged = deepMerge(merged, userOverride);
+    recordProvenance(
+      userOverride,
+      `user override (${userOverridePath})`,
+      provenance,
+      "",
+    );
+  }
+
+  if (options.workDir) {
+    const repoOverridePath = repoPresetOverridePath(
+      options.workDir,
+      presetName,
+    );
+    if (existsSync(repoOverridePath)) {
+      const repoOverride = stringifyValues(
+        parseRawToml(readFileSync(repoOverridePath, "utf-8")),
+      );
+      merged = deepMerge(merged, repoOverride);
+      recordProvenance(
+        repoOverride,
+        `repo override (${repoOverridePath})`,
+        provenance,
+        "",
+      );
+    }
+  }
+
+  if (options.cliOverride && Object.keys(options.cliOverride).length > 0) {
+    merged = deepMerge(merged, options.cliOverride);
+    recordProvenance(options.cliOverride, "CLI override", provenance, "");
+  }
+
   return { config: merged, provenance };
 }
 
-export function loadProject(projectDir: string): Config {
-  return loadLayered(projectDir).config;
+export function loadProject(
+  projectDir: string,
+  options: LoadLayeredOptions = {},
+): Config {
+  return loadLayered(projectDir, options).config;
 }
 
 export function load(path: string): Config {

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -14,6 +14,7 @@ import {
   projectHasConfig,
   put,
   userConfigPath,
+  userPresetOverridePath,
 } from "../src/config.js";
 
 const TMP_BASE = join(tmpdir(), `autoloop-ts-test-config-${process.pid}`);
@@ -222,9 +223,12 @@ describe("loadUserConfig", () => {
 
 describe("loadLayered", () => {
   const origEnv = process.env.AUTOLOOP_CONFIG;
+  const origXdg = process.env.XDG_CONFIG_HOME;
   afterEach(() => {
     if (origEnv === undefined) delete process.env.AUTOLOOP_CONFIG;
     else process.env.AUTOLOOP_CONFIG = origEnv;
+    if (origXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = origXdg;
   });
 
   it("returns defaults when no user or project config", () => {
@@ -268,6 +272,58 @@ describe("loadLayered", () => {
     const { config: cfg, provenance } = loadLayered(dir);
     expect(get(cfg, "backend.command", "")).toBe("custom-backend");
     expect(provenance["backend.command"]).toContain("project");
+  });
+
+  it("applies user and repo preset overrides after preset config", () => {
+    process.env.AUTOLOOP_CONFIG = join(TMP_BASE, "missing-user.toml");
+    process.env.XDG_CONFIG_HOME = join(TMP_BASE, "xdg");
+
+    const presetDir = tmpDir("autocode");
+    writeFileSync(
+      join(presetDir, "autoloops.toml"),
+      "[event_loop]\nmax_iterations = 100\n",
+    );
+
+    const userOverride = userPresetOverridePath("autocode");
+    mkdirSync(join(userOverride, ".."), { recursive: true });
+    writeFileSync(userOverride, "[event_loop]\nmax_iterations = 200\n");
+
+    const repoDir = tmpDir("repo-with-override");
+    const repoOverride = join(
+      repoDir,
+      ".autoloop",
+      "overrides",
+      "autocode.toml",
+    );
+    mkdirSync(join(repoOverride, ".."), { recursive: true });
+    writeFileSync(repoOverride, "[event_loop]\nmax_iterations = 250\n");
+
+    const { config: cfg, provenance } = loadLayered(presetDir, {
+      presetName: "autocode",
+      workDir: repoDir,
+    });
+
+    expect(getInt(cfg, "event_loop.max_iterations", 0)).toBe(250);
+    expect(provenance["event_loop.max_iterations"]).toContain("repo override");
+  });
+
+  it("applies run-scoped config overrides last", () => {
+    process.env.AUTOLOOP_CONFIG = join(TMP_BASE, "missing-run-user.toml");
+    process.env.XDG_CONFIG_HOME = join(TMP_BASE, "xdg-run");
+
+    const presetDir = tmpDir("autocode-run");
+    writeFileSync(
+      join(presetDir, "autoloops.toml"),
+      "[event_loop]\nmax_iterations = 100\n",
+    );
+
+    const { config: cfg, provenance } = loadLayered(presetDir, {
+      presetName: "autocode-run",
+      cliOverride: put({}, "event_loop.max_iterations", "300"),
+    });
+
+    expect(getInt(cfg, "event_loop.max_iterations", 0)).toBe(300);
+    expect(provenance["event_loop.max_iterations"]).toBe("CLI override");
   });
 
   it("non-overlapping sections preserve their sources", () => {

--- a/packages/harness/src/config-helpers.ts
+++ b/packages/harness/src/config-helpers.ts
@@ -284,19 +284,28 @@ export function buildLoopContext(
 ): LoopContext {
   const resolvedProjectDir = absolutePath(projectDir);
   const resolvedWorkDir = absolutePath(runOptions.workDir || ".");
-  const cfg = config.loadProject(resolvedProjectDir);
-  const stateDirAnchor = tryResolveGitRoot(resolvedWorkDir) ?? resolvedWorkDir;
+  const currentPresetName = basename(resolvedProjectDir);
+  const configWorkDir = tryResolveGitRoot(resolvedWorkDir) ?? resolvedWorkDir;
+  const configOverride = runOptions.configOverride || {};
+  const cfg = config.loadProject(resolvedProjectDir, {
+    presetName: currentPresetName,
+    workDir: configWorkDir,
+    cliOverride: configOverride,
+  });
+  const stateDirAnchor = configWorkDir;
   const stateDir = join(
     stateDirAnchor,
     config.get(cfg, "core.state_dir", ".autoloop"),
   );
-  const journalFile = config.resolveJournalFileIn(
-    resolvedProjectDir,
-    resolvedWorkDir,
+  const journalRelPath = config.get(
+    cfg,
+    "core.journal_file",
+    config.get(cfg, "core.events_file", ".autoloop/journal.jsonl"),
   );
-  const memoryFile = config.resolveMemoryFileIn(
-    resolvedProjectDir,
+  const journalFile = join(resolvedWorkDir, journalRelPath);
+  const memoryFile = join(
     resolvedWorkDir,
+    config.get(cfg, "core.memory_file", ".autoloop/memory.jsonl"),
   );
   // tasksFile is resolved later, after isolation mode determines effectiveStateDir
   const runId = nextRunId(journalFile, cfg);
@@ -310,7 +319,6 @@ export function buildLoopContext(
   const configIsolationEnabled =
     config.get(cfg, "worktree.enabled", "") === "true" ||
     config.get(cfg, "isolation.enabled", "false") === "true";
-  const currentPresetName = basename(resolvedProjectDir);
   const currentCat = presetCategory(currentPresetName, resolvedProjectDir);
   const isolation = resolveIsolationMode(
     {
@@ -402,12 +410,14 @@ export function buildLoopContext(
       worktreeBranch,
       worktreePath,
       worktreeMetaDir,
+      configWorkDir,
     },
     runtime: {
       runId,
       selfCommand,
       promptOverride: promptOverride ?? null,
       backendOverride,
+      configOverride,
       logLevel,
       branchMode: false,
       isolationMode: isolation.mode,
@@ -431,7 +441,11 @@ export function buildLoopContext(
 export function reloadLoop(loop: LoopContext): LoopContext {
   const pd = loop.paths.projectDir;
   const wd = loop.paths.workDir;
-  const cfg = config.loadProject(pd);
+  const cfg = config.loadProject(pd, {
+    presetName: loop.launch.preset,
+    workDir: loop.paths.configWorkDir || wd,
+    cliOverride: loop.runtime.configOverride,
+  });
   const topoData = topo.loadTopology(pd);
 
   const backend = readBackendConfig(cfg, loop.runtime.backendOverride);

--- a/packages/harness/src/types.ts
+++ b/packages/harness/src/types.ts
@@ -74,12 +74,14 @@ export interface LoopContext {
     worktreeBranch: string;
     worktreePath: string;
     worktreeMetaDir: string;
+    configWorkDir: string;
   };
   runtime: {
     runId: string;
     selfCommand: string;
     promptOverride: string | null;
     backendOverride: Record<string, unknown>;
+    configOverride: Record<string, unknown>;
     logLevel: string;
     branchMode: boolean;
     isolationMode: string;
@@ -97,6 +99,7 @@ export interface LoopContext {
 export interface RunOptions {
   workDir?: string;
   backendOverride?: Record<string, unknown>;
+  configOverride?: Record<string, unknown>;
   logLevel?: string | null;
   prompt?: string | null;
   chain?: string | null;

--- a/packages/harness/test/harness/config-helpers.test.ts
+++ b/packages/harness/test/harness/config-helpers.test.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { put } from "@mobrienv/autoloop-core/config";
 import type { RunRecord } from "@mobrienv/autoloop-core/registry/types";
 import {
   buildLoopContext,
@@ -219,6 +220,24 @@ describe("buildLoopContext", () => {
     expect(loop.backend.command).toBe("claude");
     expect(loop.backend.args).toEqual(["-p", "--dangerously-skip-permissions"]);
     expect(loop.review.args).toEqual(["-p", "--dangerously-skip-permissions"]);
+  });
+
+  it("reapplies run-scoped config overrides across hot reload", () => {
+    const projectDir = makeProject("event_loop.max_iterations = 1\n");
+    const loop = buildLoopContext(projectDir, "test", "node dist/main.js", {
+      workDir: projectDir,
+      configOverride: put({}, "event_loop.max_iterations", "42"),
+    });
+
+    expect(loop.limits.maxIterations).toBe(42);
+
+    writeFileSync(
+      join(projectDir, "autoloops.toml"),
+      "event_loop.max_iterations = 2\n",
+    );
+    const reloaded = reloadLoop(loop);
+
+    expect(reloaded.limits.maxIterations).toBe(42);
   });
 
   it("sets isolation mode to run-scoped by default for solo run", () => {


### PR DESCRIPTION
## Summary
- add run-scoped config overrides for `autoloop run`, including `--max-iterations`, `-i`/`--iterations`, and repeatable `--set key=value`
- add persistent user/repo preset overrides via `autoloop config set --user|--repo --preset ...`, with `config show --preset --explain` provenance
- carry config overrides through harness context so hot reload reapplies runtime-only overrides
- document the new CLI/configuration UX

## Test Plan
- [x] `npm test -- --run packages/core/test/config.test.ts packages/harness/test/harness/config-helpers.test.ts packages/cli/test/commands/config-show.test.ts packages/cli/test/commands/run-backend-override.test.ts`
- [x] `npm run check`
