### PR TITLE
feat(backends): drive the pi backend over a persistent RPC session

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -443,6 +443,8 @@ Run the Pi backend adapter directly. This is normally called by the harness, not
 autoloop pi-adapter [pi-command] [extra-args...]
 ```
 
+The main iteration loop and metareview no longer use this adapter — they drive a persistent `pi --mode rpc` session directly (see the configuration reference). The adapter remains the process-per-task path for parallel waves.
+
 The adapter resolves the prompt from `AUTOLOOP_PROMPT`, then falls back to projecting it via `autoloop inspect prompt`, then falls back to reading `AUTOLOOP_PROMPT_PATH`. It invokes Pi with `-p --mode json --no-session` plus any extra arguments, parses the NDJSON stream, and writes the raw stream to `.autoloop/pi-stream.<iteration>.jsonl` (or `pi-review.<iteration>.jsonl` in review mode).
 
 ## Testing

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -239,6 +239,23 @@ backend.args = ["dist/testing/mock-backend.js"]
 
 Command mode invokes the executable directly and captures stdout. It is not a supported production adapter — use Pi for real loops.
 
+## Pi backend (RPC sessions)
+
+The pi backend drives a persistent `pi --mode rpc --no-session` process over pi's JSONL RPC protocol. The harness spawns one pi process and reuses it across iterations; each iteration issues a `new_session` command so every role starts with a clean context window (the process is respawned automatically if it dies or refuses the reset). Metareview runs in its own dedicated pi RPC session. Spawn and reset round trips carry hard deadlines, so a wedged pi binary fails the iteration instead of hanging the loop.
+
+```toml
+backend.kind = "pi"
+backend.command = "pi"
+# backend.model = "anthropic/claude-sonnet-4"   # passed as --model
+# backend.args = ["--thinking", "high"]          # appended verbatim
+```
+
+Live control: `interrupt` requests map to pi's `abort` command, cancelling the in-flight turn without killing the process, and `guide` requests are additionally steered into the live turn via pi's `steer` command — delivered before the agent's next LLM call, on top of the journal-durable copy that reaches the next iteration prompt.
+
+Observability: the raw RPC event stream of every iteration is persisted to `.autoloop/runs/<run_id>/pi-stream.<iteration>.jsonl` (metareviews to `pi-review.<iteration>.jsonl`), preserving full tool-call and thinking fidelity. After each iteration the harness journals a `backend.usage` event with token counts, cost, and context-window usage from pi's `get_session_stats`.
+
+Parallel waves still run pi process-per-task through the `pi-adapter` shim (`pi -p --mode json`), since wave branches execute as independent shell commands.
+
 ## ACP backend providers
 
 ACP backends communicate with an Agent Client Protocol (ACP) stdio server over JSON-RPC 2.0. Use `backend.kind = "acp"` and select provider-specific defaults with `backend.provider`. Legacy `backend.kind = "kiro"` still works and normalizes to `kind = "acp"` plus `provider = "kiro"`.
@@ -286,7 +303,7 @@ The `trust_all_tools` key (default `true`) auto-approves ACP tool permission req
 
 ### Session lifecycle
 
-Unlike `pi` and `command` backends which spawn a process for a single invocation, ACP backends keep one stdio child process per active iteration session. The harness uses a fresh ACP session for each iteration so role-specific prompts, agent names, and model settings do not leak conversation history across planner/builder/critic roles.
+Like the pi RPC backend, ACP backends keep a stdio child process per active iteration session rather than spawning one process per invocation (only `command` backends do that). The harness uses a fresh ACP session for each iteration so role-specific prompts, agent names, and model settings do not leak conversation history across planner/builder/critic roles.
 
 Sequence: spawn provider command → `initialize` handshake → `session/new` → optional `setSessionMode` / `unstable_setSessionModel` → iteration prompt via ACP `prompt` request → `terminate` on iteration or loop exit.
 

--- a/packages/backends/package.json
+++ b/packages/backends/package.json
@@ -19,6 +19,10 @@
       "types": "./dist/acp-providers.d.ts",
       "default": "./dist/acp-providers.js"
     },
+    "./pi-rpc-client": {
+      "types": "./dist/pi-rpc-client.d.ts",
+      "default": "./dist/pi-rpc-client.js"
+    },
     "./run-command": {
       "types": "./dist/run-command.d.ts",
       "default": "./dist/run-command.js"

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -5,6 +5,7 @@ import {
   shellWords,
 } from "@mobrienv/autoloop-core";
 import { type AcpSession, sendAcpPrompt } from "./acp-client.js";
+import { type PiSession, sendPiPrompt } from "./pi-rpc-client.js";
 import { buildCommandInvocation, runShellCommand } from "./run-command.js";
 import type { BackendCommandContext, BackendRunResult } from "./types.js";
 
@@ -54,6 +55,42 @@ export async function runAcpIteration(
 }
 
 export const runKiroIteration = runAcpIteration;
+
+/**
+ * Drive one iteration against a live pi RPC session (`pi --mode rpc`) and map
+ * the result into the uniform BackendRunResult shape. The session-based path
+ * replaces the former one-shot python bridge (`pi -p --mode json`) for the
+ * main loop and reviews; parallel waves still use the process-per-task shim.
+ */
+export async function runPiIteration(
+  session: PiSession,
+  prompt: string,
+  timeoutMs: number,
+  streamLogPath?: string,
+): Promise<BackendRunResult> {
+  session.streamLogPath = streamLogPath;
+  const result = await sendPiPrompt(session, prompt, timeoutMs);
+  return {
+    output: failureOutput(result.output, result.error),
+    exitCode: result.error ? 1 : 0,
+    timedOut: result.timedOut,
+    providerKind: "pi",
+    errorCategory: result.timedOut
+      ? "timeout"
+      : result.error
+        ? "non_zero_exit"
+        : "none",
+  };
+}
+
+/**
+ * Keep the error detail in the journaled output on failure — exit codes alone
+ * make failed iterations undiagnosable after the fact.
+ */
+function failureOutput(output: string, error: string | undefined): string {
+  if (!error) return output;
+  return output ? `${output}\n\npi error: ${error}` : `pi error: ${error}`;
+}
 
 /**
  * A "mock" backend is any invocation whose command or argv mentions

--- a/packages/backends/src/pi-rpc-client.ts
+++ b/packages/backends/src/pi-rpc-client.ts
@@ -1,0 +1,538 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { writeFileSync } from "node:fs";
+
+export interface PiClientOptions {
+  command: string;
+  args: string[];
+  cwd: string;
+  modelId?: string;
+  verbose?: boolean;
+  /** Deadline for the init/reset RPC round trips (default 30s). */
+  handshakeTimeoutMs?: number;
+  /** How long a timed-out turn may drain after `abort` before the session is reused (default 2s). */
+  abortGraceMs?: number;
+}
+
+const DEFAULT_HANDSHAKE_TIMEOUT_MS = 30_000;
+const DEFAULT_ABORT_GRACE_MS = 2_000;
+const STATS_TIMEOUT_MS = 3_000;
+/** Cap on retained pi stderr — the process is long-lived, keep only the tail. */
+const STDERR_CAP_BYTES = 64 * 1024;
+
+interface PendingResponse {
+  resolve: (msg: PiRpcMessage) => void;
+  reject: (err: Error) => void;
+}
+
+export interface PiRpcMessage {
+  type?: string;
+  id?: string;
+  success?: boolean;
+  error?: string;
+  [key: string]: unknown;
+}
+
+export interface PiSession {
+  process: ChildProcess;
+  options: PiClientOptions;
+  textBuffer: string;
+  stderrBuffer: string;
+  lastError: string;
+  /** Resolves when the child process exits — used to race against hanging prompts */
+  closed: Promise<{ code: number | null; signal: string | null }>;
+  nextRequestId: number;
+  pending: Map<string, PendingResponse>;
+  agentEndWaiters: ((event: PiRpcMessage) => void)[];
+  /** Raw RPC lines for the in-flight prompt, flushed to streamLogPath. */
+  streamLines: string[];
+  /** Where to persist the raw RPC stream for the current prompt, if anywhere. */
+  streamLogPath?: string;
+}
+
+export interface PiPromptResult {
+  output: string;
+  timedOut: boolean;
+  error?: string;
+}
+
+/** Per-session usage totals from pi's `get_session_stats` RPC command. */
+export interface PiUsageStats {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  totalTokens: number;
+  costUsd: number;
+  contextPercent?: number;
+}
+
+/**
+ * Format a pi RPC event for verbose stderr output.
+ * Returns null for event types that should be silenced.
+ */
+export function formatPiStreamingEvent(event: PiRpcMessage): string | null {
+  if (event.type === "message_update") {
+    const delta = event.assistantMessageEvent as
+      | { type?: string; delta?: string }
+      | undefined;
+    if (delta?.type === "text_delta") return delta.delta ?? null;
+    return null;
+  }
+  if (event.type === "tool_execution_start") {
+    const name = typeof event.toolName === "string" ? event.toolName : "tool";
+    return `[tool:${name}]\n`;
+  }
+  if (event.type === "tool_execution_end") {
+    const name = typeof event.toolName === "string" ? event.toolName : "tool";
+    return event.isError ? `[tool:✗] ${name}\n` : `[tool:✓] ${name}\n`;
+  }
+  return null;
+}
+
+/**
+ * Spawn `pi --mode rpc` and verify the RPC channel with a get_state round
+ * trip. The session holds one live pi process; iterations get fresh context
+ * via resetPiSession (a `new_session` command) instead of respawning.
+ */
+export async function initPiSession(opts: PiClientOptions): Promise<PiSession> {
+  const args = buildPiArgs(opts);
+  const child = spawn(opts.command, args, {
+    stdio: ["pipe", "pipe", "pipe"],
+    cwd: opts.cwd,
+    env: process.env,
+    detached: true, // own process group so terminatePiSession can kill the full tree
+  });
+
+  if (!child.stdout || !child.stdin) {
+    throw new Error("Failed to create pi process stdio streams");
+  }
+
+  const session: PiSession = {
+    process: child,
+    options: opts,
+    textBuffer: "",
+    stderrBuffer: "",
+    lastError: "",
+    closed: new Promise((resolve) => {
+      child.on("error", () => resolve({ code: null, signal: null }));
+      child.on("close", (code, signal) => resolve({ code, signal }));
+    }),
+    nextRequestId: 0,
+    pending: new Map(),
+    agentEndWaiters: [],
+    streamLines: [],
+  };
+
+  if (child.stderr) {
+    child.stderr.on("data", (chunk: Buffer) => {
+      session.stderrBuffer = (session.stderrBuffer + chunk.toString()).slice(
+        -STDERR_CAP_BYTES,
+      );
+    });
+  }
+
+  attachJsonlReader(child, (line) => handlePiLine(session, line));
+
+  // Reject all pending requests when the process dies so callers never hang.
+  void session.closed.then(({ code, signal }) => {
+    const err = crashError(session, code, signal);
+    for (const pending of session.pending.values()) pending.reject(err);
+    session.pending.clear();
+  });
+
+  // Handshake: confirm the RPC channel is live before reporting success. A
+  // wedged spawn must not hang the loop — enforce a deadline and reap the
+  // orphan on failure.
+  try {
+    await Promise.race([
+      sendPiCommand(session, { type: "get_state" }),
+      rejectAfter(handshakeTimeout(opts), "pi RPC handshake timed out"),
+      session.closed.then(({ code, signal }) => {
+        throw crashError(session, code, signal);
+      }),
+    ]);
+  } catch (err) {
+    await terminatePiSession(session).catch(() => {
+      /* best-effort */
+    });
+    throw err;
+  }
+  return session;
+}
+
+/**
+ * Send one autoloop iteration prompt and wait for the agent to finish.
+ * Output is the accumulated assistant text (streaming deltas, with the
+ * agent_end message list as fallback). On timeout the in-flight turn is
+ * aborted via the RPC `abort` command and partial output is returned.
+ */
+export async function sendPiPrompt(
+  session: PiSession,
+  prompt: string,
+  timeoutMs: number,
+): Promise<PiPromptResult> {
+  session.textBuffer = "";
+  session.lastError = "";
+  session.streamLines = [];
+
+  let timedOut = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const agentEnd = waitForAgentEnd(session);
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      timedOut = true;
+      reject(new Error("pi prompt timed out"));
+    }, timeoutMs);
+  });
+  const crashPromise = session.closed.then(({ code, signal }) => {
+    throw crashError(session, code, signal);
+  });
+
+  try {
+    const ack = await Promise.race([
+      sendPiCommand(session, { type: "prompt", message: prompt }),
+      timeoutPromise,
+      crashPromise,
+    ]);
+    if (ack.success === false) {
+      clearTimeout(timer);
+      return {
+        output: "",
+        timedOut: false,
+        error: ack.error || "pi rejected prompt",
+      };
+    }
+    const end = await Promise.race([agentEnd, timeoutPromise, crashPromise]);
+    clearTimeout(timer);
+    return finishPrompt(session, end);
+  } catch (err) {
+    clearTimeout(timer);
+    if (timedOut) {
+      abortPiTurn(session);
+      // Bounded grace: let the aborted turn drain (agent_end) so the next
+      // new_session lands on an idle agent instead of a streaming one.
+      await Promise.race([
+        agentEnd,
+        sleep(session.options.abortGraceMs ?? DEFAULT_ABORT_GRACE_MS),
+        session.closed,
+      ]);
+      return { output: session.textBuffer, timedOut: true };
+    }
+    return { output: session.textBuffer, timedOut: false, error: String(err) };
+  } finally {
+    flushStreamLog(session);
+  }
+}
+
+/**
+ * Start a fresh pi conversation on the live process — the per-iteration
+ * context reset. Throws if the process is gone or pi refuses, in which case
+ * the caller should respawn via initPiSession.
+ */
+export async function resetPiSession(session: PiSession): Promise<void> {
+  if (!session.process.pid || session.process.killed) {
+    throw new Error("pi process is not running");
+  }
+  const ack = await Promise.race([
+    sendPiCommand(session, { type: "new_session" }),
+    rejectAfter(handshakeTimeout(session.options), "pi new_session timed out"),
+    session.closed.then(({ code, signal }) => {
+      throw crashError(session, code, signal);
+    }),
+  ]);
+  if (ack.success === false) {
+    throw new Error(ack.error || "pi new_session failed");
+  }
+  session.textBuffer = "";
+  session.lastError = "";
+}
+
+export async function terminatePiSession(session: PiSession): Promise<void> {
+  const child = session.process;
+  if (!child.pid || child.killed) return;
+
+  // Abort any in-flight turn before killing
+  abortPiTurn(session);
+
+  // Kill the entire process tree — pi tool subprocesses run in the same
+  // process group and won't die from just killing the parent.
+  const pid = child.pid;
+  try {
+    process.kill(-pid, "SIGTERM");
+  } catch {
+    /* process group may not exist */
+  }
+  child.kill("SIGTERM");
+
+  const exited = await Promise.race([
+    new Promise<boolean>((resolve) => child.on("exit", () => resolve(true))),
+    new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 3000)),
+  ]);
+  if (!exited && !child.killed) {
+    try {
+      process.kill(-pid, "SIGKILL");
+    } catch {
+      /* already dead */
+    }
+    child.kill("SIGKILL");
+  }
+}
+
+function buildPiArgs(opts: PiClientOptions): string[] {
+  const args = ["--mode", "rpc", "--no-session"];
+  if (opts.modelId) args.push("--model", opts.modelId);
+  return [...args, ...opts.args];
+}
+
+function sendPiCommand(
+  session: PiSession,
+  command: Record<string, unknown>,
+): Promise<PiRpcMessage> {
+  const stdin = session.process.stdin;
+  if (!stdin || stdin.destroyed || stdin.writableEnded) {
+    return Promise.reject(new Error("pi stdin is not writable"));
+  }
+  session.nextRequestId += 1;
+  const id = `req-${session.nextRequestId}`;
+  return new Promise<PiRpcMessage>((resolve, reject) => {
+    session.pending.set(id, { resolve, reject });
+    stdin.write(`${JSON.stringify({ id, ...command })}\n`, (err) => {
+      if (err) {
+        session.pending.delete(id);
+        reject(err);
+      }
+    });
+  });
+}
+
+/** Fire-and-forget abort of the in-flight turn; never throws. */
+export function abortPiTurn(session: PiSession): void {
+  sendPiCommand(session, { type: "abort" }).catch(() => {
+    /* best-effort */
+  });
+}
+
+/**
+ * Fire-and-forget live steering: queue a message into the in-flight turn via
+ * pi's `steer` command. Delivered after the current assistant turn finishes
+ * its tool calls, before the next LLM call. Never throws.
+ */
+export function steerPiTurn(session: PiSession, message: string): void {
+  sendPiCommand(session, { type: "steer", message }).catch(() => {
+    /* best-effort */
+  });
+}
+
+/**
+ * Fetch token/cost totals for the current pi conversation. Best-effort with
+ * its own short deadline — telemetry must never stall the loop.
+ */
+export async function getPiSessionStats(
+  session: PiSession,
+): Promise<PiUsageStats | undefined> {
+  try {
+    const ack = await Promise.race([
+      sendPiCommand(session, { type: "get_session_stats" }),
+      rejectAfter(STATS_TIMEOUT_MS, "pi get_session_stats timed out"),
+      session.closed.then(({ code, signal }) => {
+        throw crashError(session, code, signal);
+      }),
+    ]);
+    if (ack.success === false) return undefined;
+    return parseUsageStats(ack.data);
+  } catch {
+    return undefined;
+  }
+}
+
+function parseUsageStats(data: unknown): PiUsageStats | undefined {
+  const stats = data as
+    | {
+        tokens?: Record<string, number>;
+        cost?: number;
+        contextUsage?: { percent?: number | null };
+      }
+    | undefined;
+  if (!stats?.tokens) return undefined;
+  return {
+    inputTokens: stats.tokens.input ?? 0,
+    outputTokens: stats.tokens.output ?? 0,
+    cacheReadTokens: stats.tokens.cacheRead ?? 0,
+    cacheWriteTokens: stats.tokens.cacheWrite ?? 0,
+    totalTokens: stats.tokens.total ?? 0,
+    costUsd: stats.cost ?? 0,
+    contextPercent: stats.contextUsage?.percent ?? undefined,
+  };
+}
+
+function waitForAgentEnd(session: PiSession): Promise<PiRpcMessage> {
+  return new Promise((resolve) => {
+    session.agentEndWaiters.push(resolve);
+  });
+}
+
+function finishPrompt(session: PiSession, end: PiRpcMessage): PiPromptResult {
+  const output = session.textBuffer || agentEndText(end);
+  const error = session.lastError || stopReasonError(end);
+  if (error) return { output, timedOut: false, error };
+  return { output, timedOut: false };
+}
+
+/**
+ * Route one stdout JSONL record. RPC framing is strict LF-delimited JSON —
+ * responses carry an `id`, events do not.
+ */
+function handlePiLine(session: PiSession, line: string): void {
+  session.streamLines.push(line);
+
+  let msg: PiRpcMessage;
+  try {
+    msg = JSON.parse(line) as PiRpcMessage;
+  } catch {
+    return; /* skip malformed */
+  }
+
+  if (msg.type === "response" && typeof msg.id === "string") {
+    const pending = session.pending.get(msg.id);
+    if (pending) {
+      session.pending.delete(msg.id);
+      pending.resolve(msg);
+    }
+    return;
+  }
+
+  if (msg.type === "message_update") {
+    const delta = msg.assistantMessageEvent as
+      | { type?: string; delta?: string; reason?: string }
+      | undefined;
+    if (delta?.type === "text_delta") {
+      session.textBuffer += delta.delta ?? "";
+    } else if (delta?.type === "error" && delta.reason) {
+      session.lastError = delta.reason;
+    }
+  }
+
+  if (session.options.verbose) {
+    const text = formatPiStreamingEvent(msg);
+    if (text) process.stderr.write(text);
+  }
+
+  if (msg.type === "agent_end") {
+    const waiters = session.agentEndWaiters;
+    session.agentEndWaiters = [];
+    for (const waiter of waiters) waiter(msg);
+  }
+}
+
+/** Last assistant message text from an agent_end event — streaming fallback. */
+function agentEndText(end: PiRpcMessage): string {
+  const messages = Array.isArray(end.messages) ? end.messages : [];
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i] as {
+      role?: string;
+      content?: { type?: string; text?: string }[];
+    };
+    if (message?.role !== "assistant") continue;
+    const parts = Array.isArray(message.content) ? message.content : [];
+    return parts
+      .filter((part) => part?.type === "text")
+      .map((part) => part.text ?? "")
+      .join("");
+  }
+  return "";
+}
+
+/** Error from the final assistant message's stopReason, if any. */
+function stopReasonError(end: PiRpcMessage): string {
+  const messages = Array.isArray(end.messages) ? end.messages : [];
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i] as {
+      role?: string;
+      stopReason?: string;
+      errorMessage?: string;
+    };
+    if (message?.role !== "assistant") continue;
+    if (message.stopReason === "error" || message.stopReason === "aborted") {
+      return message.errorMessage || `pi stopped: ${message.stopReason}`;
+    }
+    return "";
+  }
+  return "";
+}
+
+function handshakeTimeout(opts: PiClientOptions): number {
+  return opts.handshakeTimeoutMs ?? DEFAULT_HANDSHAKE_TIMEOUT_MS;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function rejectAfter(ms: number, message: string): Promise<never> {
+  return new Promise((_resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), ms);
+    timer.unref?.();
+  });
+}
+
+/**
+ * Persist the raw RPC traffic of the finished prompt — the pi equivalent of
+ * the journal's backend output, but with full tool/thinking event fidelity.
+ */
+function flushStreamLog(session: PiSession): void {
+  const path = session.streamLogPath;
+  if (!path || session.streamLines.length === 0) return;
+  try {
+    writeFileSync(path, `${session.streamLines.join("\n")}\n`, "utf-8");
+  } catch {
+    /* logging must never fail the iteration */
+  }
+  session.streamLines = [];
+}
+
+function crashError(
+  session: PiSession,
+  code: number | null,
+  signal: string | null,
+): Error {
+  const stderr = session.stderrBuffer.trim();
+  const detail = stderr ? `\n${stderr}` : "";
+  return new Error(
+    `pi exited unexpectedly: code=${code} signal=${signal}${detail}`,
+  );
+}
+
+/**
+ * Strict JSONL reader per pi's RPC framing rules: split on LF only, strip a
+ * trailing CR. (Node readline is not protocol-compliant — it also splits on
+ * U+2028/U+2029, which are valid inside JSON strings.)
+ */
+function attachJsonlReader(
+  child: ChildProcess,
+  onLine: (line: string) => void,
+): void {
+  const stdout = child.stdout;
+  if (!stdout) return;
+  let buffer = "";
+  const decoder = new TextDecoder();
+
+  const emit = (raw: string) => {
+    const line = raw.endsWith("\r") ? raw.slice(0, -1) : raw;
+    if (line.trim()) onLine(line);
+  };
+
+  stdout.on("data", (chunk: Buffer) => {
+    buffer += decoder.decode(chunk, { stream: true });
+    let newlineIndex = buffer.indexOf("\n");
+    while (newlineIndex !== -1) {
+      emit(buffer.slice(0, newlineIndex));
+      buffer = buffer.slice(newlineIndex + 1);
+      newlineIndex = buffer.indexOf("\n");
+    }
+  });
+  stdout.on("end", () => {
+    buffer += decoder.decode();
+    if (buffer) emit(buffer);
+  });
+}

--- a/packages/backends/test/pi-rpc-session.test.ts
+++ b/packages/backends/test/pi-rpc-session.test.ts
@@ -1,0 +1,597 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runPiIteration } from "@mobrienv/autoloop-backends";
+import {
+  abortPiTurn,
+  formatPiStreamingEvent,
+  getPiSessionStats,
+  initPiSession,
+  type PiSession,
+  resetPiSession,
+  sendPiPrompt,
+  steerPiTurn,
+  terminatePiSession,
+} from "@mobrienv/autoloop-backends/pi-rpc-client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface MockChild extends ChildProcess {
+  sent: Record<string, unknown>[];
+  pushLine: (msg: Record<string, unknown> | string) => void;
+  autoRespond: boolean;
+  failCommands: Set<string>;
+  responseData: Record<string, unknown>;
+}
+
+let lastChild: MockChild;
+
+vi.mock("node:child_process", () => {
+  const EventEmitter = require("node:events");
+  const { Readable, Writable } = require("node:stream");
+
+  function createMockChild(): ChildProcess {
+    const child = new EventEmitter() as MockChild;
+    child.sent = [];
+    child.autoRespond = (globalThis as any).__piAutoRespond ?? true;
+    child.failCommands = new Set();
+    child.responseData = {};
+    child.pushLine = (msg) => {
+      const line = typeof msg === "string" ? msg : JSON.stringify(msg);
+      (child.stdout as any).push(`${line}\n`);
+    };
+    child.stdin = new Writable({
+      write(chunk: Buffer, _e: unknown, cb: () => void) {
+        for (const line of chunk.toString().split("\n")) {
+          if (!line.trim()) continue;
+          const cmd = JSON.parse(line) as Record<string, unknown>;
+          child.sent.push(cmd);
+          if (child.autoRespond && cmd.id) {
+            const success = !child.failCommands.has(String(cmd.type));
+            const data = child.responseData[String(cmd.type)];
+            child.pushLine({
+              type: "response",
+              id: cmd.id,
+              command: cmd.type,
+              success,
+              ...(data === undefined ? {} : { data }),
+              ...(success ? {} : { error: `${cmd.type} refused` }),
+            });
+          }
+        }
+        cb();
+      },
+    });
+    child.stdout = new Readable({ read() {} });
+    child.stderr = new Readable({ read() {} });
+    child.pid = 23456;
+    child.killed = false;
+    child.kill = vi.fn(() => {
+      child.killed = true;
+      process.nextTick(() => {
+        child.emit("exit", 0, null);
+        child.emit("close", 0, null);
+      });
+      return true;
+    });
+    return child;
+  }
+
+  return {
+    spawn: vi.fn(() => {
+      const child = createMockChild();
+      (globalThis as any).__lastPiMockChild = child;
+      return child;
+    }),
+  };
+});
+
+function settle(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+async function startSession(
+  opts: Partial<Parameters<typeof initPiSession>[0]> = {},
+): Promise<PiSession> {
+  const session = await initPiSession({
+    command: "pi",
+    args: [],
+    cwd: "/tmp",
+    handshakeTimeoutMs: 1000,
+    abortGraceMs: 20,
+    ...opts,
+  });
+  lastChild = (globalThis as any).__lastPiMockChild as MockChild;
+  return session;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("initPiSession", () => {
+  it("spawns pi in RPC mode, detached, and handshakes via get_state", async () => {
+    const spawnFn = spawn as unknown as ReturnType<typeof vi.fn>;
+    await startSession({ args: ["--thinking", "high"], modelId: "gpt-5" });
+
+    expect(spawnFn).toHaveBeenCalledWith(
+      "pi",
+      [
+        "--mode",
+        "rpc",
+        "--no-session",
+        "--model",
+        "gpt-5",
+        "--thinking",
+        "high",
+      ],
+      expect.objectContaining({ detached: true, cwd: "/tmp" }),
+    );
+    expect(lastChild.sent[0]).toMatchObject({ type: "get_state" });
+  });
+
+  it("rejects when the process dies before the handshake completes", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    (globalThis as any).__piAutoRespond = false;
+    try {
+      const pending = initPiSession({ command: "pi", args: [], cwd: "/tmp" });
+      const child = (globalThis as any).__lastPiMockChild as MockChild;
+      child.stderr?.push("boom: command exploded\n");
+      await settle();
+      child.emit("close", 1, null);
+
+      await expect(pending).rejects.toThrow(/pi exited unexpectedly: code=1/);
+      await expect(pending).rejects.toThrow(/boom: command exploded/);
+    } finally {
+      (globalThis as any).__piAutoRespond = true;
+      killSpy.mockRestore();
+    }
+  });
+
+  it("times out a wedged handshake and reaps the orphan process", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    (globalThis as any).__piAutoRespond = false;
+    try {
+      const pending = initPiSession({
+        command: "pi",
+        args: [],
+        cwd: "/tmp",
+        handshakeTimeoutMs: 30,
+      });
+
+      await expect(pending).rejects.toThrow("pi RPC handshake timed out");
+      const child = (globalThis as any).__lastPiMockChild as MockChild;
+      expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    } finally {
+      (globalThis as any).__piAutoRespond = true;
+      killSpy.mockRestore();
+    }
+  });
+
+  it("caps the retained stderr buffer on the long-lived process", async () => {
+    const session = await startSession();
+    lastChild.stderr?.push("x".repeat(100 * 1024));
+    await settle();
+
+    expect(session.stderrBuffer.length).toBeLessThanOrEqual(64 * 1024);
+  });
+});
+
+describe("sendPiPrompt", () => {
+  it("accumulates streamed text deltas until agent_end", async () => {
+    const session = await startSession();
+    const pending = sendPiPrompt(session, "do the thing", 5000);
+    await settle();
+
+    expect(session.process).toBe(lastChild);
+    expect(lastChild.sent.at(-1)).toMatchObject({
+      type: "prompt",
+      message: "do the thing",
+    });
+    lastChild.pushLine({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "Hello " },
+    });
+    lastChild.pushLine({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "world" },
+    });
+    lastChild.pushLine({ type: "agent_end", messages: [] });
+
+    const result = await pending;
+    expect(result).toEqual({ output: "Hello world", timedOut: false });
+  });
+
+  it("falls back to the agent_end assistant message when nothing streamed", async () => {
+    const session = await startSession();
+    const pending = sendPiPrompt(session, "quiet run", 5000);
+    await settle();
+    lastChild.pushLine({
+      type: "agent_end",
+      messages: [
+        { role: "user", content: "quiet run" },
+        {
+          role: "assistant",
+          stopReason: "stop",
+          content: [
+            { type: "thinking", thinking: "hmm" },
+            { type: "text", text: "DONE" },
+          ],
+        },
+        { role: "toolResult", content: [{ type: "text", text: "noise" }] },
+      ],
+    });
+
+    const result = await pending;
+    expect(result.output).toBe("DONE");
+    expect(result.error).toBeUndefined();
+  });
+
+  it("surfaces streaming error events as failures", async () => {
+    const session = await startSession();
+    const pending = sendPiPrompt(session, "fail please", 5000);
+    await settle();
+    lastChild.pushLine({
+      type: "message_update",
+      assistantMessageEvent: { type: "error", reason: "quota exceeded" },
+    });
+    lastChild.pushLine({ type: "agent_end", messages: [] });
+
+    const result = await pending;
+    expect(result.error).toBe("quota exceeded");
+  });
+
+  it("treats an error stopReason on the final assistant message as failure", async () => {
+    const session = await startSession();
+    const pending = sendPiPrompt(session, "hi", 5000);
+    await settle();
+    lastChild.pushLine({
+      type: "agent_end",
+      messages: [
+        {
+          role: "assistant",
+          stopReason: "error",
+          errorMessage: "overloaded",
+          content: [{ type: "text", text: "partial" }],
+        },
+      ],
+    });
+
+    const result = await pending;
+    expect(result.output).toBe("partial");
+    expect(result.error).toBe("overloaded");
+  });
+
+  it("aborts the turn and returns partial output on timeout", async () => {
+    const session = await startSession();
+    const pending = sendPiPrompt(session, "slow", 30);
+    await settle();
+    lastChild.pushLine({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "partial..." },
+    });
+
+    const result = await pending;
+    expect(result.timedOut).toBe(true);
+    expect(result.output).toBe("partial...");
+    await settle();
+    expect(lastChild.sent.at(-1)).toMatchObject({ type: "abort" });
+  });
+
+  it("returns the RPC error when pi rejects the prompt", async () => {
+    const session = await startSession();
+    lastChild.failCommands.add("prompt");
+
+    const result = await sendPiPrompt(session, "nope", 5000);
+    expect(result).toEqual({
+      output: "",
+      timedOut: false,
+      error: "prompt refused",
+    });
+  });
+
+  it("reports a crash mid-prompt with stderr detail", async () => {
+    const session = await startSession();
+    const pending = sendPiPrompt(session, "boom", 5000);
+    await settle();
+    lastChild.stderr?.push("segfault details\n");
+    await settle();
+    lastChild.emit("close", 137, "SIGKILL");
+
+    const result = await pending;
+    expect(result.error).toContain("pi exited unexpectedly: code=137");
+    expect(result.error).toContain("segfault details");
+  });
+});
+
+describe("resetPiSession", () => {
+  it("starts a new conversation and clears session buffers", async () => {
+    const session = await startSession();
+    session.textBuffer = "stale";
+    session.lastError = "stale error";
+
+    await resetPiSession(session);
+
+    expect(lastChild.sent.at(-1)).toMatchObject({ type: "new_session" });
+    expect(session.textBuffer).toBe("");
+    expect(session.lastError).toBe("");
+  });
+
+  it("throws when pi refuses the new session", async () => {
+    const session = await startSession();
+    lastChild.failCommands.add("new_session");
+
+    await expect(resetPiSession(session)).rejects.toThrow(
+      "new_session refused",
+    );
+  });
+
+  it("throws when the process is no longer running", async () => {
+    const session = await startSession();
+    session.process.kill("SIGTERM");
+    await settle();
+
+    await expect(resetPiSession(session)).rejects.toThrow(
+      "pi process is not running",
+    );
+  });
+
+  it("times out when pi never answers the reset", async () => {
+    const session = await startSession({ handshakeTimeoutMs: 30 });
+    lastChild.autoRespond = false;
+
+    await expect(resetPiSession(session)).rejects.toThrow(
+      "pi new_session timed out",
+    );
+  });
+});
+
+describe("terminatePiSession", () => {
+  let killSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    killSpy.mockRestore();
+  });
+
+  it("aborts the turn and SIGTERMs the process group", async () => {
+    const session = await startSession();
+
+    await terminatePiSession(session);
+
+    expect(killSpy).toHaveBeenCalledWith(-23456, "SIGTERM");
+    expect(session.process.kill).toHaveBeenCalledWith("SIGTERM");
+    const aborts = lastChild.sent.filter((cmd) => cmd.type === "abort");
+    expect(aborts).toHaveLength(1);
+  });
+
+  it("is a no-op for an already-dead process", async () => {
+    const session = await startSession();
+    session.process.kill("SIGTERM");
+    await settle();
+    (session.process.kill as ReturnType<typeof vi.fn>).mockClear();
+
+    await terminatePiSession(session);
+
+    expect(session.process.kill).not.toHaveBeenCalled();
+  });
+});
+
+describe("RPC framing", () => {
+  it("handles chunk-split lines, CRLF, and malformed JSON", async () => {
+    const session = await startSession();
+    const pending = sendPiPrompt(session, "framing", 5000);
+    await settle();
+
+    const stdout = lastChild.stdout as any;
+    stdout.push('{"type":"message_update","assistantMessageEvent"');
+    stdout.push(':{"type":"text_delta","delta":"split"}}\r\n');
+    stdout.push("not json at all\n");
+    stdout.push('{"type":"agent_end","messages":[]}\n');
+
+    const result = await pending;
+    expect(result.output).toBe("split");
+  });
+});
+
+describe("steerPiTurn", () => {
+  it("queues a steer command for the in-flight turn", async () => {
+    const session = await startSession();
+
+    steerPiTurn(session, "focus on the failing test");
+    await settle();
+
+    expect(lastChild.sent.at(-1)).toMatchObject({
+      type: "steer",
+      message: "focus on the failing test",
+    });
+  });
+
+  it("never throws even when stdin is gone", async () => {
+    const session = await startSession();
+    session.process.stdin?.destroy();
+    await settle();
+
+    expect(() => steerPiTurn(session, "anything")).not.toThrow();
+  });
+});
+
+describe("getPiSessionStats", () => {
+  it("parses token and cost totals from get_session_stats", async () => {
+    const session = await startSession();
+    lastChild.responseData.get_session_stats = {
+      tokens: {
+        input: 100,
+        output: 40,
+        cacheRead: 5,
+        cacheWrite: 7,
+        total: 152,
+      },
+      cost: 0.42,
+      contextUsage: { percent: 31 },
+    };
+
+    await expect(getPiSessionStats(session)).resolves.toEqual({
+      inputTokens: 100,
+      outputTokens: 40,
+      cacheReadTokens: 5,
+      cacheWriteTokens: 7,
+      totalTokens: 152,
+      costUsd: 0.42,
+      contextPercent: 31,
+    });
+  });
+
+  it("returns undefined when pi refuses or returns no token data", async () => {
+    const session = await startSession();
+    lastChild.failCommands.add("get_session_stats");
+    await expect(getPiSessionStats(session)).resolves.toBeUndefined();
+
+    lastChild.failCommands.delete("get_session_stats");
+    await expect(getPiSessionStats(session)).resolves.toBeUndefined();
+  });
+});
+
+describe("stream logging", () => {
+  it("persists the raw RPC traffic of a prompt to the stream log path", async () => {
+    const session = await startSession();
+    const logPath = join(tmpdir(), `pi-stream-test-${process.pid}.jsonl`);
+
+    const pending = runPiIteration(session, "log me", 5000, logPath);
+    await settle();
+    lastChild.pushLine({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "OK" },
+    });
+    lastChild.pushLine({ type: "agent_end", messages: [] });
+    await pending;
+
+    const logged = readFileSync(logPath, "utf-8");
+    expect(logged).toContain('"type":"agent_end"');
+    expect(logged).toContain('"delta":"OK"');
+  });
+});
+
+describe("runPiIteration", () => {
+  it("maps prompt results into the uniform backend result shape", async () => {
+    const session = await startSession();
+    const pending = runPiIteration(session, "iterate", 5000);
+    await settle();
+    lastChild.pushLine({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "OK" },
+    });
+    lastChild.pushLine({ type: "agent_end", messages: [] });
+
+    await expect(pending).resolves.toEqual({
+      output: "OK",
+      exitCode: 0,
+      timedOut: false,
+      providerKind: "pi",
+      errorCategory: "none",
+    });
+  });
+
+  it("maps failures and timeouts to error categories", async () => {
+    const session = await startSession();
+    lastChild.failCommands.add("prompt");
+    await expect(runPiIteration(session, "x", 5000)).resolves.toMatchObject({
+      exitCode: 1,
+      errorCategory: "non_zero_exit",
+    });
+
+    lastChild.failCommands.delete("prompt");
+    await expect(runPiIteration(session, "y", 20)).resolves.toMatchObject({
+      exitCode: 0,
+      timedOut: true,
+      errorCategory: "timeout",
+    });
+  });
+
+  it("keeps the error detail in the journaled output on failure", async () => {
+    const session = await startSession();
+    const pending = runPiIteration(session, "fail", 5000);
+    await settle();
+    lastChild.pushLine({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "partial work" },
+    });
+    lastChild.pushLine({
+      type: "message_update",
+      assistantMessageEvent: { type: "error", reason: "quota exceeded" },
+    });
+    lastChild.pushLine({ type: "agent_end", messages: [] });
+
+    const result = await pending;
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toBe("partial work\n\npi error: quota exceeded");
+  });
+});
+
+describe("abortPiTurn", () => {
+  it("never throws even when stdin is gone", async () => {
+    const session = await startSession();
+    session.process.stdin?.destroy();
+    await settle();
+
+    expect(() => abortPiTurn(session)).not.toThrow();
+  });
+});
+
+describe("formatPiStreamingEvent", () => {
+  it("formats deltas and tool lifecycle, silences the rest", () => {
+    expect(
+      formatPiStreamingEvent({
+        type: "message_update",
+        assistantMessageEvent: { type: "text_delta", delta: "hi" },
+      }),
+    ).toBe("hi");
+    expect(
+      formatPiStreamingEvent({
+        type: "message_update",
+        assistantMessageEvent: { type: "thinking_delta" },
+      }),
+    ).toBeNull();
+    expect(
+      formatPiStreamingEvent({
+        type: "tool_execution_start",
+        toolName: "bash",
+      }),
+    ).toBe("[tool:bash]\n");
+    expect(
+      formatPiStreamingEvent({ type: "tool_execution_end", toolName: "bash" }),
+    ).toBe("[tool:✓] bash\n");
+    expect(
+      formatPiStreamingEvent({
+        type: "tool_execution_end",
+        toolName: "bash",
+        isError: true,
+      }),
+    ).toBe("[tool:✗] bash\n");
+    expect(formatPiStreamingEvent({ type: "queue_update" })).toBeNull();
+  });
+
+  it("streams verbose output to stderr when enabled", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    try {
+      const session = await startSession({ verbose: true });
+      const pending = sendPiPrompt(session, "verbose", 5000);
+      await settle();
+      lastChild.pushLine({
+        type: "message_update",
+        assistantMessageEvent: { type: "text_delta", delta: "loud" },
+      });
+      lastChild.pushLine({ type: "agent_end", messages: [] });
+      await pending;
+
+      expect(stderrSpy).toHaveBeenCalledWith("loud");
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+});

--- a/packages/harness/src/config-helpers.ts
+++ b/packages/harness/src/config-helpers.ts
@@ -570,6 +570,7 @@ export function reloadLoop(loop: LoopContext): LoopContext {
     agentMap: loadAgentMap(pd),
     // Alias, never copy: all reloaded contexts must share one session holder.
     acpSession: loop.acpSession ?? { current: undefined },
+    piSession: loop.piSession ?? { current: undefined },
     onEvent: loop.onEvent,
   };
   return applyRuntimeModeOverrides(updated);

--- a/packages/harness/src/control/pi-adapter.ts
+++ b/packages/harness/src/control/pi-adapter.ts
@@ -7,13 +7,24 @@ import type {
   GuidePayload,
 } from "./types.js";
 
+export interface PiAdapterHooks {
+  /** Called when the supervisor asks the backend to cancel its in-flight turn. */
+  triggerInterrupt: () => void;
+  /** Called to queue guidance into the in-flight turn via pi's `steer` command. */
+  triggerSteer: (message: string) => void;
+}
+
 /**
- * Live-control adapter for the Pi backend. Pi has no in-flight cancel; we keep
- * it in the abstraction by reporting limited capabilities honestly. Guidance
- * is still durable via the journal, so `guide` is always applied even when
- * its interrupt component is ignored.
+ * Live-control adapter for the pi backend. Pi runs as a persistent RPC
+ * session (`pi --mode rpc`): `abort` cancels the in-flight turn, and `steer`
+ * queues guidance into it mid-turn — delivered before the next LLM call.
+ * Guidance also stays durable via the journal, so `guide` is always applied
+ * even when live steering is unavailable.
  */
-export function piControlAdapter(runId: string): LiveControlAdapter {
+export function piControlAdapter(
+  runId: string,
+  hooks: PiAdapterHooks,
+): LiveControlAdapter {
   const caps = buildCapabilities(runId);
 
   return {
@@ -23,20 +34,14 @@ export function piControlAdapter(runId: string): LiveControlAdapter {
     },
     onRequest(request: ControlRequest): ControlAck {
       if (request.verb === "interrupt") {
-        return {
-          state: "ignored",
-          detail: "pi backend has no in-flight cancel",
-        };
+        return applyInterrupt(hooks);
       }
       if (request.verb === "guide") {
         const payload = request.payload as GuidePayload;
         if (payload?.interrupt) {
-          return {
-            state: "applied",
-            detail: "guidance appended; interrupt ignored (pi)",
-          };
+          return applyInterrupt(hooks, "guidance-driven");
         }
-        return { state: "applied", detail: "guidance appended" };
+        return applySteer(hooks, payload?.message ?? "");
       }
       return { state: "ignored", detail: `unknown verb: ${request.verb}` };
     },
@@ -44,5 +49,50 @@ export function piControlAdapter(runId: string): LiveControlAdapter {
 }
 
 function buildCapabilities(runId: string): ControlCapabilities {
-  return defaultCapabilities("pi", runId);
+  const base = defaultCapabilities("pi", runId);
+  base.interrupt = {
+    supported: true,
+    detail: "pi RPC abort of the in-flight turn",
+  };
+  base.guidance = {
+    supported: true,
+    detail: "journal-durable + live steer into the in-flight turn",
+  };
+  return base;
+}
+
+function applySteer(hooks: PiAdapterHooks, message: string): ControlAck {
+  if (!message) {
+    return { state: "applied", detail: "guidance appended" };
+  }
+  try {
+    hooks.triggerSteer(message);
+    return {
+      state: "applied",
+      detail: "guidance appended + steered into live turn",
+    };
+  } catch {
+    // Steering is opportunistic; the journal copy still reaches the next
+    // iteration prompt, so the guidance itself is applied either way.
+    return {
+      state: "applied",
+      detail: "guidance appended (live steer unavailable)",
+    };
+  }
+}
+
+function applyInterrupt(
+  hooks: PiAdapterHooks,
+  detailPrefix = "interrupt",
+): ControlAck {
+  try {
+    hooks.triggerInterrupt();
+    return { state: "applied", detail: `${detailPrefix}: pi abort sent` };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      state: "rejected",
+      detail: `${detailPrefix}: abort failed: ${msg}`,
+    };
+  }
 }

--- a/packages/harness/src/emit.ts
+++ b/packages/harness/src/emit.ts
@@ -50,6 +50,7 @@ const CORE_SYSTEM_TOPICS = new Set([
   "review.finish",
   "backend.start",
   "backend.finish",
+  "backend.usage",
   "event.invalid",
 ]);
 

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -2,6 +2,11 @@ import { existsSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AcpSession } from "@mobrienv/autoloop-backends/acp-client";
 import { terminateAcpSession } from "@mobrienv/autoloop-backends/acp-client";
+import {
+  abortPiTurn,
+  steerPiTurn,
+  terminatePiSession,
+} from "@mobrienv/autoloop-backends/pi-rpc-client";
 import * as config from "@mobrienv/autoloop-core/config";
 import { readIfExists } from "@mobrienv/autoloop-core/journal";
 import {
@@ -76,12 +81,19 @@ export async function run(
   const teardown = () => {
     if (aborted) return;
     aborted = true;
-    // Fire-and-forget ACP termination — abort handlers must stay sync.
+    // Fire-and-forget session termination — abort handlers must stay sync.
     // The finally block below awaits a final terminate as backstop.
     if (loop.acpSession.current) {
       const session = loop.acpSession.current;
       loop.acpSession.current = undefined;
       terminateAcpSession(session).catch(() => {
+        /* best-effort */
+      });
+    }
+    if (loop.piSession.current) {
+      const session = loop.piSession.current;
+      loop.piSession.current = undefined;
+      terminatePiSession(session).catch(() => {
         /* best-effort */
       });
     }
@@ -163,6 +175,14 @@ export async function run(
         /* best-effort */
       }
       loop.acpSession.current = undefined;
+    }
+    if (loop.piSession.current) {
+      try {
+        await terminatePiSession(loop.piSession.current);
+      } catch {
+        /* best-effort */
+      }
+      loop.piSession.current = undefined;
     }
     runOptions.signal?.removeEventListener("abort", onAbort);
   }
@@ -301,6 +321,14 @@ export async function runParallelBranchCli(
       }
       seeded.acpSession.current = undefined;
     }
+    if (seeded.piSession.current) {
+      try {
+        await terminatePiSession(seeded.piSession.current);
+      } catch {
+        /* best-effort */
+      }
+      seeded.piSession.current = undefined;
+    }
   }
   const finishedMs = Date.now();
   const elapsedMs = finishedMs - startMs;
@@ -407,7 +435,18 @@ function buildControlAdapter(
     });
   }
   if (loop.backend.kind === "pi") {
-    return piControlAdapter(loop.runtime.runId);
+    return piControlAdapter(loop.runtime.runId, {
+      triggerInterrupt: () => {
+        if (loop.piSession.current) {
+          abortPiTurn(loop.piSession.current);
+        }
+      },
+      triggerSteer: (message) => {
+        if (loop.piSession.current) {
+          steerPiTurn(loop.piSession.current, message);
+        }
+      },
+    });
   }
   return undefined;
 }

--- a/packages/harness/src/iteration.ts
+++ b/packages/harness/src/iteration.ts
@@ -1,11 +1,19 @@
-import { runAcpIteration } from "@mobrienv/autoloop-backends";
+import { join } from "node:path";
+import { runAcpIteration, runPiIteration } from "@mobrienv/autoloop-backends";
 import type { AcpClientOptions } from "@mobrienv/autoloop-backends/acp-client";
 import {
   initAcpSession,
   terminateAcpSession,
 } from "@mobrienv/autoloop-backends/acp-client";
-import { listText } from "@mobrienv/autoloop-core";
 import {
+  getPiSessionStats,
+  initPiSession,
+  resetPiSession,
+  terminatePiSession,
+} from "@mobrienv/autoloop-backends/pi-rpc-client";
+import { jsonFieldRaw, listText } from "@mobrienv/autoloop-core";
+import {
+  appendEvent,
   extractField,
   extractIteration,
   extractTopic,
@@ -88,18 +96,13 @@ export async function runIteration(
     );
   }
 
-  const { output, exitCode, timedOut } =
-    iter.backend.kind === "acp" && loop.acpSession.current
-      ? await runAcpIteration(
-          loop.acpSession.current,
-          iter.prompt,
-          iter.backend.timeoutMs,
-        )
-      : runProcess(
-          buildBackendCommand(loop, iter),
-          iter.backend.timeoutMs,
-          iter.backend.kind,
-        );
+  // Pi reuses one live RPC process across iterations; each iteration starts a
+  // fresh conversation (`new_session`) so roles get a clean context window.
+  if (iter.backend.kind === "pi") {
+    await ensurePiSession(loop, iter, iteration);
+  }
+
+  const { output, exitCode, timedOut } = await runBackendIteration(loop, iter);
   const elapsedS = Math.floor(Date.now() / 1000) - startEpoch;
 
   appendBackendFinish(loop, iter, output, exitCode, timedOut);
@@ -116,6 +119,107 @@ export async function runIteration(
   if (timedOut) return stopBackendTimeout(loop, iteration, output);
   if (exitCode !== 0) return stopBackendFailed(loop, iteration, output);
   return finishIteration(loop, iter, output, iterate);
+}
+
+async function runBackendIteration(
+  loop: LoopContext,
+  iter: IterationContext,
+): Promise<{ output: string; exitCode: number; timedOut: boolean }> {
+  if (iter.backend.kind === "acp" && loop.acpSession.current) {
+    return runAcpIteration(
+      loop.acpSession.current,
+      iter.prompt,
+      iter.backend.timeoutMs,
+    );
+  }
+  if (iter.backend.kind === "pi" && loop.piSession.current) {
+    const result = await runPiIteration(
+      loop.piSession.current,
+      iter.prompt,
+      iter.backend.timeoutMs,
+      join(loop.paths.stateDir, `pi-stream.${iter.iteration}.jsonl`),
+    );
+    await recordPiUsage(loop, iter);
+    return result;
+  }
+  return runProcess(
+    buildBackendCommand(loop, iter),
+    iter.backend.timeoutMs,
+    iter.backend.kind,
+  );
+}
+
+/**
+ * Journal per-iteration token/cost totals from pi's get_session_stats.
+ * Best-effort: telemetry never fails or stalls the iteration.
+ */
+async function recordPiUsage(
+  loop: LoopContext,
+  iter: IterationContext,
+): Promise<void> {
+  const session = loop.piSession.current;
+  if (!session) return;
+  const stats = await getPiSessionStats(session);
+  if (!stats) return;
+  appendEvent(
+    loop.paths.journalFile,
+    loop.runtime.runId,
+    String(iter.iteration),
+    "backend.usage",
+    jsonFieldRaw("input_tokens", String(stats.inputTokens)) +
+      ", " +
+      jsonFieldRaw("output_tokens", String(stats.outputTokens)) +
+      ", " +
+      jsonFieldRaw("cache_read_tokens", String(stats.cacheReadTokens)) +
+      ", " +
+      jsonFieldRaw("cache_write_tokens", String(stats.cacheWriteTokens)) +
+      ", " +
+      jsonFieldRaw("total_tokens", String(stats.totalTokens)) +
+      ", " +
+      jsonFieldRaw("cost_usd", String(stats.costUsd)) +
+      (stats.contextPercent === undefined
+        ? ""
+        : `, ${jsonFieldRaw("context_percent", String(stats.contextPercent))}`),
+  );
+}
+
+/**
+ * Make sure a live pi RPC session with a fresh conversation is available.
+ * Prefers a `new_session` reset on the running process; respawns when the
+ * process is gone or refuses the reset.
+ */
+async function ensurePiSession(
+  loop: LoopContext,
+  iter: IterationContext,
+  iteration: number,
+): Promise<void> {
+  const existing = loop.piSession.current;
+  if (existing) {
+    try {
+      await resetPiSession(existing);
+      log(loop, "debug", `pi session reset for iteration ${iteration}`);
+      return;
+    } catch {
+      loop.piSession.current = undefined;
+      try {
+        await terminatePiSession(existing);
+      } catch {
+        /* best-effort */
+      }
+    }
+  }
+  loop.piSession.current = await initPiSession({
+    command: iter.backend.command,
+    args: iter.backend.args,
+    cwd: loop.paths.workDir,
+    modelId: iter.backend.model || undefined,
+    verbose: loop.runtime.logLevel === "debug",
+  });
+  log(
+    loop,
+    "debug",
+    `new pi RPC session for iteration ${iteration} model="${iter.backend.model || "default"}"`,
+  );
 }
 
 export async function finishIteration(

--- a/packages/harness/src/metareview.ts
+++ b/packages/harness/src/metareview.ts
@@ -1,10 +1,14 @@
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { runAcpIteration } from "@mobrienv/autoloop-backends";
+import { runAcpIteration, runPiIteration } from "@mobrienv/autoloop-backends";
 import {
   initAcpSession,
   terminateAcpSession,
 } from "@mobrienv/autoloop-backends/acp-client";
+import {
+  initPiSession,
+  terminatePiSession,
+} from "@mobrienv/autoloop-backends/pi-rpc-client";
 import { jsonBool, jsonField, jsonFieldRaw } from "@mobrienv/autoloop-core";
 import { appendEvent, readRunLines } from "@mobrienv/autoloop-core/journal";
 import { reloadLoop } from "./config-helpers.js";
@@ -101,11 +105,13 @@ export async function runMetareviewReview(
   const { output, exitCode, timedOut } =
     loop.review.kind === "acp"
       ? await runAcpReview(loop, reviewPrompt)
-      : runProcess(
-          buildReviewCommand(loop, iteration, reviewPrompt),
-          loop.review.timeoutMs,
-          loop.review.kind,
-        );
+      : loop.review.kind === "pi"
+        ? await runPiReview(loop, reviewPrompt, iteration)
+        : runProcess(
+            buildReviewCommand(loop, iteration, reviewPrompt),
+            loop.review.timeoutMs,
+            loop.review.kind,
+          );
 
   appendEvent(
     loop.paths.journalFile,
@@ -176,6 +182,38 @@ export async function runMetareviewReview(
 // Reviews get their own ACP session built from the review spec — the live
 // iteration session may belong to a different provider/agent/model and
 // carries the iteration's conversation context.
+/**
+ * Run a pi metareview in a dedicated RPC session — never the live iteration
+ * session — so the reviewer judges with a clean context window.
+ */
+async function runPiReview(
+  loop: LoopContext,
+  reviewPrompt: string,
+  iteration: number,
+): Promise<{ output: string; exitCode: number; timedOut: boolean }> {
+  const session = await initPiSession({
+    command: loop.review.command,
+    args: loop.review.args,
+    cwd: loop.paths.workDir,
+    modelId: loop.review.model || undefined,
+    verbose: loop.runtime.logLevel === "debug",
+  });
+  try {
+    return await runPiIteration(
+      session,
+      reviewPrompt,
+      loop.review.timeoutMs,
+      join(loop.paths.stateDir, `pi-review.${iteration}.jsonl`),
+    );
+  } finally {
+    try {
+      await terminatePiSession(session);
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
 async function runAcpReview(
   loop: LoopContext,
   reviewPrompt: string,

--- a/packages/harness/src/types.ts
+++ b/packages/harness/src/types.ts
@@ -1,4 +1,5 @@
 import type { AcpSession } from "@mobrienv/autoloop-backends/acp-client";
+import type { PiSession } from "@mobrienv/autoloop-backends/pi-rpc-client";
 import type { AgentMap } from "@mobrienv/autoloop-core/agent-map";
 import type * as topo from "@mobrienv/autoloop-core/topology";
 import type { LiveControlAdapter } from "./control/adapter.js";
@@ -103,6 +104,12 @@ export interface LoopContext {
    * even though iterations run on reloaded context clones.
    */
   acpSession: { current: AcpSession | undefined };
+  /**
+   * Live pi RPC session holder. Same aliasing rules as acpSession: the
+   * process persists across iterations (context resets via `new_session`),
+   * so reloads must share one holder.
+   */
+  piSession: { current: PiSession | undefined };
   lastVerdict?: Verdict;
   /** Optional structured-event emitter, forwarded from RunOptions.onEvent. */
   onEvent?: LoopEventEmitter;

--- a/packages/harness/test/control/adapters.test.ts
+++ b/packages/harness/test/control/adapters.test.ts
@@ -78,30 +78,102 @@ describe("acpControlAdapter", () => {
 });
 
 describe("piControlAdapter", () => {
-  it("reports interrupt as unsupported", () => {
-    const adapter = piControlAdapter("run-1");
+  function makeHooks() {
+    return { triggerInterrupt: vi.fn(), triggerSteer: vi.fn() };
+  }
+
+  it("reports interrupt and live-steer guidance as supported", () => {
+    const adapter = piControlAdapter("run-1", makeHooks());
     const caps = adapter.capabilities();
     expect(caps.backend).toBe("pi");
-    expect(caps.interrupt.supported).toBe(false);
+    expect(caps.interrupt.supported).toBe(true);
+    expect(caps.interrupt.detail).toContain("pi RPC abort");
     expect(caps.guidance.supported).toBe(true);
+    expect(caps.guidance.detail).toContain("live steer");
     expect(caps.inspect.supported).toBe(true);
   });
 
-  it("ignores interrupt requests", () => {
-    const adapter = piControlAdapter("run-1");
+  it("invokes triggerInterrupt on interrupt verb", () => {
+    const hooks = makeHooks();
+    const adapter = piControlAdapter("run-1", hooks);
     const ack = adapter.onRequest(buildRequest("run-1", "interrupt", {}));
-    expect(ack.state).toBe("ignored");
+    expect(hooks.triggerInterrupt).toHaveBeenCalledTimes(1);
+    expect(ack.state).toBe("applied");
+    expect(ack.detail).toContain("pi abort sent");
   });
 
-  it("applies guide with durable-guidance ack even when interrupt requested", () => {
-    const adapter = piControlAdapter("run-1");
+  it("invokes interrupt when guide payload requests it", () => {
+    const hooks = makeHooks();
+    const adapter = piControlAdapter("run-1", hooks);
     const ack = adapter.onRequest(
       buildRequest("run-1", "guide", {
-        message: "hello",
+        message: "pivot",
         interrupt: true,
       }),
     );
+    expect(hooks.triggerInterrupt).toHaveBeenCalledTimes(1);
+    expect(hooks.triggerSteer).not.toHaveBeenCalled();
     expect(ack.state).toBe("applied");
-    expect(ack.detail).toContain("interrupt ignored");
+    expect(ack.detail).toContain("guidance-driven");
+  });
+
+  it("steers guidance into the live turn when interrupt is not requested", () => {
+    const hooks = makeHooks();
+    const adapter = piControlAdapter("run-1", hooks);
+    const ack = adapter.onRequest(
+      buildRequest("run-1", "guide", {
+        message: "focus on tests",
+        interrupt: false,
+      }),
+    );
+    expect(hooks.triggerInterrupt).not.toHaveBeenCalled();
+    expect(hooks.triggerSteer).toHaveBeenCalledWith("focus on tests");
+    expect(ack.state).toBe("applied");
+    expect(ack.detail).toContain("steered into live turn");
+  });
+
+  it("still applies guidance when live steering throws", () => {
+    const hooks = makeHooks();
+    hooks.triggerSteer.mockImplementation(() => {
+      throw new Error("session gone");
+    });
+    const adapter = piControlAdapter("run-1", hooks);
+    const ack = adapter.onRequest(
+      buildRequest("run-1", "guide", {
+        message: "still durable",
+        interrupt: false,
+      }),
+    );
+    expect(ack.state).toBe("applied");
+    expect(ack.detail).toContain("live steer unavailable");
+  });
+
+  it("applies guidance without steering when the message is empty", () => {
+    const hooks = makeHooks();
+    const adapter = piControlAdapter("run-1", hooks);
+    const ack = adapter.onRequest(
+      buildRequest("run-1", "guide", { message: "", interrupt: false }),
+    );
+    expect(hooks.triggerSteer).not.toHaveBeenCalled();
+    expect(ack.state).toBe("applied");
+  });
+
+  it("ignores unknown verbs", () => {
+    const adapter = piControlAdapter("run-1", makeHooks());
+    const ack = adapter.onRequest(
+      buildRequest("run-1", "inspect" as never, {}),
+    );
+    expect(ack.state).toBe("ignored");
+  });
+
+  it("reports rejected when the abort hook throws", () => {
+    const hooks = makeHooks();
+    hooks.triggerInterrupt.mockImplementation(() => {
+      throw new Error("rpc gone");
+    });
+    const adapter = piControlAdapter("run-1", hooks);
+    const ack = adapter.onRequest(buildRequest("run-1", "interrupt", {}));
+    expect(ack.state).toBe("rejected");
+    expect(ack.detail).toContain("rpc gone");
   });
 });

--- a/packages/harness/test/harness/iteration.test.ts
+++ b/packages/harness/test/harness/iteration.test.ts
@@ -1,9 +1,10 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AcpSession } from "@mobrienv/autoloop-backends/acp-client";
+import type { PiSession } from "@mobrienv/autoloop-backends/pi-rpc-client";
 import type { LoopContext } from "@mobrienv/autoloop-harness/types";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const acpMocks = vi.hoisted(() => ({
   initAcpSession: vi.fn(),
@@ -11,10 +12,22 @@ const acpMocks = vi.hoisted(() => ({
   runAcpIteration: vi.fn(),
 }));
 
+const piMocks = vi.hoisted(() => ({
+  initPiSession: vi.fn(),
+  resetPiSession: vi.fn(),
+  terminatePiSession: vi.fn(),
+  runPiIteration: vi.fn(),
+  getPiSessionStats: vi.fn(),
+}));
+
 vi.mock("@mobrienv/autoloop-backends", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("@mobrienv/autoloop-backends")>();
-  return { ...actual, runAcpIteration: acpMocks.runAcpIteration };
+  return {
+    ...actual,
+    runAcpIteration: acpMocks.runAcpIteration,
+    runPiIteration: piMocks.runPiIteration,
+  };
 });
 
 vi.mock("@mobrienv/autoloop-backends/acp-client", async (importOriginal) => {
@@ -26,6 +39,20 @@ vi.mock("@mobrienv/autoloop-backends/acp-client", async (importOriginal) => {
     ...actual,
     initAcpSession: acpMocks.initAcpSession,
     terminateAcpSession: acpMocks.terminateAcpSession,
+  };
+});
+
+vi.mock("@mobrienv/autoloop-backends/pi-rpc-client", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@mobrienv/autoloop-backends/pi-rpc-client")
+    >();
+  return {
+    ...actual,
+    initPiSession: piMocks.initPiSession,
+    resetPiSession: piMocks.resetPiSession,
+    terminatePiSession: piMocks.terminatePiSession,
+    getPiSessionStats: piMocks.getPiSessionStats,
   };
 });
 
@@ -135,7 +162,26 @@ function makeAcpLoop(): LoopContext {
     store: {},
     agentMap: null,
     acpSession: { current: undefined },
+    piSession: { current: undefined },
   };
+}
+
+function makePiLoop(): LoopContext {
+  const loop = makeAcpLoop();
+  loop.objective = "Use pi";
+  loop.runtime.runId = "run-pi";
+  loop.backend = {
+    kind: "pi",
+    provider: "",
+    command: "pi",
+    args: ["--thinking", "high"],
+    promptMode: "arg",
+    timeoutMs: 4321,
+    trustAllTools: true,
+    agent: "",
+    model: "gpt-5",
+  };
+  return loop;
 }
 
 describe("runIteration ACP provider execution", () => {
@@ -175,6 +221,129 @@ describe("runIteration ACP provider execution", () => {
       1234,
     );
     expect(summary.stopReason).toBe("completion_promise");
+  });
+});
+
+describe("runIteration pi RPC execution", () => {
+  beforeEach(() => {
+    piMocks.initPiSession.mockReset();
+    piMocks.resetPiSession.mockReset();
+    piMocks.terminatePiSession.mockReset();
+    piMocks.runPiIteration.mockReset();
+    piMocks.getPiSessionStats.mockReset();
+    piMocks.getPiSessionStats.mockResolvedValue(undefined);
+    piMocks.runPiIteration.mockResolvedValue({
+      output: "DONE",
+      exitCode: 0,
+      timedOut: false,
+    });
+  });
+
+  it("starts a pi RPC session from iter.backend and runs the pi runner", async () => {
+    const loop = makePiLoop();
+    const fakeSession = { process: { pid: 99 } } as unknown as PiSession;
+    piMocks.initPiSession.mockResolvedValue(fakeSession);
+
+    const summary = await runIteration(loop, 1, async () => ({
+      iterations: 1,
+      stopReason: "continued",
+      runId: loop.runtime.runId,
+    }));
+
+    expect(piMocks.initPiSession).toHaveBeenCalledWith({
+      command: "pi",
+      args: ["--thinking", "high"],
+      cwd: loop.paths.workDir,
+      modelId: "gpt-5",
+      verbose: false,
+    });
+    expect(piMocks.runPiIteration).toHaveBeenCalledWith(
+      fakeSession,
+      expect.stringContaining("Use pi"),
+      4321,
+      expect.stringContaining("pi-stream.1.jsonl"),
+    );
+    expect(loop.piSession.current).toBe(fakeSession);
+    expect(summary.stopReason).toBe("completion_promise");
+  });
+
+  it("journals a backend.usage event when pi reports session stats", async () => {
+    const loop = makePiLoop();
+    loop.piSession.current = { process: { pid: 99 } } as unknown as PiSession;
+    piMocks.resetPiSession.mockResolvedValue(undefined);
+    piMocks.getPiSessionStats.mockResolvedValue({
+      inputTokens: 100,
+      outputTokens: 40,
+      cacheReadTokens: 5,
+      cacheWriteTokens: 7,
+      totalTokens: 152,
+      costUsd: 0.42,
+      contextPercent: 31,
+    });
+
+    const summary = await runIteration(loop, 1, async () => ({
+      iterations: 1,
+      stopReason: "continued",
+      runId: loop.runtime.runId,
+    }));
+
+    const journal = readFileSync(loop.paths.journalFile, "utf-8");
+    expect(journal).toContain('"topic": "backend.usage"');
+    expect(journal).toContain('"total_tokens": 152');
+    expect(journal).toContain('"cost_usd": 0.42');
+    expect(journal).toContain('"context_percent": 31');
+    // backend.usage is a system topic — it must never be mistaken for the
+    // agent's emitted event, which would invalidate the iteration.
+    expect(journal).not.toContain('"topic": "event.invalid"');
+    expect(summary.stopReason).toBe("completion_promise");
+  });
+
+  it("reuses the live session via new_session instead of respawning", async () => {
+    const loop = makePiLoop();
+    const liveSession = { process: { pid: 99 } } as unknown as PiSession;
+    loop.piSession.current = liveSession;
+    piMocks.resetPiSession.mockResolvedValue(undefined);
+
+    await runIteration(loop, 1, async () => ({
+      iterations: 1,
+      stopReason: "continued",
+      runId: loop.runtime.runId,
+    }));
+
+    expect(piMocks.resetPiSession).toHaveBeenCalledWith(liveSession);
+    expect(piMocks.initPiSession).not.toHaveBeenCalled();
+    expect(piMocks.runPiIteration).toHaveBeenCalledWith(
+      liveSession,
+      expect.any(String),
+      4321,
+      expect.any(String),
+    );
+  });
+
+  it("terminates and respawns when the session reset fails", async () => {
+    const loop = makePiLoop();
+    const deadSession = { process: { pid: 99 } } as unknown as PiSession;
+    const freshSession = { process: { pid: 100 } } as unknown as PiSession;
+    loop.piSession.current = deadSession;
+    piMocks.resetPiSession.mockRejectedValue(new Error("process gone"));
+    piMocks.terminatePiSession.mockRejectedValue(new Error("already dead"));
+    piMocks.initPiSession.mockResolvedValue(freshSession);
+
+    await runIteration(loop, 1, async () => ({
+      iterations: 1,
+      stopReason: "continued",
+      runId: loop.runtime.runId,
+    }));
+
+    expect(piMocks.terminatePiSession).toHaveBeenCalledWith(deadSession);
+    expect(piMocks.initPiSession).toHaveBeenCalledTimes(1);
+    expect(loop.piSession.current).toBe(freshSession);
+    expect(piMocks.runPiIteration).toHaveBeenCalledWith(
+      freshSession,
+      expect.any(String),
+      4321,
+      expect.any(String),
+    );
   });
 });
 

--- a/packages/harness/test/harness/metareview.test.ts
+++ b/packages/harness/test/harness/metareview.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AcpSession } from "@mobrienv/autoloop-backends/acp-client";
+import type { PiSession } from "@mobrienv/autoloop-backends/pi-rpc-client";
 import {
   runMetareviewReview,
   shouldRunMetareview,
@@ -13,12 +14,31 @@ const backendMocks = vi.hoisted(() => ({
   runAcpIteration: vi.fn(),
   initAcpSession: vi.fn(),
   terminateAcpSession: vi.fn(),
+  runPiIteration: vi.fn(),
+  initPiSession: vi.fn(),
+  terminatePiSession: vi.fn(),
 }));
 
 vi.mock("@mobrienv/autoloop-backends", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("@mobrienv/autoloop-backends")>();
-  return { ...actual, runAcpIteration: backendMocks.runAcpIteration };
+  return {
+    ...actual,
+    runAcpIteration: backendMocks.runAcpIteration,
+    runPiIteration: backendMocks.runPiIteration,
+  };
+});
+
+vi.mock("@mobrienv/autoloop-backends/pi-rpc-client", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@mobrienv/autoloop-backends/pi-rpc-client")
+    >();
+  return {
+    ...actual,
+    initPiSession: backendMocks.initPiSession,
+    terminatePiSession: backendMocks.terminatePiSession,
+  };
 });
 
 vi.mock("@mobrienv/autoloop-backends/acp-client", async (importOriginal) => {
@@ -148,7 +168,27 @@ function makeAcpReviewLoop(): LoopContext {
         provider: { id: "claude-agent-acp" },
       } as unknown as AcpSession,
     },
+    piSession: { current: undefined },
   };
+}
+
+function makePiReviewLoop(): LoopContext {
+  const loop = makeAcpReviewLoop();
+  loop.runtime.runId = "run-review-pi";
+  loop.review = {
+    ...loop.review,
+    kind: "pi",
+    provider: "",
+    command: "pi",
+    args: ["--thinking", "high"],
+    promptMode: "arg",
+    model: "gpt-5",
+    agent: "",
+  };
+  loop.piSession = {
+    current: { process: { pid: 7 } } as unknown as PiSession,
+  };
+  return loop;
 }
 
 describe("shouldRunMetareview", () => {
@@ -281,5 +321,63 @@ describe("runMetareviewReview", () => {
     expect(backendMocks.terminateAcpSession).toHaveBeenCalledWith(
       reviewSession,
     );
+  });
+
+  function mockPiReviewRun(): PiSession {
+    const reviewSession = { process: { pid: 8 } } as unknown as PiSession;
+    backendMocks.initPiSession.mockReset();
+    backendMocks.terminatePiSession.mockReset();
+    backendMocks.runPiIteration.mockReset();
+    backendMocks.initPiSession.mockResolvedValue(reviewSession);
+    backendMocks.terminatePiSession.mockResolvedValue(undefined);
+    backendMocks.runPiIteration.mockResolvedValue({
+      output:
+        '```json\n{"verdict":"CONTINUE","confidence":0.8,"reasoning":"ok"}\n```',
+      exitCode: 0,
+      timedOut: false,
+    });
+    return reviewSession;
+  }
+
+  it("runs pi reviews in a dedicated RPC session built from the review spec", async () => {
+    const loop = makePiReviewLoop();
+    const reviewSession = mockPiReviewRun();
+
+    const verdict = await runMetareviewReview(loop, 2);
+
+    expect(backendMocks.initPiSession).toHaveBeenCalledWith({
+      command: "pi",
+      args: ["--thinking", "high"],
+      cwd: loop.paths.workDir,
+      modelId: "gpt-5",
+      verbose: false,
+    });
+    expect(backendMocks.runPiIteration).toHaveBeenCalledWith(
+      reviewSession,
+      expect.stringContaining("You are the metareview meta-reviewer"),
+      4321,
+      expect.stringContaining("pi-review.2.jsonl"),
+    );
+    expect(verdict.verdict).toBe("CONTINUE");
+  });
+
+  it("does not reuse the live pi iteration session for reviews", async () => {
+    const loop = makePiReviewLoop();
+    const reviewSession = mockPiReviewRun();
+
+    await runMetareviewReview(loop, 2);
+
+    const [usedSession] = backendMocks.runPiIteration.mock.calls[0];
+    expect(usedSession).toBe(reviewSession);
+    expect(usedSession).not.toBe(loop.piSession.current);
+  });
+
+  it("terminates the pi review session after the verdict, even on failure", async () => {
+    const loop = makePiReviewLoop();
+    const reviewSession = mockPiReviewRun();
+    backendMocks.runPiIteration.mockRejectedValue(new Error("boom"));
+
+    await expect(runMetareviewReview(loop, 2)).rejects.toThrow("boom");
+    expect(backendMocks.terminatePiSession).toHaveBeenCalledWith(reviewSession);
   });
 });

--- a/test/integration/backend-e2e.test.ts
+++ b/test/integration/backend-e2e.test.ts
@@ -32,9 +32,6 @@ beforeAll(() => {
  * and asserts the loop completes through the journal artifacts.
  */
 
-const hasPython3 =
-  spawnSync("python3", ["--version"], { encoding: "utf-8" }).status === 0;
-
 /**
  * The pi adapter re-invokes the CLI via its own executable path (selfCommand
  * uses argv[1]), so the pi test must go through the real bin entry point
@@ -97,53 +94,85 @@ function expectLoopCompleted(project: string): string {
 }
 
 describe("integration: pi backend end to end", () => {
-  // Fake pi binary: verifies the built-in pi flags arrive, reads the prompt
-  // on stdin, and answers with pi --mode json event lines.
+  // Fake pi binary: verifies the harness launches RPC mode, then speaks the
+  // pi --mode rpc JSONL protocol (responses for commands, streamed events).
   const FAKE_PI = `
 const args = process.argv.slice(2);
-for (const flag of ["-p", "--mode", "json", "--no-session"]) {
+for (const flag of ["--mode", "rpc", "--no-session"]) {
   if (!args.includes(flag)) {
     process.stderr.write("fake-pi: missing expected flag " + flag + "\\n");
     process.exit(9);
   }
 }
-let prompt = "";
+const out = (msg) => process.stdout.write(JSON.stringify(msg) + "\\n");
+let buffer = "";
 process.stdin.setEncoding("utf-8");
-process.stdin.on("data", (chunk) => { prompt += chunk; });
-process.stdin.on("end", () => {
-  if (!prompt.trim()) {
-    process.stderr.write("fake-pi: empty prompt on stdin\\n");
-    process.exit(8);
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  let idx = buffer.indexOf("\\n");
+  while (idx !== -1) {
+    const line = buffer.slice(0, idx);
+    buffer = buffer.slice(idx + 1);
+    idx = buffer.indexOf("\\n");
+    if (!line.trim()) continue;
+    const cmd = JSON.parse(line);
+    if (cmd.type === "prompt") {
+      if (!cmd.message || !cmd.message.trim()) {
+        process.stderr.write("fake-pi: empty prompt message\\n");
+        process.exit(8);
+      }
+      out({ type: "response", id: cmd.id, command: "prompt", success: true });
+      const text = "pi backend handled the iteration. LOOP_COMPLETE";
+      out({ type: "agent_start" });
+      out({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: text } });
+      out({
+        type: "agent_end",
+        messages: [{ role: "assistant", stopReason: "stop", content: [{ type: "text", text }] }],
+      });
+    } else if (cmd.type === "get_session_stats") {
+      out({
+        type: "response", id: cmd.id, command: cmd.type, success: true,
+        data: {
+          tokens: { input: 120, output: 45, cacheRead: 10, cacheWrite: 3, total: 178 },
+          cost: 0.07,
+          contextUsage: { percent: 12 },
+        },
+      });
+    } else {
+      out({ type: "response", id: cmd.id, command: cmd.type, success: true });
+    }
   }
-  const text = "pi backend handled the iteration. LOOP_COMPLETE";
-  const events = [
-    { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: text } },
-    { type: "turn_end", message: { content: [{ type: "text", text }] } },
-  ];
-  for (const event of events) process.stdout.write(JSON.stringify(event) + "\\n");
 });
 `;
 
-  it.skipIf(!hasPython3)(
-    "completes a loop through the pi adapter bridge",
-    () => {
-      const bin = mkdtempSync(join(tmpdir(), "autoloop-fake-pi-"));
-      const fakePiScript = writeExecutable(bin, "fake-pi.cjs", FAKE_PI);
-      const piPath = wrapNodeScript(bin, "pi", fakePiScript);
+  it("completes a loop through a live pi RPC session", () => {
+    const bin = mkdtempSync(join(tmpdir(), "autoloop-fake-pi-"));
+    const fakePiScript = writeExecutable(bin, "fake-pi.cjs", FAKE_PI);
+    const piPath = wrapNodeScript(bin, "pi", fakePiScript);
 
-      const project = makeBackendProject("pi", [
-        'backend.kind = "pi"',
-        `backend.command = ${JSON.stringify(piPath)}`,
-        "backend.timeout_ms = 30000",
-      ]);
-      const res = runBinCli(["run", project, "pi e2e"], project);
+    const project = makeBackendProject("pi", [
+      'backend.kind = "pi"',
+      `backend.command = ${JSON.stringify(piPath)}`,
+      "backend.timeout_ms = 30000",
+    ]);
+    const res = runBinCli(["run", project, "pi e2e"], project);
 
-      expect(res.status).toBe(0);
-      const journal = expectLoopCompleted(project);
-      expect(journal).toContain("pi backend handled the iteration.");
-    },
-    30_000,
-  );
+    expect(res.status).toBe(0);
+    const journal = expectLoopCompleted(project);
+    expect(journal).toContain("pi backend handled the iteration.");
+
+    // Usage telemetry journaled from pi's get_session_stats
+    expect(journal).toContain('"topic": "backend.usage"');
+    expect(journal).toContain('"total_tokens": 178');
+    expect(journal).toContain('"cost_usd": 0.07');
+
+    // Raw RPC stream persisted per iteration in the run-scoped state dir
+    const runId = journal.match(/"run": "([^"]+)"/)?.[1] ?? "";
+    const streamLog = readText(
+      join(project, ".autoloop/runs", runId, "pi-stream.1.jsonl"),
+    );
+    expect(streamLog).toContain('"type":"agent_end"');
+  }, 30_000);
 });
 
 describe("integration: claude command backend end to end", () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
       "@mobrienv/autoloop-dashboard": `${DASHBOARD}/app.ts`,
       "@mobrienv/autoloop-backends/acp-client": `${BACKENDS}/acp-client.ts`,
       "@mobrienv/autoloop-backends/acp-providers": `${BACKENDS}/acp-providers.ts`,
+      "@mobrienv/autoloop-backends/pi-rpc-client": `${BACKENDS}/pi-rpc-client.ts`,
       "@mobrienv/autoloop-backends/run-command": `${BACKENDS}/run-command.ts`,
       "@mobrienv/autoloop-backends/types": `${BACKENDS}/types.ts`,
       "@mobrienv/autoloop-backends": `${BACKENDS}/index.ts`,


### PR DESCRIPTION
## Summary

Replaces the pi backend's one-shot python bridge (`pi -p --mode json` scraped through an embedded script) with a native TypeScript client for **`pi --mode rpc`**, mirroring the ACP session architecture the harness already uses.

### Session lifecycle
- One long-lived pi process per loop; each iteration starts a fresh conversation via `new_session` so roles keep clean context windows without paying process startup. Respawns automatically on crash or refused reset.
- Metareview runs in a dedicated RPC session, never the live iteration session.
- The session holder (`loop.piSession`) is aliased across context reloads, same as `acpSession`, and terminated at every loop-exit path.

### Robustness
- Hard deadlines on the spawn handshake and session reset — a wedged pi binary fails the iteration (and reaps the orphan) instead of hanging the loop. Iteration prompts remain governed solely by `backend.timeout_ms`.
- Timed-out turns get a bounded drain grace after `abort` so the next reset lands on an idle agent.
- Failed iterations keep the error detail in the journaled output (`pi error: …`); the long-lived process's stderr buffer is capped at 64KB.

### New capabilities
- **Live control**: `interrupt` maps to pi's `abort` command (previously reported as unsupported); `guide` requests are additionally steered into the in-flight turn via pi's `steer` — delivered before the next LLM call, on top of the journal-durable copy.
- **Usage telemetry**: each iteration journals a `backend.usage` event (tokens, cost, context-window %) from `get_session_stats`. Registered as a core system topic so it can never be mistaken for the agent's emitted event (caught by the e2e during development).
- **Stream logs**: raw RPC traffic persists per iteration to `.autoloop/runs/<run_id>/pi-stream.<n>.jsonl` (`pi-review.<n>.jsonl` for metareviews), restoring bridge-era observability with full tool/thinking fidelity.

Parallel waves still use the `pi-adapter` shim since wave branches run as independent shell commands. Docs updated in `configuration.md` and `cli.md`.

## Test plan
- [x] `npm run check` green: biome + tsc + 1198 tests with coverage gates
- [x] New unit suite for the RPC client (29 tests: framing, timeouts, abort grace, crash detection, steer, stats, stream logs, process-tree teardown)
- [x] Harness tests for session reuse/respawn, dedicated review sessions, control adapter steer/abort, usage journaling
- [x] e2e: fake pi RPC server drives the real built CLI through a full loop; asserts completion, `backend.usage` event, and the on-disk stream log

🤖 Generated with [Claude Code](https://claude.com/claude-code)