### PR TITLE
feat: operability release — guards, doctor/stats, init, and agent-friendly surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [Unreleased]
+### Added
+- **Cost budget stop condition.** Set `event_loop.max_cost_usd` and the harness stops the run (reason `cost_budget`) once accumulated journaled cost from `backend.usage` events reaches the budget. Journal-derived, so it covers every continue path and survives context reloads. Disabled by default (`0`).
+- **Stall detection.** Set `event_loop.stall_iterations = N` and the harness stops the run (reason `stalled`) after N consecutive byte-identical backend outputs — a loop that repeats itself is burning the rest of its iteration budget. Disabled by default (`0`).
+- **`autoloop inspect usage`.** Per-iteration token counts and cost for a run, aggregated from `backend.usage` journal events (`--run`, `--json` supported). Backed by new `collectUsage`/`formatUsage` helpers in `@mobrienv/autoloop-core`.
+- **`autoloop stats`.** Cross-run analytics grouped by preset: run counts, success rate, average iterations and duration, and total journaled cost. `--json` for agents and scripts.
+- **`autoloop doctor`.** Environment and state-health diagnostics: node/git/backend availability, `.autoloop` writability, malformed registry lines, runs marked `running` whose process is gone, stale wave markers, and orphaned worktrees. Exit code 1 only on failures; `--json` supported.
+- **"Did you mean" suggestions.** Mistyped preset names and `inspect` targets now suggest the closest match (shared Levenshtein-based helper in the CLI).
+- **`autoloop init`.** Project onboarding scaffold: writes a fully commented starter `autoloops.toml`, adds `.autoloop/` to `.gitignore` in git repos, and `--preset <name>` scaffolds a runnable custom preset (config, harness.md, 2-role topology, role prompts, README). Never overwrites existing files.
+- **`autoloop chain run --dry-run`.** Prints the resolved execution plan (steps, preset dirs, backend overrides) plus budget validation without running anything; `--json` for machines; exit 1 on budget violations. Explicit chains are now budget-enforced at the root too: `max_steps` is pre-checked and `max_runtime_ms` is enforced between steps, stopping with outcome `budget_exceeded` (journaled via a `failed_reason` field on `chain.complete`).
+- **`autoloop worktree diff <run-id>`.** Preview a worktree's changes against its base before merging: diffstat summary by default, `--patch` for the full patch, `--json` for the structured result (new `diffWorktree` in `@mobrienv/autoloop-core/worktree`).
+- **Task priorities + soft tasks.** `task add --priority <high|normal|low>` and `--soft`; open tasks sort by priority in prompts and listings, and the completion gate now blocks only on non-soft tasks (soft tasks are advisory). Fully backward compatible with existing `tasks.jsonl` files.
+- **Memory lifecycle: `memory compact` and `memory prune`.** `compact` tombstones exact-duplicate learnings (keeping the oldest); `prune --max-age <days>` tombstones stale learnings (never preferences or meta). Both are append-only via the existing tombstone mechanism.
+- **Finish notifications.** Configure `[notify] command = "..."` (with `notify.on` stop-reason classes `completed,failed,stopped` and `notify.timeout_ms`) and the harness runs it when a loop ends, passing `AUTOLOOP_RUN_ID`/`AUTOLOOP_STOP_REASON`/`AUTOLOOP_ITERATIONS`/`AUTOLOOP_PRESET`/`AUTOLOOP_PROJECT_DIR` env vars plus a JSON payload on stdin. Best-effort, journaled as `notify.sent`/`notify.failed`.
+- **Live dashboard updates.** New `/api/stream` SSE endpoint pushes run-list updates when the registry changes (fs.watch with polling fallback, debounce, keepalives); the dashboard UI consumes it via `EventSource` and falls back to polling on error.
+- **`--json` for operator commands.** `loops [--all]`, `loops show`, `loops artifacts`, `loops health`, and `list` all support `--json` for agents and scripts. Human output is unchanged.
+
 ## [0.7.4] - 2026-05-07
 ### Fixed
 - **Harness: fresh ACP session per iteration.** Previously the kiro backend reused a single session across iterations and flipped modes via `setSessionMode()` — context from the finder role bled into the doer/checker/closer roles. The iteration loop now terminates and recreates the ACP session each pass, matching the AgentSpacesDesktop harness's per-iteration session lifecycle so every role gets an independent context window.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ If Ralph is the broader experimentation surface, autoloop is the cleaner runtime
 - **Designed for agents too** -- autoloop is intentionally shaped as a surface that agents can use directly, not just a human operator CLI
 - **Dynamic chains** -- compose presets into multi-stage pipelines
 - **Persistent memory + profiles** -- loops accumulate learnings across runs and can load repo/user tuning profiles
+- **Cost budgets + stall protection** -- stop runaway loops automatically with `event_loop.max_cost_usd` (journaled token cost) and `event_loop.stall_iterations` (repeated identical outputs)
+- **Finish notifications** -- run any command when a loop ends (`[notify] command = "..."`) with run metadata in env vars and a JSON payload on stdin
 
 ## What autoloop is
 
@@ -140,23 +142,28 @@ The main commands are:
 
 ```
 autoloop run <preset-name|preset-dir> [prompt...] [flags]
-autoloop list
-autoloop loops [--all]
-autoloop loops show <run-id>
-autoloop loops artifacts <run-id>
+autoloop init [--preset <name>] [dir]
+autoloop list [--json]
+autoloop loops [--all] [--json]
+autoloop loops show <run-id> [--json]
+autoloop loops artifacts <run-id> [--json]
 autoloop loops watch <run-id>
+autoloop loops health [--verbose] [--json]
 autoloop inspect <artifact> [selector] [project-dir] [--format <md|terminal|text|json|csv|graph>]
 autoloop dashboard [--port <port>]
-autoloop worktree <list|show|merge|clean> [args]
-autoloop chain <list|run> [args]
+autoloop worktree <list|show|diff|merge|clean> [args]
+autoloop chain list [project-dir]
+autoloop chain run <name> [project-dir] [prompt...] [--dry-run] [--json]
 autoloop emit <topic> [summary]
-autoloop memory <list|status|find|add|remove> [args]
+autoloop memory <list|status|find|add|remove|compact|prune> [args]
 autoloop task <add|complete|update|remove|list> [args]
 autoloop runs clean [--max-age <days>]
+autoloop stats [project-dir] [--json]
+autoloop doctor [project-dir] [--json]
 autoloop config <show|set|unset|path> [args]
 ```
 
-Use `run` to start work, `loops` and `inspect` to understand what happened, and `dashboard` when you want a local operator surface.
+Use `run` to start work, `loops` and `inspect` to understand what happened, and `dashboard` when you want a local operator surface. `stats` summarizes success rates and cost per preset; `doctor` diagnoses the environment and `.autoloop` state.
 
 ### Flags
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -62,6 +62,7 @@ export default defineConfig({
             { text: "Tasks", link: "/features/tasks" },
             { text: "LLM Judge", link: "/features/llm-judge" },
             { text: "Operator Health", link: "/features/operator-health" },
+            { text: "Cost, Stalls & Doctor", link: "/features/operability" },
           ],
         },
         {

--- a/docs/features/operability.md
+++ b/docs/features/operability.md
@@ -1,0 +1,83 @@
+# Cost, Stall Protection & Health
+
+Long-running loops fail in two expensive ways: they burn money without converging, or they spin in place repeating the same output. autoloop guards against both from the journal itself, and ships two operator commands — `doctor` and `stats` — that read the same state.
+
+## Cost budget (`event_loop.max_cost_usd`)
+
+Backends with usage telemetry (the pi RPC backend today) journal one `backend.usage` event per iteration with token counts and cost. Set a USD budget and the harness stops the run once accumulated journaled cost reaches it:
+
+```toml
+[event_loop]
+max_cost_usd = 5.0
+```
+
+```bash
+autoloop run autocode --set event_loop.max_cost_usd=5.0 "Refactor the parser"
+```
+
+The run stops with reason `cost_budget` and journals a `loop.stop` event carrying `cost_usd` and `max_cost_usd`. A budget of `0` (the default) disables the check. Backends without telemetry report zero cost, so the budget never mis-fires for them.
+
+Because the check is journal-derived, it covers every continue path — routed events, rejected emits, and plain continues — and survives context reloads.
+
+## Stall detection (`event_loop.stall_iterations`)
+
+A loop that produces byte-identical output N iterations in a row is not converging; it's burning the rest of its iteration budget. Enable stall detection to stop early:
+
+```toml
+[event_loop]
+stall_iterations = 3
+```
+
+After `stall_iterations` consecutive identical backend outputs the run stops with reason `stalled`, journaling how many identical outputs were seen. Empty outputs never count (backend failures and timeouts already have their own stop reasons), and `0` (the default) disables the check.
+
+## Inspecting usage
+
+```bash
+autoloop inspect usage              # per-iteration tokens + cost for the latest run
+autoloop inspect usage --run <id>   # a specific run
+autoloop inspect usage --json       # machine-readable
+```
+
+## `autoloop stats`
+
+Cross-run analytics grouped by preset, derived from the registry plus journaled usage:
+
+```bash
+autoloop stats            # table: runs, success rate, avg iterations/duration, cost
+autoloop stats --json     # machine-readable
+```
+
+Use it to answer "which presets actually finish, how long do they take, and what do they cost" before reaching for a single run's journal.
+
+## Finish notifications (`[notify]`)
+
+Run any command when a loop ends — post to Slack, fire a webhook via `curl`, ring a bell:
+
+```toml
+[notify]
+command = "curl -s -X POST -d @- https://hooks.example.com/autoloop"
+on = "completed,failed"   # stop-reason classes: completed, failed, stopped
+timeout_ms = 10000
+```
+
+The command receives `AUTOLOOP_RUN_ID`, `AUTOLOOP_STOP_REASON`, `AUTOLOOP_ITERATIONS`, `AUTOLOOP_PRESET`, and `AUTOLOOP_PROJECT_DIR` in its environment, plus the same fields as a JSON payload on stdin. Delivery is best-effort and journaled as `notify.sent` / `notify.failed` — a broken notifier never fails the run.
+
+## `autoloop doctor`
+
+Preflight and state-health diagnostics in one command:
+
+```bash
+autoloop doctor           # human-readable report
+autoloop doctor --json    # machine-readable (for agents and CI)
+```
+
+Checks include:
+
+- **node / git / backend** — runtime version, git availability, and whether the configured backend command resolves on `PATH`
+- **state** — `.autoloop/` existence and writability
+- **registry** — malformed `registry.jsonl` lines
+- **runs** — runs marked `running` whose process is gone
+- **waves** — stale `waves/active` markers that would block future parallel waves
+- **worktrees** — orphaned worktrees (suggests `autoloop worktree clean`)
+
+Exit code is `1` only when a check fails; warnings exit `0`, so it's safe to wire into scripts.

--- a/packages/cli/src/chains/budget.ts
+++ b/packages/cli/src/chains/budget.ts
@@ -1,4 +1,4 @@
-import type { Budget, ChainTracker } from "./types.js";
+import type { Budget, ChainSpec, ChainTracker } from "./types.js";
 
 export function defaultBudget(): Budget {
   return {
@@ -36,6 +36,24 @@ export function checkBudget(
     return {
       ok: false,
       reason: `max_consecutive_failures exceeded (${tracker.consecutiveFailures}/${budget.maxConsecutiveFailures})`,
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * Static (pre-execution) budget validation for an explicit chain: the chain's
+ * own step count must fit within maxSteps. Runtime limits (maxRuntimeMs,
+ * consecutive failures) are enforced during execution instead.
+ */
+export function checkPlanBudget(
+  spec: Pick<ChainSpec, "steps">,
+  budget: Budget,
+): { ok: boolean; reason?: string } {
+  if (spec.steps.length > budget.maxSteps) {
+    return {
+      ok: false,
+      reason: `max_steps exceeded (${spec.steps.length}/${budget.maxSteps})`,
     };
   }
   return { ok: true };

--- a/packages/cli/src/chains/dry-run.ts
+++ b/packages/cli/src/chains/dry-run.ts
@@ -1,0 +1,47 @@
+import { checkPlanBudget } from "./budget.js";
+import type { Budget, ChainPlan, ChainSpec } from "./types.js";
+
+/**
+ * Build the execution plan for a chain without running anything: ordered
+ * steps with resolved preset dirs and backend overrides, the budget that
+ * would apply, and a static budget validation result.
+ */
+export function buildChainPlan(spec: ChainSpec, budget: Budget): ChainPlan {
+  return {
+    chain: spec.name,
+    steps: spec.steps.map((step, idx) => ({
+      index: idx + 1,
+      name: step.name,
+      presetDir: step.presetDir,
+      ...(step.backendOverride !== undefined
+        ? { backendOverride: step.backendOverride }
+        : {}),
+    })),
+    budget,
+    validation: checkPlanBudget(spec, budget),
+  };
+}
+
+export function renderChainPlan(plan: ChainPlan): string {
+  let out = `Chain: ${plan.chain}\n`;
+  out += `Steps (${plan.steps.length}):\n`;
+  for (const step of plan.steps) {
+    out += `  ${step.index}. ${step.name}  ${step.presetDir}`;
+    if (step.backendOverride !== undefined) {
+      out += `  backend=${JSON.stringify(step.backendOverride)}`;
+    }
+    out += "\n";
+  }
+  const b = plan.budget;
+  out +=
+    "Budget: " +
+    `max_depth=${b.maxDepth}, ` +
+    `max_steps=${b.maxSteps}, ` +
+    `max_runtime_ms=${b.maxRuntimeMs}, ` +
+    `max_children=${b.maxChildren}, ` +
+    `max_consecutive_failures=${b.maxConsecutiveFailures}\n`;
+  out += plan.validation.ok
+    ? "Plan: OK"
+    : `Plan: INVALID — ${plan.validation.reason}`;
+  return out;
+}

--- a/packages/cli/src/chains/run.ts
+++ b/packages/cli/src/chains/run.ts
@@ -16,20 +16,27 @@ import {
   readLines,
 } from "@mobrienv/autoloop-core/journal";
 import * as harness from "@mobrienv/autoloop-harness";
-import { checkBudget, defaultBudget } from "./budget.js";
-import { parseInlineChain } from "./load.js";
+import { checkBudget, checkPlanBudget, defaultBudget } from "./budget.js";
+import { loadBudget, parseInlineChain } from "./load.js";
 import type {
+  Budget,
   ChainSpec,
   ChainTracker,
   DynamicChainSpec,
   StepRecord,
 } from "./types.js";
 
+interface ChainRuntime {
+  budget: Budget;
+  startedAt: number;
+}
+
 export async function runChain(
   chainSpec: ChainSpec,
   projectDir: string,
   selfCommand: string,
   runOptions: harness.RunOptions,
+  budgetOverride?: Budget,
 ): Promise<{
   completed: StepRecord[];
   outcome: string;
@@ -38,6 +45,7 @@ export async function runChain(
 }> {
   const chainName = chainSpec.name;
   const steps = chainSpec.steps;
+  const budget = budgetOverride ?? loadBudget(projectDir);
   const cfg = config.loadProject(projectDir);
   const chainRunId = nextChainRunId(projectDir, cfg);
   const chainDir = join(chainStateRoot(projectDir), chainRunId);
@@ -55,17 +63,25 @@ export async function runChain(
       jsonField("step_count", String(steps.length)),
   );
 
-  const result = await runSteps(
-    steps,
-    1,
-    projectDir,
-    chainDir,
-    chainRunId,
-    selfCommand,
-    runOptions,
-    journalFile,
-    [],
-  );
+  const planCheck = checkPlanBudget(chainSpec, budget);
+  const result = planCheck.ok
+    ? await runSteps(
+        steps,
+        1,
+        projectDir,
+        chainDir,
+        chainRunId,
+        selfCommand,
+        runOptions,
+        journalFile,
+        [],
+        { budget, startedAt: Date.now() },
+      )
+    : {
+        completed: [] as StepRecord[],
+        outcome: "budget_exceeded",
+        failedReason: `budget_exceeded:${planCheck.reason}`,
+      };
 
   appendChainEvent(
     journalFile,
@@ -75,7 +91,10 @@ export async function runChain(
       ", " +
       jsonField("steps_completed", String(result.completed.length)) +
       ", " +
-      jsonField("outcome", result.outcome),
+      jsonField("outcome", result.outcome) +
+      (result.failedReason
+        ? ", " + jsonField("failed_reason", result.failedReason)
+        : ""),
   );
 
   return result;
@@ -149,6 +168,7 @@ async function runSteps(
   runOptions: harness.RunOptions,
   journalFile: string,
   completed: StepRecord[],
+  runtime: ChainRuntime,
 ): Promise<{
   completed: StepRecord[];
   outcome: string;
@@ -157,6 +177,20 @@ async function runSteps(
 }> {
   if (steps.length === 0) {
     return { completed, outcome: "all_steps_complete" };
+  }
+
+  // Enforce maxRuntimeMs between steps: stop before starting the next step
+  // once the chain has run past its runtime budget.
+  if (completed.length > 0) {
+    const elapsed = Date.now() - runtime.startedAt;
+    if (elapsed >= runtime.budget.maxRuntimeMs) {
+      return {
+        completed,
+        outcome: "budget_exceeded",
+        failedStep: stepNum,
+        failedReason: `budget_exceeded:max_runtime_ms exceeded (${elapsed}ms/${runtime.budget.maxRuntimeMs}ms)`,
+      };
+    }
   }
 
   const [step, ...rest] = steps;
@@ -237,6 +271,7 @@ async function runSteps(
       runOptions,
       journalFile,
       updatedCompleted,
+      runtime,
     );
   }
   return {

--- a/packages/cli/src/chains/types.ts
+++ b/packages/cli/src/chains/types.ts
@@ -47,6 +47,20 @@ export interface StepRecord {
   runId?: string;
 }
 
+export interface ChainPlanStep {
+  index: number;
+  name: string;
+  presetDir: string;
+  backendOverride?: StepBackendOverride;
+}
+
+export interface ChainPlan {
+  chain: string;
+  steps: ChainPlanStep[];
+  budget: Budget;
+  validation: { ok: boolean; reason?: string };
+}
+
 export interface ChainTracker {
   depth: number;
   totalSteps: number;

--- a/packages/cli/src/cli/render.ts
+++ b/packages/cli/src/cli/render.ts
@@ -5,6 +5,7 @@
 // stdout. They are NOT part of the embedded SDK surface: SDK consumers read
 // journals directly or via packages/core readers in Phase 2.
 
+import { collectUsage, formatUsage } from "@mobrienv/autoloop-core";
 import * as config from "@mobrienv/autoloop-core/config";
 import {
   readAllJournals,
@@ -138,6 +139,20 @@ export function renderMetrics(
   const lines = readRunLines(journalFile, runId);
   const rows = collectMetricsRows(lines);
   printProjectedText(formatMetrics(rows, format), format);
+}
+
+export function renderUsage(
+  projectDir: string,
+  format: string,
+  runIdOverride?: string,
+): void {
+  const { journalFile, runId } = resolveJournalAndRun(
+    projectDir,
+    runIdOverride,
+  );
+  const lines = readRunLines(journalFile, runId);
+  const usage = collectUsage(lines);
+  printProjectedText(formatUsage(usage, format), format);
 }
 
 export function renderJournalTimeline(

--- a/packages/cli/src/cli/suggest.ts
+++ b/packages/cli/src/cli/suggest.ts
@@ -1,0 +1,53 @@
+// "Did you mean …?" suggestions for mistyped commands, subcommands, and
+// preset names. One shared implementation so every error path suggests with
+// the same tolerance.
+
+/** Classic Levenshtein edit distance. */
+export function editDistance(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= a.length; i++) {
+    const curr = [i];
+    for (let j = 1; j <= b.length; j++) {
+      const substitution = prev[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1);
+      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, substitution);
+    }
+    prev = curr;
+  }
+  return prev[b.length];
+}
+
+/**
+ * Return the closest candidate within an edit-distance budget scaled to the
+ * input length (minimum 2), or null when nothing is plausibly close.
+ * Prefix matches win outright so `art` suggests `artifacts`.
+ */
+export function suggestClosest(
+  input: string,
+  candidates: string[],
+): string | null {
+  if (!input) return null;
+  const needle = input.toLowerCase();
+  for (const candidate of candidates) {
+    if (candidate.toLowerCase().startsWith(needle)) return candidate;
+  }
+  const budget = Math.max(2, Math.floor(needle.length / 3));
+  let best: string | null = null;
+  let bestDistance = budget + 1;
+  for (const candidate of candidates) {
+    const distance = editDistance(needle, candidate.toLowerCase());
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = candidate;
+    }
+  }
+  return best;
+}
+
+/** Render the standard hint line, or an empty string when no suggestion. */
+export function didYouMean(input: string, candidates: string[]): string {
+  const suggestion = suggestClosest(input, candidates);
+  return suggestion ? `Did you mean \`${suggestion}\`?` : "";
+}

--- a/packages/cli/src/commands/chain.ts
+++ b/packages/cli/src/commands/chain.ts
@@ -1,3 +1,4 @@
+import { buildChainPlan, renderChainPlan } from "../chains/dry-run.js";
 import * as chains from "../chains.js";
 
 export async function dispatchChain(
@@ -25,19 +26,32 @@ export async function dispatchChain(
       return true;
     }
     case "run": {
-      const name = args[1];
+      const dryRun = args.includes("--dry-run");
+      const asJson = args.includes("--json");
+      const positional = args
+        .slice(1)
+        .filter((a) => a !== "--dry-run" && a !== "--json");
+      const name = positional[0];
       if (!name) {
         console.log(
-          "Usage: autoloop chain run <name> [project-dir] [prompt...]",
+          "Usage: autoloop chain run <name> [project-dir] [prompt...] [--dry-run] [--json]",
         );
         return true;
       }
-      const projectDir = args[2] ?? resolveRuntimeProjectDir();
-      const prompt = args.slice(3).join(" ") || null;
+      const projectDir = positional[1] ?? resolveRuntimeProjectDir();
+      const prompt = positional.slice(2).join(" ") || null;
       const chainsData = chains.load(projectDir);
       const chainSpec = chains.resolveChain(chainsData, name);
       if (!chainSpec) {
         console.log(`chain \`${name}\` not found in chains.toml`);
+        if (dryRun) process.exitCode = 1;
+        return true;
+      }
+      if (dryRun) {
+        const plan = buildChainPlan(chainSpec, chainsData.budget);
+        if (asJson) console.log(JSON.stringify(plan, null, 2));
+        else console.log(renderChainPlan(plan));
+        if (!plan.validation.ok) process.exitCode = 1;
         return true;
       }
       await chains.runChain(chainSpec, projectDir, selfCmd, {
@@ -48,7 +62,9 @@ export async function dispatchChain(
     default:
       console.log("Usage:");
       console.log("  autoloop chain list [project-dir]");
-      console.log("  autoloop chain run <name> [project-dir] [prompt...]");
+      console.log(
+        "  autoloop chain run <name> [project-dir] [prompt...] [--dry-run] [--json]",
+      );
       return true;
   }
 }

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,0 +1,298 @@
+// `autoloop doctor` — preflight and state-health diagnostics.
+//
+// Checks the environment (node, git, backend command) and the `.autoloop/`
+// state tree (registry integrity, stale "running" runs, stale wave markers,
+// orphaned worktrees) so operators — and agents — can diagnose a project in
+// one command before or after a run. `--json` emits machine-readable results.
+
+import { accessSync, constants, existsSync, readFileSync } from "node:fs";
+import { delimiter, join } from "node:path";
+import * as config from "@mobrienv/autoloop-core/config";
+import { readRegistry } from "@mobrienv/autoloop-core/registry/read";
+import { listWorktreeMetas } from "@mobrienv/autoloop-core/worktree";
+
+export type DoctorStatus = "ok" | "warn" | "fail";
+
+export interface DoctorCheck {
+  name: string;
+  status: DoctorStatus;
+  detail: string;
+}
+
+export function dispatchDoctor(args: string[]): void {
+  if (args[0] === "--help" || args[0] === "-h") {
+    printDoctorUsage();
+    return;
+  }
+  let json = false;
+  const positionals: string[] = [];
+  for (const arg of args) {
+    if (arg === "--json") json = true;
+    else positionals.push(arg);
+  }
+  const projectDir = positionals[0] ?? resolveRuntimeProjectDir();
+  const checks = runDoctorChecks(projectDir);
+  if (json) {
+    console.log(JSON.stringify({ projectDir, checks }, null, 2));
+  } else {
+    console.log(renderDoctorReport(projectDir, checks));
+  }
+  if (checks.some((c) => c.status === "fail")) process.exitCode = 1;
+}
+
+export function runDoctorChecks(projectDir: string): DoctorCheck[] {
+  const stateDir = join(projectDir, ".autoloop");
+  const checks: DoctorCheck[] = [];
+  checks.push(checkNode());
+  checks.push(checkGit(projectDir));
+  checks.push(checkBackendCommand(projectDir));
+  checks.push(checkStateDir(stateDir));
+  if (existsSync(stateDir)) {
+    checks.push(checkRegistry(stateDir));
+    checks.push(checkStaleRunningRuns(stateDir));
+    checks.push(checkWaveMarker(stateDir));
+    checks.push(checkOrphanWorktrees(stateDir));
+  }
+  return checks;
+}
+
+export function renderDoctorReport(
+  projectDir: string,
+  checks: DoctorCheck[],
+): string {
+  const lines: string[] = [`autoloop doctor — ${projectDir}`, ""];
+  const nameWidth = Math.max(...checks.map((c) => c.name.length));
+  for (const check of checks) {
+    const icon =
+      check.status === "ok" ? "✓" : check.status === "warn" ? "!" : "✗";
+    lines.push(`  ${icon} ${check.name.padEnd(nameWidth)}  ${check.detail}`);
+  }
+  const warns = checks.filter((c) => c.status === "warn").length;
+  const fails = checks.filter((c) => c.status === "fail").length;
+  lines.push("");
+  lines.push(`${fails} failure(s), ${warns} warning(s)`);
+  return lines.join("\n");
+}
+
+function checkNode(): DoctorCheck {
+  const major = Number.parseInt(process.versions.node.split(".")[0], 10);
+  if (major >= 18) {
+    return {
+      name: "node",
+      status: "ok",
+      detail: `v${process.versions.node} (>= 18 required)`,
+    };
+  }
+  return {
+    name: "node",
+    status: "fail",
+    detail: `v${process.versions.node} is below the required Node 18`,
+  };
+}
+
+function checkGit(projectDir: string): DoctorCheck {
+  if (!commandOnPath("git")) {
+    return {
+      name: "git",
+      status: "warn",
+      detail: "git not found on PATH — worktree isolation is unavailable",
+    };
+  }
+  const inRepo = existsSync(join(projectDir, ".git"));
+  return {
+    name: "git",
+    status: "ok",
+    detail: inRepo
+      ? "available (project is a git repository)"
+      : "available (project dir has no .git — worktree isolation needs one)",
+  };
+}
+
+function checkBackendCommand(projectDir: string): DoctorCheck {
+  let command = "claude";
+  try {
+    const cfg = config.loadProject(projectDir);
+    command = config.get(cfg, "backend.command", "claude");
+  } catch {
+    /* fall through with the default */
+  }
+  const executable = command.split(" ")[0];
+  if (commandOnPath(executable)) {
+    return {
+      name: "backend",
+      status: "ok",
+      detail: `\`${executable}\` resolves on PATH`,
+    };
+  }
+  return {
+    name: "backend",
+    status: "warn",
+    detail: `configured backend command \`${executable}\` not found on PATH`,
+  };
+}
+
+function checkStateDir(stateDir: string): DoctorCheck {
+  if (!existsSync(stateDir)) {
+    return {
+      name: "state",
+      status: "warn",
+      detail: `${stateDir} does not exist yet (created on first run)`,
+    };
+  }
+  try {
+    accessSync(stateDir, constants.W_OK);
+  } catch {
+    return {
+      name: "state",
+      status: "fail",
+      detail: `${stateDir} is not writable`,
+    };
+  }
+  return { name: "state", status: "ok", detail: `${stateDir} is writable` };
+}
+
+function checkRegistry(stateDir: string): DoctorCheck {
+  const registryPath = join(stateDir, "registry.jsonl");
+  if (!existsSync(registryPath)) {
+    return {
+      name: "registry",
+      status: "ok",
+      detail: "no registry yet (created on first run)",
+    };
+  }
+  const lines = readFileSync(registryPath, "utf-8")
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l !== "");
+  let malformed = 0;
+  for (const line of lines) {
+    try {
+      JSON.parse(line);
+    } catch {
+      malformed++;
+    }
+  }
+  const runs = readRegistry(registryPath).length;
+  if (malformed > 0) {
+    return {
+      name: "registry",
+      status: "warn",
+      detail: `${malformed} malformed line(s) in registry.jsonl (${runs} run(s) readable)`,
+    };
+  }
+  return {
+    name: "registry",
+    status: "ok",
+    detail: `${runs} run(s) recorded`,
+  };
+}
+
+function checkStaleRunningRuns(stateDir: string): DoctorCheck {
+  const registryPath = join(stateDir, "registry.jsonl");
+  const running = readRegistry(registryPath).filter(
+    (r) => r.status === "running",
+  );
+  const stale = running.filter((r) => r.pid !== undefined && !pidAlive(r.pid));
+  if (stale.length > 0) {
+    const ids = stale.map((r) => r.run_id).join(", ");
+    return {
+      name: "runs",
+      status: "warn",
+      detail: `${stale.length} run(s) marked running but the process is gone: ${ids}`,
+    };
+  }
+  return {
+    name: "runs",
+    status: "ok",
+    detail: `${running.length} run(s) currently running`,
+  };
+}
+
+function checkWaveMarker(stateDir: string): DoctorCheck {
+  const marker = join(stateDir, "waves", "active");
+  if (!existsSync(marker)) {
+    return { name: "waves", status: "ok", detail: "no active wave marker" };
+  }
+  const registryPath = join(stateDir, "registry.jsonl");
+  const running = readRegistry(registryPath).filter(
+    (r) => r.status === "running",
+  );
+  if (running.length > 0) {
+    return {
+      name: "waves",
+      status: "ok",
+      detail: "wave marker present with a running run",
+    };
+  }
+  return {
+    name: "waves",
+    status: "warn",
+    detail: `stale wave marker blocks future parallel waves — delete ${marker}`,
+  };
+}
+
+function checkOrphanWorktrees(stateDir: string): DoctorCheck {
+  let orphans = 0;
+  let total = 0;
+  try {
+    const metas = listWorktreeMetas(stateDir);
+    total = metas.length;
+    orphans = metas.filter((m) => m.orphan).length;
+  } catch {
+    /* unreadable worktree metadata is reported as zero */
+  }
+  if (orphans > 0) {
+    return {
+      name: "worktrees",
+      status: "warn",
+      detail: `${orphans} orphaned worktree(s) of ${total} — run \`autoloop worktree clean\``,
+    };
+  }
+  return {
+    name: "worktrees",
+    status: "ok",
+    detail:
+      total === 0 ? "no worktrees" : `${total} worktree(s), none orphaned`,
+  };
+}
+
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function commandOnPath(executable: string): boolean {
+  if (!executable) return false;
+  if (executable.includes("/")) return existsSync(executable);
+  const pathEnv = process.env.PATH ?? "";
+  for (const dir of pathEnv.split(delimiter)) {
+    if (!dir) continue;
+    try {
+      accessSync(join(dir, executable), constants.X_OK);
+      return true;
+    } catch {
+      /* keep looking */
+    }
+  }
+  return false;
+}
+
+function printDoctorUsage(): void {
+  console.log("Usage: autoloop doctor [project-dir] [--json]");
+  console.log("");
+  console.log("Diagnose the environment and .autoloop state: node/git/backend");
+  console.log(
+    "availability, registry integrity, stale running runs, stale wave",
+  );
+  console.log("markers, and orphaned worktrees.");
+  console.log("");
+  console.log("Exit code is 1 when any check fails (warnings exit 0).");
+}
+
+function resolveRuntimeProjectDir(): string {
+  return process.env.AUTOLOOP_PROJECT_DIR || ".";
+}

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,276 @@
+// `autoloop init` — project onboarding scaffold.
+//
+// `autoloop init [dir]` writes a fully commented starter `autoloops.toml`
+// and gitignores `.autoloop/` so a project is ready for its first run.
+// `autoloop init --preset <name> [dir]` scaffolds a custom preset directory
+// (autoloops.toml + harness.md + topology.toml + roles/) modeled on the
+// bundled presets, with a minimal builder → critic topology.
+//
+// Existing files are never overwritten — every file is created-or-skipped
+// and reported individually so re-running init is always safe.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export function dispatchInit(args: string[]): void {
+  if (args[0] === "--help" || args[0] === "-h") {
+    printInitUsage();
+    return;
+  }
+  let preset = "";
+  const positionals: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--preset") {
+      i++;
+      const name = args[i];
+      if (!name || name.startsWith("-")) {
+        fail("init: --preset requires a name (e.g. --preset myloop)");
+        return;
+      }
+      preset = name;
+    } else if (arg.startsWith("-")) {
+      fail(`init: unknown flag \`${arg}\` — see \`autoloop init --help\``);
+      return;
+    } else {
+      positionals.push(arg);
+    }
+  }
+  if (positionals.length > 1) {
+    fail(
+      `init: expected at most one directory argument, got: ${positionals.join(" ")}`,
+    );
+    return;
+  }
+  const dir = positionals[0] ?? ".";
+  if (preset !== "") {
+    initPreset(dir, preset);
+  } else {
+    initProject(dir);
+  }
+}
+
+export function initProject(dir: string): void {
+  mkdirSync(dir, { recursive: true });
+  writeIfMissing(dir, "autoloops.toml", starterConfig());
+  ensureGitignore(dir);
+  console.log("");
+  console.log("Next steps:");
+  console.log('  autoloop run autocode "describe your objective"');
+  console.log("  autoloop list      # browse bundled presets");
+  console.log("  autoloop doctor    # check environment and state health");
+}
+
+export function initPreset(dir: string, name: string): void {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(name)) {
+    fail(
+      `init: invalid preset name \`${name}\` — use letters, digits, dot, dash, underscore`,
+    );
+    return;
+  }
+  const presetDir = join(dir, "presets", name);
+  mkdirSync(join(presetDir, "roles"), { recursive: true });
+  writeIfMissing(presetDir, "autoloops.toml", presetConfig(name));
+  writeIfMissing(presetDir, "harness.md", presetHarness(name));
+  writeIfMissing(presetDir, "topology.toml", presetTopology(name));
+  writeIfMissing(presetDir, join("roles", "builder.md"), builderPrompt());
+  writeIfMissing(presetDir, join("roles", "critic.md"), criticPrompt());
+  writeIfMissing(presetDir, "README.md", presetReadme(name));
+  console.log("");
+  console.log("Run it with:");
+  console.log(`  autoloop run ./presets/${name} "describe your objective"`);
+}
+
+/** Append `.autoloop/` to .gitignore when `dir` is a git repo (no duplicates). */
+export function ensureGitignore(dir: string): void {
+  if (!existsSync(join(dir, ".git"))) return;
+  const entry = ".autoloop/";
+  const path = join(dir, ".gitignore");
+  if (!existsSync(path)) {
+    writeFileSync(path, `${entry}\n`);
+    console.log("created .gitignore (.autoloop/)");
+    return;
+  }
+  const text = readFileSync(path, "utf-8");
+  const lines = text.split("\n").map((l) => l.trim());
+  if (lines.includes(entry) || lines.includes(".autoloop")) {
+    console.log(".gitignore already ignores .autoloop/, skipped");
+    return;
+  }
+  const sep = text === "" || text.endsWith("\n") ? "" : "\n";
+  writeFileSync(path, `${text}${sep}${entry}\n`);
+  console.log("updated .gitignore (.autoloop/)");
+}
+
+function writeIfMissing(dir: string, relative: string, content: string): void {
+  const path = join(dir, relative);
+  if (existsSync(path)) {
+    console.log(`${path} already exists, skipped`);
+    return;
+  }
+  writeFileSync(path, content);
+  console.log(`created ${path}`);
+}
+
+function fail(message: string): void {
+  console.error(message);
+  process.exitCode = 1;
+}
+
+function starterConfig(): string {
+  return `# autoloop project configuration.
+# Every key is optional — values below are the defaults. Uncomment to change.
+
+[event_loop]
+# Maximum harness iterations before the loop stops.
+max_iterations = 3
+# Event that marks the run complete (emit via the event tool / \`autoloop emit\`).
+completion_event = "task.complete"
+# Literal promise string the backend prints to declare completion.
+completion_promise = "LOOP_COMPLETE"
+# Stop after N consecutive identical backend outputs (0 = disabled).
+stall_iterations = 0
+# Stop once the journaled run cost reaches this USD budget (0 = disabled).
+max_cost_usd = 0
+
+[backend]
+# Command used to drive each iteration.
+command = "claude"
+# Per-iteration timeout in milliseconds.
+timeout_ms = 300000
+
+[memory]
+# Character budget for durable memory injected into each prompt.
+prompt_budget_chars = 8000
+`;
+}
+
+function presetConfig(name: string): string {
+  return `# ${name} — custom builder → critic preset scaffolded by \`autoloop init\`.
+
+event_loop.max_iterations = 25
+event_loop.completion_event = "task.complete"
+event_loop.completion_promise = "LOOP_COMPLETE"
+# Stop after N consecutive identical backend outputs (0 = disabled).
+event_loop.stall_iterations = 0
+# Stop once journaled run cost reaches this USD budget (0 = disabled).
+event_loop.max_cost_usd = 0
+
+backend.kind = "command"
+backend.command = "claude"
+backend.args = ["-p", "--dangerously-skip-permissions"]
+backend.prompt_mode = "file"
+backend.timeout_ms = 300000
+
+memory.prompt_budget_chars = 8000
+harness.instructions_file = "harness.md"
+`;
+}
+
+function presetTopology(name: string): string {
+  return `name = "${name}"
+completion = "task.complete"
+
+[[role]]
+id = "builder"
+emits = ["review.ready", "build.blocked"]
+prompt_file = "roles/builder.md"
+
+[[role]]
+id = "critic"
+emits = ["review.rejected", "task.complete"]
+prompt_file = "roles/critic.md"
+
+[handoff]
+"loop.start" = ["builder"]
+"review.ready" = ["critic"]
+"review.rejected" = ["builder"]
+"build.blocked" = ["builder"]
+`;
+}
+
+function presetHarness(name: string): string {
+  return `# ${name} harness
+
+Shared rules for every role, loaded on every iteration.
+
+- The objective is given in the prompt; shared state lives in \`{{STATE_DIR}}/\`.
+- Keep \`{{STATE_DIR}}/progress.md\` current: what is done, what is next.
+- Hand off with the event tool — prose-only handoffs are not routing.
+- Prefer small, verifiable changes; verify before claiming success and cite
+  the exact commands you ran.
+- Only the critic may emit \`task.complete\`.
+`;
+}
+
+function builderPrompt(): string {
+  return `You are the builder.
+
+Do not review your own work — that is the critic's job.
+
+Your job:
+1. Read \`{{STATE_DIR}}/progress.md\` (if it exists) and the objective.
+2. Implement the next small, verifiable slice of work.
+3. Verify it (build, test, or run as appropriate) and record the evidence
+   in \`{{STATE_DIR}}/progress.md\`.
+4. Emit \`review.ready\` with a summary of what changed and how it was verified.
+
+On \`review.rejected\` reactivation:
+- Read the critic's concerns in \`{{STATE_DIR}}/progress.md\` and address them.
+- Emit \`review.ready\` again.
+
+If you cannot make progress, emit \`build.blocked\` explaining what is missing.
+`;
+}
+
+function criticPrompt(): string {
+  return `You are the critic.
+
+Do not build — that is the builder's job.
+
+Your job:
+1. Read \`{{STATE_DIR}}/progress.md\` and the builder's summary.
+2. Independently verify the work: rerun the cited commands, inspect the
+   changed files, and look for gaps or regressions.
+3. Decide:
+   - Work is incomplete, unverified, or wrong → emit \`review.rejected\`
+     with specific, actionable concerns recorded in \`{{STATE_DIR}}/progress.md\`.
+   - The whole objective is met and verified → emit \`task.complete\`
+     with a closing summary.
+
+Start skeptical: missing evidence means rejection, not benefit of the doubt.
+`;
+}
+
+function presetReadme(name: string): string {
+  return `# ${name}
+
+Custom builder → critic preset scaffolded by \`autoloop init --preset ${name}\`.
+
+Shape:
+- builder — implements and verifies one slice at a time
+- critic — independently verifies and decides completion
+
+Run from the project root:
+
+\`\`\`bash
+autoloop run ./presets/${name} "describe your objective"
+\`\`\`
+`;
+}
+
+function printInitUsage(): void {
+  console.log("Usage: autoloop init [dir]");
+  console.log("       autoloop init --preset <name> [dir]");
+  console.log("");
+  console.log("Scaffold autoloop files into a project (default dir: `.`).");
+  console.log("");
+  console.log("  autoloop init             write a commented starter");
+  console.log("                            autoloops.toml and gitignore");
+  console.log("                            .autoloop/ (git repos only)");
+  console.log("  autoloop init --preset x  scaffold a custom preset at");
+  console.log("                            <dir>/presets/x/ (autoloops.toml,");
+  console.log("                            harness.md, topology.toml, roles/)");
+  console.log("");
+  console.log("Existing files are never overwritten.");
+}

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -6,6 +6,7 @@ import * as tasks from "@mobrienv/autoloop-core/tasks";
 import * as topo from "@mobrienv/autoloop-core/topology";
 import * as chains from "../chains.js";
 import * as render from "../cli/render.js";
+import { suggestClosest } from "../cli/suggest.js";
 import { printInspectUsage } from "../usage.js";
 
 const INSPECT_TARGETS = [
@@ -19,6 +20,7 @@ const INSPECT_TARGETS = [
   "coordination",
   "chain",
   "metrics",
+  "usage",
   "profiles",
   "topology",
 ];
@@ -77,6 +79,9 @@ export function dispatchInspect(args: string[]): boolean {
     case "metrics":
       render.renderMetrics(projectDir, format, selector || spec.run);
       return true;
+    case "usage":
+      render.renderUsage(projectDir, format, spec.run);
+      return true;
     case "chain":
       console.log(chains.renderChainState(projectDir));
       return true;
@@ -101,7 +106,7 @@ export function dispatchInspect(args: string[]): boolean {
       render.renderOutput(projectDir, selector, spec.run);
       return true;
     default: {
-      const suggestion = findClosestTarget(artifact, INSPECT_TARGETS);
+      const suggestion = suggestClosest(artifact, INSPECT_TARGETS);
       console.log(`Unknown inspect target \`${artifact}\`.`);
       if (suggestion) {
         console.log(`Did you mean \`${suggestion}\`?`);
@@ -234,32 +239,4 @@ function renderProfilesInspect(projectDir: string): void {
         (err instanceof Error ? err.message : String(err)),
     );
   }
-}
-
-function findClosestTarget(input: string, targets: string[]): string | null {
-  let best: string | null = null;
-  let bestScore = Infinity;
-  for (const t of targets) {
-    if (t.startsWith(input) || input.startsWith(t)) {
-      const d = Math.abs(t.length - input.length);
-      if (d < bestScore) {
-        bestScore = d;
-        best = t;
-      }
-    }
-  }
-  if (best) return best;
-  // simple character overlap heuristic
-  for (const t of targets) {
-    let overlap = 0;
-    for (const ch of input) {
-      if (t.includes(ch)) overlap++;
-    }
-    const score = input.length - overlap;
-    if (score < bestScore) {
-      bestScore = score;
-      best = t;
-    }
-  }
-  return bestScore <= 2 ? best : null;
 }

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -6,6 +6,16 @@ export function dispatchList(args: string[], bundleRoot: string): boolean {
     return true;
   }
   const presets = chains.listPresetsWithDescriptions(bundleRoot);
+  if (args.includes("--json")) {
+    console.log(
+      JSON.stringify(
+        presets.map(({ name, description }) => ({ name, description })),
+        null,
+        2,
+      ),
+    );
+    return true;
+  }
   const maxName = Math.max(...presets.map((p) => p.name.length));
   for (const { name, description } of presets) {
     const pad = " ".repeat(maxName - name.length + 2);

--- a/packages/cli/src/commands/loops.ts
+++ b/packages/cli/src/commands/loops.ts
@@ -1,5 +1,12 @@
 import { join } from "node:path";
 import { healthSummary } from "../loops/health.js";
+import {
+  artifactsJson,
+  healthJson,
+  type JsonResult,
+  listRunsJson,
+  showRunJson,
+} from "../loops/json.js";
 import { listRuns } from "../loops/list.js";
 import { showArtifacts, showRun } from "../loops/show.js";
 import { watchRun } from "../loops/watch.js";
@@ -7,13 +14,17 @@ import { watchRun } from "../loops/watch.js";
 export function dispatchLoops(args: string[]): void {
   const projectDir = resolveProjectDir();
   const stateDir = join(projectDir, ".autoloop");
+  const json = args.includes("--json");
+  const rest = json ? args.filter((a) => a !== "--json") : args;
 
-  if (args.length === 0) {
-    console.log(listRuns(stateDir, false));
+  if (rest.length === 0) {
+    console.log(
+      json ? listRunsJson(stateDir, false) : listRuns(stateDir, false),
+    );
     return;
   }
 
-  const first = args[0];
+  const first = rest[0];
 
   if (first === "--help" || first === "-h") {
     printLoopsUsage();
@@ -21,14 +32,18 @@ export function dispatchLoops(args: string[]): void {
   }
 
   if (first === "--all") {
-    console.log(listRuns(stateDir, true));
+    console.log(json ? listRunsJson(stateDir, true) : listRuns(stateDir, true));
     return;
   }
 
   if (first === "show") {
-    const runId = args[1];
+    const runId = rest[1];
     if (!runId) {
       console.log("Usage: autoloop loops show <run-id>");
+      return;
+    }
+    if (json) {
+      printJsonResult(showRunJson(stateDir, runId));
       return;
     }
     console.log(showRun(stateDir, runId));
@@ -36,9 +51,13 @@ export function dispatchLoops(args: string[]): void {
   }
 
   if (first === "artifacts") {
-    const runId = args[1];
+    const runId = rest[1];
     if (!runId) {
       console.log("Usage: autoloop loops artifacts <run-id>");
+      return;
+    }
+    if (json) {
+      printJsonResult(artifactsJson(stateDir, runId));
       return;
     }
     console.log(showArtifacts(stateDir, runId));
@@ -46,7 +65,7 @@ export function dispatchLoops(args: string[]): void {
   }
 
   if (first === "watch") {
-    const runId = args[1];
+    const runId = rest[1];
     if (!runId) {
       console.log("Usage: autoloop loops watch <run-id>");
       return;
@@ -59,13 +78,24 @@ export function dispatchLoops(args: string[]): void {
   }
 
   if (first === "health") {
-    const verbose = args.includes("--verbose") || args.includes("-v");
+    if (json) {
+      console.log(healthJson(stateDir));
+      return;
+    }
+    const verbose = rest.includes("--verbose") || rest.includes("-v");
     console.log(healthSummary(stateDir, verbose));
     return;
   }
 
   console.log(`Unknown loops subcommand: ${first}`);
   printLoopsUsage();
+}
+
+function printJsonResult(result: JsonResult): void {
+  console.log(result.output);
+  if (result.exitCode !== 0) {
+    process.exitCode = result.exitCode;
+  }
 }
 
 function printLoopsUsage(): void {

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -90,6 +90,62 @@ export function dispatchMemory(args: string[]): boolean {
       memory.promote(resolveRuntimeProjectDir(), stateDir, args[1]);
       return true;
     }
+    case "compact": {
+      if (args[1] === "--help") {
+        printMemoryCompactUsage();
+        return true;
+      }
+      const projectDir = args[1] ?? resolveRuntimeProjectDir();
+      const summary = memory.compactMemory(projectDir);
+      if (summary.duplicatesRemoved === 0) {
+        console.log(
+          `Scanned ${summary.scanned} learnings; no duplicates found.`,
+        );
+      } else {
+        console.log(
+          `Scanned ${summary.scanned} learnings; tombstoned ${summary.duplicatesRemoved} duplicate(s):`,
+        );
+        for (const id of summary.ids) console.log(`  ${id}`);
+      }
+      return true;
+    }
+    case "prune": {
+      const rest = args.slice(1);
+      if (rest[0] === "--help") {
+        printMemoryPruneUsage();
+        return true;
+      }
+      const flagIndex = rest.indexOf("--max-age");
+      if (flagIndex === -1) {
+        console.log("error: prune requires --max-age <days>");
+        printMemoryPruneUsage();
+        return true;
+      }
+      const rawDays = rest[flagIndex + 1];
+      const maxAgeDays = Number(rawDays);
+      if (!rawDays || !Number.isInteger(maxAgeDays) || maxAgeDays <= 0) {
+        console.log(
+          `error: --max-age must be a positive integer number of days (got: ${rawDays ?? "nothing"})`,
+        );
+        return true;
+      }
+      const positional = rest.filter(
+        (_, i) => i !== flagIndex && i !== flagIndex + 1,
+      );
+      const projectDir = positional[0] ?? resolveRuntimeProjectDir();
+      const summary = memory.pruneMemory(projectDir, maxAgeDays);
+      if (summary.pruned === 0) {
+        console.log(
+          `Scanned ${summary.scanned} learnings; none older than ${maxAgeDays} days.`,
+        );
+      } else {
+        console.log(
+          `Scanned ${summary.scanned} learnings; tombstoned ${summary.pruned} older than ${maxAgeDays} days:`,
+        );
+        for (const id of summary.ids) console.log(`  ${id}`);
+      }
+      return true;
+    }
     case "remove": {
       if (!args[1] || args[1] === "--help") {
         console.log("Usage: autoloop memory remove <id> [reason...]");
@@ -170,6 +226,22 @@ function dispatchMemoryAdd(args: string[]): void {
     default:
       printMemoryAddUsage();
   }
+}
+
+function printMemoryCompactUsage(): void {
+  console.log("Usage: autoloop memory compact [project-dir]");
+  console.log("");
+  console.log(
+    "Tombstones duplicate learnings (same text after whitespace normalization), keeping the oldest entry of each group.",
+  );
+}
+
+function printMemoryPruneUsage(): void {
+  console.log("Usage: autoloop memory prune --max-age <days> [project-dir]");
+  console.log("");
+  console.log(
+    "Tombstones learnings older than <days>. Preferences and meta entries are never pruned.",
+  );
 }
 
 function resolveRuntimeProjectDir(): string {

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -1,0 +1,181 @@
+// `autoloop stats` — cross-run analytics derived from the registry + journals.
+//
+// Groups runs by preset and reports counts, success rate, average iterations,
+// average duration, and total journaled cost (from `backend.usage` events).
+// Gives operators the "which presets actually finish, and what do they cost"
+// view that single-run inspection can't.
+
+import { join } from "node:path";
+import { collectUsage } from "@mobrienv/autoloop-core";
+import { readRunJournal } from "@mobrienv/autoloop-core/journal";
+import { readRegistry } from "@mobrienv/autoloop-core/registry/read";
+import type { RunRecord } from "@mobrienv/autoloop-core/registry/types";
+
+export interface PresetStats {
+  preset: string;
+  runs: number;
+  running: number;
+  completed: number;
+  failed: number;
+  stopped: number;
+  successRate: number | null;
+  avgIterations: number | null;
+  avgDurationS: number | null;
+  costUsd: number;
+}
+
+export function dispatchStats(args: string[]): void {
+  if (args[0] === "--help" || args[0] === "-h") {
+    printStatsUsage();
+    return;
+  }
+  let json = false;
+  const positionals: string[] = [];
+  for (const arg of args) {
+    if (arg === "--json") json = true;
+    else positionals.push(arg);
+  }
+  const projectDir = positionals[0] ?? resolveRuntimeProjectDir();
+  const stateDir = join(projectDir, ".autoloop");
+  const records = readRegistry(join(stateDir, "registry.jsonl"));
+  const stats = computeStats(records, (runId) =>
+    readRunJournal(stateDir, runId),
+  );
+  if (json) {
+    console.log(JSON.stringify({ projectDir, presets: stats }, null, 2));
+    return;
+  }
+  console.log(renderStats(projectDir, stats));
+}
+
+/**
+ * Aggregate run records into per-preset stats. `journalForRun` supplies raw
+ * journal lines per run so cost can be summed from `backend.usage` events.
+ */
+export function computeStats(
+  records: RunRecord[],
+  journalForRun: (runId: string) => string[],
+): PresetStats[] {
+  const byPreset = new Map<string, RunRecord[]>();
+  for (const record of records) {
+    const key = record.preset || "(unknown)";
+    const bucket = byPreset.get(key) ?? [];
+    bucket.push(record);
+    byPreset.set(key, bucket);
+  }
+  const stats: PresetStats[] = [];
+  for (const [preset, runs] of byPreset) {
+    const running = runs.filter((r) => r.status === "running");
+    const completed = runs.filter((r) => r.status === "completed");
+    const failed = runs.filter(
+      (r) => r.status === "failed" || r.status === "timed_out",
+    );
+    const stopped = runs.filter((r) => r.status === "stopped");
+    const finished = runs.length - running.length;
+    let costUsd = 0;
+    for (const run of runs) {
+      const lines = journalForRun(run.run_id);
+      costUsd += collectUsage(lines, run.run_id).totals.costUsd;
+    }
+    const finishedRuns = runs.filter((r) => r.status !== "running");
+    stats.push({
+      preset,
+      runs: runs.length,
+      running: running.length,
+      completed: completed.length,
+      failed: failed.length,
+      stopped: stopped.length,
+      successRate: finished > 0 ? completed.length / finished : null,
+      avgIterations: average(finishedRuns.map((r) => r.iteration)),
+      avgDurationS: average(
+        finishedRuns
+          .map((r) => durationSeconds(r))
+          .filter((d): d is number => d !== null),
+      ),
+      costUsd: Math.round(costUsd * 1e6) / 1e6,
+    });
+  }
+  stats.sort((a, b) => b.runs - a.runs || a.preset.localeCompare(b.preset));
+  return stats;
+}
+
+export function renderStats(projectDir: string, stats: PresetStats[]): string {
+  if (stats.length === 0) {
+    return `No runs recorded yet for ${projectDir}. Start one with \`autoloop run <preset>\`.`;
+  }
+  const header = [
+    "preset",
+    "runs",
+    "ok",
+    "fail",
+    "stop",
+    "live",
+    "success",
+    "avg_iters",
+    "avg_secs",
+    "cost_usd",
+  ];
+  const rows = stats.map((s) => [
+    s.preset,
+    String(s.runs),
+    String(s.completed),
+    String(s.failed),
+    String(s.stopped),
+    String(s.running),
+    s.successRate === null ? "-" : `${Math.round(s.successRate * 100)}%`,
+    s.avgIterations === null ? "-" : s.avgIterations.toFixed(1),
+    s.avgDurationS === null ? "-" : String(Math.round(s.avgDurationS)),
+    s.costUsd > 0 ? s.costUsd.toFixed(4) : "-",
+  ]);
+  const totalRuns = stats.reduce((acc, s) => acc + s.runs, 0);
+  const totalCost = stats.reduce((acc, s) => acc + s.costUsd, 0);
+  const lines = alignColumns([header, ...rows]);
+  return [
+    `## Run stats — ${projectDir}`,
+    "",
+    ...lines,
+    "",
+    `totals: ${totalRuns} run(s) across ${stats.length} preset(s)` +
+      (totalCost > 0 ? `, $${totalCost.toFixed(4)} journaled cost` : ""),
+  ].join("\n");
+}
+
+function durationSeconds(record: RunRecord): number | null {
+  const start = Date.parse(record.created_at);
+  const end = Date.parse(record.updated_at);
+  if (Number.isNaN(start) || Number.isNaN(end) || end < start) return null;
+  return (end - start) / 1000;
+}
+
+function average(values: number[]): number | null {
+  const usable = values.filter((v) => Number.isFinite(v));
+  if (usable.length === 0) return null;
+  return usable.reduce((acc, v) => acc + v, 0) / usable.length;
+}
+
+function alignColumns(rows: string[][]): string[] {
+  const widths: number[] = [];
+  for (const row of rows) {
+    row.forEach((cell, i) => {
+      widths[i] = Math.max(widths[i] ?? 0, cell.length);
+    });
+  }
+  return rows.map((row) =>
+    row
+      .map((cell, i) => cell.padEnd(widths[i]))
+      .join("  ")
+      .trimEnd(),
+  );
+}
+
+function printStatsUsage(): void {
+  console.log("Usage: autoloop stats [project-dir] [--json]");
+  console.log("");
+  console.log("Per-preset analytics across all recorded runs: completion");
+  console.log("counts, success rate, average iterations and duration, and");
+  console.log("total journaled cost (for backends that report usage).");
+}
+
+function resolveRuntimeProjectDir(): string {
+  return process.env.AUTOLOOP_PROJECT_DIR || ".";
+}

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -6,12 +6,22 @@ export function dispatchTask(args: string[]): boolean {
 
   switch (sub) {
     case "add": {
-      const text = args.slice(1).join(" ");
-      if (!text || text === "--help") {
-        console.log("Usage: autoloop task add <text...>");
+      const parsed = parseAddArgs(args.slice(1));
+      if (!parsed || parsed.help) {
+        console.log(
+          "Usage: autoloop task add [--priority|-p <high|normal|low>] [--soft] <text...>",
+        );
         return true;
       }
-      const id = tasks.addTask(resolveRuntimeProjectDir(), text, "manual");
+      const id = tasks.addTask(
+        resolveRuntimeProjectDir(),
+        parsed.text,
+        "manual",
+        {
+          priority: parsed.priority,
+          soft: parsed.soft,
+        },
+      );
       console.log(id);
       return true;
     }
@@ -66,6 +76,45 @@ export function dispatchTask(args: string[]): boolean {
       printTaskUsage();
       return true;
   }
+}
+
+interface ParsedAdd {
+  text: string;
+  priority?: tasks.TaskPriority;
+  soft: boolean;
+  help: boolean;
+}
+
+// Returns undefined on invalid input (missing text, bad/missing priority value).
+function parseAddArgs(args: string[]): ParsedAdd | undefined {
+  let priority: tasks.TaskPriority | undefined;
+  let soft = false;
+  let help = false;
+  const textParts: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--help") {
+      help = true;
+      continue;
+    }
+    if (arg === "--soft") {
+      soft = true;
+      continue;
+    }
+    if (arg === "--priority" || arg === "-p") {
+      i += 1;
+      const value = tasks.parsePriority(args[i] ?? "");
+      if (!value) return undefined;
+      priority = value;
+      continue;
+    }
+    textParts.push(arg);
+  }
+
+  const text = textParts.join(" ");
+  if (!text && !help) return undefined;
+  return { text, priority, soft, help };
 }
 
 function resolveRuntimeProjectDir(): string {

--- a/packages/cli/src/commands/worktree.ts
+++ b/packages/cli/src/commands/worktree.ts
@@ -1,8 +1,12 @@
 import { join } from "node:path";
 import { parseFlag } from "@mobrienv/autoloop-core";
-import type { MergeOpts } from "@mobrienv/autoloop-core/worktree";
+import type {
+  DiffWorktreeResult,
+  MergeOpts,
+} from "@mobrienv/autoloop-core/worktree";
 import {
   cleanWorktrees,
+  diffWorktree,
   isOrphanWorktree,
   listWorktreeMetas,
   mergeWorktree,
@@ -33,6 +37,18 @@ export function dispatchWorktree(args: string[]): void {
       return;
     }
     showWorktree(stateDir, runId);
+    return;
+  }
+
+  if (sub === "diff") {
+    const runId = args[1];
+    if (!runId || runId.startsWith("--")) {
+      console.log("Usage: autoloop worktree diff <run-id> [--patch] [--json]");
+      return;
+    }
+    const patch = args.includes("--patch");
+    const json = args.includes("--json");
+    doDiff(projectDir, stateDir, runId, { patch, json });
     return;
   }
 
@@ -119,6 +135,62 @@ function showWorktree(stateDir: string, runId: string): void {
   console.log(lines.join("\n"));
 }
 
+function doDiff(
+  projectDir: string,
+  stateDir: string,
+  runId: string,
+  opts: { patch: boolean; json: boolean },
+): void {
+  const metaDir = join(stateDir, "worktrees", runId);
+  if (!readMeta(metaDir)) {
+    console.log(`No worktree found for run ${runId}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  let result: DiffWorktreeResult;
+  try {
+    result = diffWorktree({
+      metaDir,
+      workDir: projectDir,
+      patch: opts.patch,
+    });
+  } catch (err: unknown) {
+    console.log(err instanceof Error ? err.message : String(err));
+    process.exitCode = 1;
+    return;
+  }
+
+  if (opts.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  console.log(field("Branch", result.branch));
+  console.log(field("Base", result.base));
+  console.log(
+    field(
+      "Changed",
+      `${result.filesChanged} file(s), +${result.insertions} -${result.deletions}`,
+    ),
+  );
+
+  if (result.files.length === 0) {
+    console.log("No changes between base and branch.");
+  } else {
+    console.log("");
+    console.log(`${"STATUS".padEnd(14)}PATH`);
+    for (const f of result.files) {
+      console.log(`${f.status.padEnd(14)}${f.path}`);
+    }
+  }
+
+  if (opts.patch && result.patch !== undefined) {
+    console.log("");
+    console.log(result.patch.replace(/\n$/, ""));
+  }
+}
+
 function doMerge(
   projectDir: string,
   stateDir: string,
@@ -178,6 +250,9 @@ function printWorktreeUsage(): void {
   console.log("  autoloop worktree list                    List worktrees");
   console.log(
     "  autoloop worktree show <run-id>           Show worktree details",
+  );
+  console.log(
+    "  autoloop worktree diff <run-id> [--patch] [--json]   Preview changes vs base",
   );
   console.log(
     "  autoloop worktree merge <run-id> [--strategy <squash|merge|rebase>]",

--- a/packages/cli/src/loops/json.ts
+++ b/packages/cli/src/loops/json.ts
@@ -1,0 +1,183 @@
+import {
+  mergedActiveRuns,
+  mergedFindRunByPrefix,
+  readMergedRegistry,
+} from "@mobrienv/autoloop-core/registry/discover";
+import type { RunRecord } from "@mobrienv/autoloop-core/registry/types";
+import {
+  categorizeRecords,
+  categorizeRuns,
+} from "@mobrienv/autoloop-core/runs-health";
+
+/** Result of a JSON command: text to print plus desired exit code. */
+export interface JsonResult {
+  output: string;
+  exitCode: number;
+}
+
+/**
+ * Project a run record down to the fields the list table shows.
+ * Worktree fields are only included when present.
+ */
+export function runSummary(r: RunRecord): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    run_id: r.run_id,
+    status: r.status,
+    preset: r.preset,
+    iteration: r.iteration,
+    max_iterations: r.max_iterations,
+    stop_reason: r.stop_reason,
+    latest_event: r.latest_event,
+    created_at: r.created_at,
+    updated_at: r.updated_at,
+    isolation_mode: r.isolation_mode,
+  };
+  if (r.worktree_name) out.worktree_name = r.worktree_name;
+  if (r.worktree_path) out.worktree_path = r.worktree_path;
+  if (r.worktree_merged !== undefined) out.worktree_merged = r.worktree_merged;
+  if (r.worktree_merged_at != null)
+    out.worktree_merged_at = r.worktree_merged_at;
+  if (r.worktree_merge_strategy)
+    out.worktree_merge_strategy = r.worktree_merge_strategy;
+  return out;
+}
+
+/**
+ * JSON equivalent of listRuns: array of run summaries.
+ * Mirrors the same selection/ordering as the human table.
+ */
+export function listRunsJson(stateDir: string, all: boolean): string {
+  const runs = all
+    ? readMergedRegistry(stateDir).sort((a, b) =>
+        b.updated_at.localeCompare(a.updated_at),
+      )
+    : mergedActiveRuns(stateDir);
+  return JSON.stringify(runs.map(runSummary), null, 2);
+}
+
+/**
+ * JSON equivalent of showRun: the full RunRecord plus a derived
+ * `health` bucket. Unknown/ambiguous ids produce an error object
+ * and exit code 1.
+ */
+export function showRunJson(stateDir: string, partial: string): JsonResult {
+  const result = mergedFindRunByPrefix(stateDir, partial);
+
+  if (result === undefined) {
+    return {
+      output: JSON.stringify(
+        { error: `No run matching '${partial}'.` },
+        null,
+        2,
+      ),
+      exitCode: 1,
+    };
+  }
+
+  if (Array.isArray(result)) {
+    return {
+      output: JSON.stringify(
+        {
+          error: `Ambiguous run ID '${partial}'.`,
+          matches: result.map((r: RunRecord) => r.run_id),
+        },
+        null,
+        2,
+      ),
+      exitCode: 1,
+    };
+  }
+
+  return {
+    output: JSON.stringify(
+      { ...result, health: healthBucketFor(result) },
+      null,
+      2,
+    ),
+    exitCode: 0,
+  };
+}
+
+/**
+ * JSON equivalent of showArtifacts: artifact paths for a run.
+ */
+export function artifactsJson(stateDir: string, partial: string): JsonResult {
+  const result = mergedFindRunByPrefix(stateDir, partial);
+
+  if (result === undefined) {
+    return {
+      output: JSON.stringify(
+        { error: `No run matching '${partial}'.` },
+        null,
+        2,
+      ),
+      exitCode: 1,
+    };
+  }
+
+  if (Array.isArray(result)) {
+    return {
+      output: JSON.stringify(
+        {
+          error: `Ambiguous run ID '${partial}'.`,
+          matches: result.map((r: RunRecord) => r.run_id),
+        },
+        null,
+        2,
+      ),
+      exitCode: 1,
+    };
+  }
+
+  return {
+    output: JSON.stringify(
+      {
+        run_id: result.run_id,
+        journal_file: result.journal_file,
+        state_dir: result.state_dir || stateDir,
+        work_dir: result.work_dir,
+      },
+      null,
+      2,
+    ),
+    exitCode: 0,
+  };
+}
+
+/**
+ * JSON equivalent of healthSummary: every bucket with counts and run ids.
+ * The JSON form always includes all buckets (verbose has no effect).
+ */
+export function healthJson(stateDir: string): string {
+  const h = categorizeRuns(stateDir);
+  const bucket = (runs: RunRecord[]) => ({
+    count: runs.length,
+    run_ids: runs.map((r) => r.run_id),
+  });
+  return JSON.stringify(
+    {
+      active: bucket(h.active),
+      watching: bucket(h.watching),
+      stuck: bucket(h.stuck),
+      recent_failed: bucket(h.recentFailed),
+      recent_completed: bucket(h.recentCompleted),
+    },
+    null,
+    2,
+  );
+}
+
+/**
+ * Derive the health bucket a single record falls into, or null when it
+ * lands outside every bucket (e.g. finished more than 24h ago).
+ * Categorization runs on a copy so the reported record is never mutated.
+ */
+function healthBucketFor(r: RunRecord): string | null {
+  const h = categorizeRecords([{ ...r }]);
+  if (h.stuck.length > 0) return "stuck";
+  if (h.watching.length > 0) return "watching";
+  if (h.active.length > 0) return "active";
+  if (h.recentFailed.length > 0) return "recent_failed";
+  if (h.recentCompleted.length > 0) return "recent_completed";
+  return null;
+}

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -7,7 +7,9 @@ import { dispatchChain } from "./commands/chain.js";
 import { dispatchConfig } from "./commands/config.js";
 import { dispatchControl } from "./commands/control.js";
 import { dispatchDashboard } from "./commands/dashboard.js";
+import { dispatchDoctor } from "./commands/doctor.js";
 import { dispatchGuide } from "./commands/guide.js";
+import { dispatchInit } from "./commands/init.js";
 import { dispatchInspect } from "./commands/inspect.js";
 import { dispatchKanban } from "./commands/kanban.js";
 import { dispatchList } from "./commands/list.js";
@@ -16,6 +18,7 @@ import { dispatchMemory } from "./commands/memory.js";
 import { dispatchPiAdapter } from "./commands/pi-adapter.js";
 import { dispatchRun } from "./commands/run.js";
 import { dispatchRuns } from "./commands/runs.js";
+import { dispatchStats } from "./commands/stats.js";
 import { dispatchTask } from "./commands/task.js";
 import { dispatchWorktree } from "./commands/worktree.js";
 import { printEmitUsage, printUsage } from "./usage.js";
@@ -90,6 +93,15 @@ async function dispatch(args: string[], argv: string[]): Promise<void> {
     case "runs":
       dispatchRuns(args.slice(1));
       return;
+    case "stats":
+      dispatchStats(args.slice(1));
+      return;
+    case "doctor":
+      dispatchDoctor(args.slice(1));
+      return;
+    case "init":
+      dispatchInit(args.slice(1));
+      return;
     case "chain":
       await dispatchChain(args.slice(1), selfCmd);
       return;
@@ -143,6 +155,9 @@ function isCliCommand(value: string): boolean {
     "list",
     "loops",
     "runs",
+    "stats",
+    "doctor",
+    "init",
     "chain",
     "pi-adapter",
     "branch-run",

--- a/packages/cli/src/usage.ts
+++ b/packages/cli/src/usage.ts
@@ -1,29 +1,38 @@
 import { joinCsv } from "@mobrienv/autoloop-core";
 import * as chains from "./chains.js";
+import { didYouMean } from "./cli/suggest.js";
 
 export function printUsage(): void {
   console.log("autoloop — autonomous LLM loop harness");
   console.log("");
   console.log("Usage:");
   console.log("  autoloop run <preset-name|preset-dir> [prompt...] [flags]");
+  console.log("  autoloop init [--preset <name>] [dir]");
   console.log("  autoloop emit <topic> [summary]");
   console.log(
     "  autoloop inspect <artifact> [selector] [project-dir] [--format <md|terminal|text|json|csv|graph>]",
   );
-  console.log("  autoloop memory <list|status|find|add|remove> [args]");
+  console.log(
+    "  autoloop memory <list|status|find|add|remove|compact|prune> [args]",
+  );
   console.log("  autoloop task <add|complete|update|remove|list> [args]");
-  console.log("  autoloop list");
-  console.log("  autoloop loops [--all]");
+  console.log("  autoloop list [--json]");
+  console.log("  autoloop loops [--all] [--json]");
   console.log("  autoloop loops show <run-id>");
   console.log("  autoloop loops artifacts <run-id>");
   console.log("  autoloop loops watch <run-id>");
-  console.log("  autoloop loops health [--verbose]");
+  console.log("  autoloop loops health [--verbose] [--json]");
   console.log(
     "  autoloop control <show|capabilities|interrupt|guide> <run-id>",
   );
-  console.log("  autoloop chain <list|run> [args]");
+  console.log("  autoloop chain list [project-dir]");
+  console.log(
+    "  autoloop chain run <name> [project-dir] [prompt...] [--dry-run] [--json]",
+  );
   console.log("  autoloop runs clean [--max-age <days>]");
-  console.log("  autoloop worktree <list|show|merge|clean> [args]");
+  console.log("  autoloop stats [project-dir] [--json]");
+  console.log("  autoloop doctor [project-dir] [--json]");
+  console.log("  autoloop worktree <list|show|diff|merge|clean> [args]");
   console.log("  autoloop config <show|set|unset|path> [args]");
   console.log("  autoloop dashboard [--port <port>]");
   console.log("  autoloop kanban [--port <port>]");
@@ -172,6 +181,9 @@ export function printInspectUsage(): void {
     "  metrics        [run_id]      md, terminal, csv, json terminal",
   );
   console.log(
+    "  usage          [--run]       terminal, json          terminal",
+  );
+  console.log(
     "  profiles       —             terminal                terminal",
   );
   console.log(
@@ -195,11 +207,15 @@ export function printMemoryUsage(): void {
   console.log("  autoloop memory add preference <category> <text...>");
   console.log("  autoloop memory add meta <key> <value...>");
   console.log("  autoloop memory remove <id> [reason...]");
+  console.log("  autoloop memory compact [project-dir]");
+  console.log("  autoloop memory prune --max-age <days> [project-dir]");
 }
 
 export function printTaskUsage(): void {
   console.log("Usage:");
-  console.log("  autoloop task add <text...>");
+  console.log(
+    "  autoloop task add [--priority|-p <high|normal|low>] [--soft] <text...>",
+  );
   console.log("  autoloop task complete <id>");
   console.log("  autoloop task update <id> <text...>");
   console.log("  autoloop task remove <id> [reason...]");
@@ -242,6 +258,8 @@ export function missingPresetError(): void {
 
 export function unknownPresetError(name: string): void {
   console.log(`error: preset \`${name}\` not found`);
+  const hint = didYouMean(name, chains.listKnownPresets());
+  if (hint) console.log(hint);
   console.log("");
   console.log(
     `The argument \`${name}\` is not a valid preset name or directory.`,

--- a/packages/cli/test/chains/dry-run.test.ts
+++ b/packages/cli/test/chains/dry-run.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { checkPlanBudget, defaultBudget } from "../../src/chains/budget.js";
+import { buildChainPlan, renderChainPlan } from "../../src/chains/dry-run.js";
+import type { ChainSpec } from "../../src/chains/types.js";
+
+const spec: ChainSpec = {
+  name: "nightly",
+  steps: [
+    { name: "autocode", presetDir: "/presets/autocode" },
+    {
+      name: "autoqa",
+      presetDir: "/presets/autoqa",
+      backendOverride: { kind: "pi", model: "opus" },
+    },
+  ],
+};
+
+describe("checkPlanBudget", () => {
+  it("accepts a chain within maxSteps", () => {
+    const result = checkPlanBudget(spec, defaultBudget());
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects a chain with more steps than maxSteps", () => {
+    const result = checkPlanBudget(spec, {
+      ...defaultBudget(),
+      maxSteps: 1,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("max_steps exceeded (2/1)");
+  });
+});
+
+describe("buildChainPlan", () => {
+  it("builds an ordered plan with resolved preset dirs", () => {
+    const plan = buildChainPlan(spec, defaultBudget());
+    expect(plan.chain).toBe("nightly");
+    expect(plan.steps).toEqual([
+      { index: 1, name: "autocode", presetDir: "/presets/autocode" },
+      {
+        index: 2,
+        name: "autoqa",
+        presetDir: "/presets/autoqa",
+        backendOverride: { kind: "pi", model: "opus" },
+      },
+    ]);
+    expect(plan.budget).toEqual(defaultBudget());
+    expect(plan.validation).toEqual({ ok: true });
+  });
+
+  it("omits backendOverride for steps without one", () => {
+    const plan = buildChainPlan(spec, defaultBudget());
+    expect("backendOverride" in plan.steps[0]).toBe(false);
+  });
+
+  it("flags budget violations in validation", () => {
+    const plan = buildChainPlan(spec, { ...defaultBudget(), maxSteps: 1 });
+    expect(plan.validation.ok).toBe(false);
+    expect(plan.validation.reason).toContain("max_steps exceeded");
+  });
+});
+
+describe("renderChainPlan", () => {
+  it("renders a valid plan as text", () => {
+    const text = renderChainPlan(buildChainPlan(spec, defaultBudget()));
+    expect(text).toContain("Chain: nightly");
+    expect(text).toContain("Steps (2):");
+    expect(text).toContain("1. autocode  /presets/autocode");
+    expect(text).toContain("2. autoqa  /presets/autoqa");
+    expect(text).toContain('backend={"kind":"pi","model":"opus"}');
+    expect(text).toContain(
+      "Budget: max_depth=5, max_steps=50, max_runtime_ms=3600000, " +
+        "max_children=10, max_consecutive_failures=3",
+    );
+    expect(text).toContain("Plan: OK");
+  });
+
+  it("renders an invalid plan with the violation reason", () => {
+    const text = renderChainPlan(
+      buildChainPlan(spec, { ...defaultBudget(), maxSteps: 1 }),
+    );
+    expect(text).toContain("Plan: INVALID");
+    expect(text).toContain("max_steps exceeded (2/1)");
+    expect(text).not.toContain("Plan: OK");
+  });
+});

--- a/packages/cli/test/chains/run-budget.test.ts
+++ b/packages/cli/test/chains/run-budget.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Verify root budget enforcement in runChain: maxSteps is checked before
+ * executing, and maxRuntimeMs stops the chain between steps. Budget stops
+ * are journaled via chain.complete with a budget_exceeded outcome.
+ */
+
+let journalLines: string[] = [];
+
+vi.mock("@mobrienv/autoloop-core/config", () => ({
+  loadProject: vi.fn(() => ({})),
+  get: vi.fn(() => "compact"),
+  stateDirPath: vi.fn(() => "/tmp/test-chain-budget-state"),
+  resolveJournalFile: vi.fn(() => "/tmp/test-chain-budget-journal"),
+  resolveProjectDir: vi.fn((_name: string) => null),
+  projectHasConfig: vi.fn(() => false),
+}));
+
+vi.mock("@mobrienv/autoloop-core/journal", () => ({
+  appendText: vi.fn((_file: string, line: string) => {
+    journalLines.push(line);
+  }),
+  readLines: vi.fn(() => []),
+  extractTopic: vi.fn(() => ""),
+  extractField: vi.fn(() => ""),
+}));
+
+vi.mock("@mobrienv/autoloop-harness", () => ({
+  run: vi.fn(() => ({
+    stopReason: "completion_event",
+    iterations: 1,
+    runId: "run-1",
+  })),
+}));
+
+vi.mock("@mobrienv/autoloop-core/isolation/resolve", () => ({
+  presetCategory: vi.fn(() => "code"),
+}));
+
+vi.mock("@mobrienv/autoloop-core", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@mobrienv/autoloop-core")>();
+  return {
+    ...actual,
+    generateCompactId: vi.fn(() => "chain-budget-1"),
+  };
+});
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    existsSync: vi.fn(() => false),
+    readdirSync: vi.fn(() => []),
+  };
+});
+
+import * as harness from "@mobrienv/autoloop-harness";
+import { defaultBudget } from "../../src/chains/budget.js";
+import { runChain } from "../../src/chains/run.js";
+import type { ChainSpec } from "../../src/chains/types.js";
+
+const twoStepSpec: ChainSpec = {
+  name: "budget-chain",
+  steps: [
+    { name: "autocode", presetDir: "/presets/autocode" },
+    { name: "autoqa", presetDir: "/presets/autoqa" },
+  ],
+};
+
+describe("runChain root budget enforcement", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    journalLines = [];
+  });
+
+  it("runs all steps when the budget permits", async () => {
+    const result = await runChain(twoStepSpec, ".", "autoloop", {});
+    expect(result.outcome).toBe("all_steps_complete");
+    expect(result.completed).toHaveLength(2);
+    expect(vi.mocked(harness.run)).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a chain whose step count exceeds maxSteps before running", async () => {
+    const budget = { ...defaultBudget(), maxSteps: 1 };
+    const result = await runChain(twoStepSpec, ".", "autoloop", {}, budget);
+
+    expect(result.outcome).toBe("budget_exceeded");
+    expect(result.failedReason).toBe(
+      "budget_exceeded:max_steps exceeded (2/1)",
+    );
+    expect(result.completed).toHaveLength(0);
+    expect(vi.mocked(harness.run)).not.toHaveBeenCalled();
+  });
+
+  it("stops between steps when maxRuntimeMs is exhausted", async () => {
+    const budget = { ...defaultBudget(), maxRuntimeMs: 0 };
+    const result = await runChain(twoStepSpec, ".", "autoloop", {}, budget);
+
+    expect(result.outcome).toBe("budget_exceeded");
+    expect(result.failedStep).toBe(2);
+    expect(result.failedReason).toMatch(
+      /^budget_exceeded:max_runtime_ms exceeded \(\d+ms\/0ms\)$/,
+    );
+    expect(result.completed).toHaveLength(1);
+    expect(vi.mocked(harness.run)).toHaveBeenCalledTimes(1);
+  });
+
+  it("journals budget stops via chain.complete with failed_reason", async () => {
+    const budget = { ...defaultBudget(), maxSteps: 1 };
+    await runChain(twoStepSpec, ".", "autoloop", {}, budget);
+
+    const complete = journalLines.find((l) => l.includes("chain.complete"));
+    expect(complete).toBeDefined();
+    expect(complete).toContain('"outcome": "budget_exceeded"');
+    expect(complete).toContain(
+      '"failed_reason": "budget_exceeded:max_steps exceeded (2/1)"',
+    );
+    // chain.start is still journaled so the rejection is visible in renders
+    expect(journalLines.some((l) => l.includes("chain.start"))).toBe(true);
+  });
+
+  it("does not add failed_reason to chain.complete on success", async () => {
+    await runChain(twoStepSpec, ".", "autoloop", {});
+    const complete = journalLines.find((l) => l.includes("chain.complete"));
+    expect(complete).toBeDefined();
+    expect(complete).toContain('"outcome": "all_steps_complete"');
+    expect(complete).not.toContain("failed_reason");
+  });
+});

--- a/packages/cli/test/cli/suggest.test.ts
+++ b/packages/cli/test/cli/suggest.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  didYouMean,
+  editDistance,
+  suggestClosest,
+} from "../../src/cli/suggest.js";
+
+describe("editDistance", () => {
+  it("handles equal and empty strings", () => {
+    expect(editDistance("abc", "abc")).toBe(0);
+    expect(editDistance("", "abc")).toBe(3);
+    expect(editDistance("abc", "")).toBe(3);
+  });
+
+  it("computes substitutions, insertions, deletions", () => {
+    expect(editDistance("kitten", "sitting")).toBe(3);
+    expect(editDistance("loop", "loops")).toBe(1);
+  });
+});
+
+describe("suggestClosest", () => {
+  const commands = ["loops", "inspect", "worktree", "doctor", "stats"];
+
+  it("suggests near-misses", () => {
+    expect(suggestClosest("lops", commands)).toBe("loops");
+    expect(suggestClosest("inspct", commands)).toBe("inspect");
+  });
+
+  it("prefers prefix matches", () => {
+    expect(suggestClosest("doc", commands)).toBe("doctor");
+  });
+
+  it("returns null for distant inputs and empty input", () => {
+    expect(suggestClosest("zzzzzzzz", commands)).toBeNull();
+    expect(suggestClosest("", commands)).toBeNull();
+  });
+});
+
+describe("didYouMean", () => {
+  it("renders the hint line", () => {
+    expect(didYouMean("autcode", ["autocode"])).toBe(
+      "Did you mean `autocode`?",
+    );
+  });
+  it("renders nothing when no candidate is close", () => {
+    expect(didYouMean("qqqqqq", ["autocode"])).toBe("");
+  });
+});

--- a/packages/cli/test/commands/chain-dry-run.test.ts
+++ b/packages/cli/test/commands/chain-dry-run.test.ts
@@ -1,0 +1,145 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Verify `autoloop chain run <name> --dry-run [--json]`: prints the plan
+ * without executing anything, and sets process.exitCode = 1 when the plan
+ * violates the budget.
+ */
+
+// Mock harness so any accidental execution is observable (and side-effect free)
+vi.mock("@mobrienv/autoloop-harness", () => ({
+  run: vi.fn(() => ({ stopReason: "completion_event", iterations: 1 })),
+}));
+
+import * as harness from "@mobrienv/autoloop-harness";
+import { dispatchChain } from "../../src/commands/chain.js";
+
+const VALID_TOML = `
+[[chain]]
+name = "ship"
+steps = ["autocode", "autoqa"]
+
+[[chain]]
+name = "solo"
+
+[[chain.step]]
+preset = "autocode"
+backend = { kind = "pi", model = "opus" }
+`;
+
+const OVER_BUDGET_TOML = `
+[budget]
+max_steps = 1
+
+[[chain]]
+name = "ship"
+steps = ["autocode", "autoqa"]
+`;
+
+describe("chain run --dry-run", () => {
+  let projectDir: string;
+  let logged: string[];
+  let savedExitCode: typeof process.exitCode;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "autoloop-chain-dry-"));
+    logged = [];
+    savedExitCode = process.exitCode;
+    process.exitCode = undefined;
+    vi.spyOn(console, "log").mockImplementation((msg: string) => {
+      logged.push(String(msg));
+    });
+  });
+
+  afterEach(() => {
+    process.exitCode = savedExitCode;
+    vi.restoreAllMocks();
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it("prints a text plan and exits 0 for a valid chain", async () => {
+    writeFileSync(join(projectDir, "chains.toml"), VALID_TOML);
+    await dispatchChain(["run", "ship", projectDir, "--dry-run"], "autoloop");
+
+    const output = logged.join("\n");
+    expect(output).toContain("Chain: ship");
+    expect(output).toContain("Steps (2):");
+    expect(output).toContain("1. autocode");
+    expect(output).toContain("2. autoqa");
+    expect(output).toContain("Budget: max_depth=5, max_steps=50");
+    expect(output).toContain("Plan: OK");
+    expect(process.exitCode).toBeUndefined();
+    expect(vi.mocked(harness.run)).not.toHaveBeenCalled();
+  });
+
+  it("includes backend overrides in the text plan", async () => {
+    writeFileSync(join(projectDir, "chains.toml"), VALID_TOML);
+    await dispatchChain(["run", "solo", projectDir, "--dry-run"], "autoloop");
+
+    const output = logged.join("\n");
+    expect(output).toContain('backend={"kind":"pi","model":"opus"}');
+  });
+
+  it("prints a machine-readable plan with --json", async () => {
+    writeFileSync(join(projectDir, "chains.toml"), VALID_TOML);
+    await dispatchChain(
+      ["run", "ship", projectDir, "--dry-run", "--json"],
+      "autoloop",
+    );
+
+    expect(logged).toHaveLength(1);
+    const plan = JSON.parse(logged[0]);
+    expect(plan.chain).toBe("ship");
+    expect(plan.steps).toHaveLength(2);
+    expect(plan.steps[0].index).toBe(1);
+    expect(plan.steps[0].name).toBe("autocode");
+    expect(typeof plan.steps[0].presetDir).toBe("string");
+    expect(plan.budget.maxSteps).toBe(50);
+    expect(plan.validation.ok).toBe(true);
+    expect(vi.mocked(harness.run)).not.toHaveBeenCalled();
+  });
+
+  it("sets exit code 1 when the plan violates the budget", async () => {
+    writeFileSync(join(projectDir, "chains.toml"), OVER_BUDGET_TOML);
+    await dispatchChain(["run", "ship", projectDir, "--dry-run"], "autoloop");
+
+    const output = logged.join("\n");
+    expect(output).toContain("Plan: INVALID");
+    expect(output).toContain("max_steps exceeded (2/1)");
+    expect(process.exitCode).toBe(1);
+    expect(vi.mocked(harness.run)).not.toHaveBeenCalled();
+  });
+
+  it("reports budget violations in --json output", async () => {
+    writeFileSync(join(projectDir, "chains.toml"), OVER_BUDGET_TOML);
+    await dispatchChain(
+      ["run", "ship", projectDir, "--dry-run", "--json"],
+      "autoloop",
+    );
+
+    const plan = JSON.parse(logged[0]);
+    expect(plan.budget.maxSteps).toBe(1);
+    expect(plan.validation.ok).toBe(false);
+    expect(plan.validation.reason).toContain("max_steps exceeded");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("sets exit code 1 when the chain is not found", async () => {
+    writeFileSync(join(projectDir, "chains.toml"), VALID_TOML);
+    await dispatchChain(["run", "nope", projectDir, "--dry-run"], "autoloop");
+
+    expect(logged.join("\n")).toContain("not found in chains.toml");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("does not change exit code for a missing chain without --dry-run", async () => {
+    writeFileSync(join(projectDir, "chains.toml"), VALID_TOML);
+    await dispatchChain(["run", "nope", projectDir], "autoloop");
+
+    expect(logged.join("\n")).toContain("not found in chains.toml");
+    expect(process.exitCode).toBeUndefined();
+  });
+});

--- a/packages/cli/test/commands/doctor.test.ts
+++ b/packages/cli/test/commands/doctor.test.ts
@@ -1,0 +1,146 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  dispatchDoctor,
+  renderDoctorReport,
+  runDoctorChecks,
+} from "../../src/commands/doctor.js";
+
+function registryLine(overrides: Record<string, unknown>): string {
+  return JSON.stringify({
+    run_id: "run-x",
+    status: "completed",
+    preset: "autocode",
+    created_at: "2026-06-01T00:00:00Z",
+    updated_at: "2026-06-01T00:10:00Z",
+    iteration: 3,
+    ...overrides,
+  });
+}
+
+describe("doctor", () => {
+  let projectDir: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "autoloop-doctor-test-"));
+    stateDir = join(projectDir, ".autoloop");
+    mkdirSync(stateDir, { recursive: true });
+  });
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  function check(name: string) {
+    const found = runDoctorChecks(projectDir).find((c) => c.name === name);
+    expect(found, `check ${name} should exist`).toBeDefined();
+    return found as { name: string; status: string; detail: string };
+  }
+
+  it("reports ok for a healthy empty state dir", () => {
+    expect(check("node").status).toBe("ok");
+    expect(check("state").status).toBe("ok");
+    expect(check("registry").status).toBe("ok");
+    expect(check("runs").status).toBe("ok");
+    expect(check("waves").status).toBe("ok");
+    expect(check("worktrees").status).toBe("ok");
+  });
+
+  it("warns when the state dir does not exist yet", () => {
+    rmSync(stateDir, { recursive: true, force: true });
+    const checks = runDoctorChecks(projectDir);
+    const state = checks.find((c) => c.name === "state");
+    expect(state?.status).toBe("warn");
+    // State-tree checks are skipped when there is no state tree.
+    expect(checks.find((c) => c.name === "registry")).toBeUndefined();
+  });
+
+  it("flags runs marked running whose process is gone", () => {
+    writeFileSync(
+      join(stateDir, "registry.jsonl"),
+      `${registryLine({ run_id: "dead-run", status: "running", pid: 2 ** 30 })}\n`,
+    );
+    const runs = check("runs");
+    expect(runs.status).toBe("warn");
+    expect(runs.detail).toContain("dead-run");
+  });
+
+  it("accepts a running run whose process is alive", () => {
+    writeFileSync(
+      join(stateDir, "registry.jsonl"),
+      `${registryLine({ run_id: "live-run", status: "running", pid: process.pid })}\n`,
+    );
+    expect(check("runs").status).toBe("ok");
+  });
+
+  it("warns about malformed registry lines", () => {
+    writeFileSync(
+      join(stateDir, "registry.jsonl"),
+      `${registryLine({})}\nnot-json\n`,
+    );
+    const registry = check("registry");
+    expect(registry.status).toBe("warn");
+    expect(registry.detail).toContain("1 malformed");
+  });
+
+  it("flags a stale wave marker with no running runs", () => {
+    mkdirSync(join(stateDir, "waves"), { recursive: true });
+    writeFileSync(join(stateDir, "waves", "active"), "wave-1");
+    const waves = check("waves");
+    expect(waves.status).toBe("warn");
+    expect(waves.detail).toContain("stale wave marker");
+  });
+
+  it("accepts a wave marker while a run is alive", () => {
+    mkdirSync(join(stateDir, "waves"), { recursive: true });
+    writeFileSync(join(stateDir, "waves", "active"), "wave-1");
+    writeFileSync(
+      join(stateDir, "registry.jsonl"),
+      `${registryLine({ status: "running", pid: process.pid })}\n`,
+    );
+    expect(check("waves").status).toBe("ok");
+  });
+
+  it("renders a summary line with counts", () => {
+    const report = renderDoctorReport(projectDir, [
+      { name: "a", status: "ok", detail: "fine" },
+      { name: "b", status: "warn", detail: "meh" },
+      { name: "c", status: "fail", detail: "bad" },
+    ]);
+    expect(report).toContain("autoloop doctor");
+    expect(report).toContain("1 failure(s), 1 warning(s)");
+  });
+
+  it("dispatch prints JSON with --json", () => {
+    const lines: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((...args) => {
+      lines.push(args.join(" "));
+    });
+    dispatchDoctor([projectDir, "--json"]);
+    const parsed = JSON.parse(lines.join("\n"));
+    expect(parsed.projectDir).toBe(projectDir);
+    expect(Array.isArray(parsed.checks)).toBe(true);
+    expect(parsed.checks.length).toBeGreaterThan(0);
+  });
+
+  it("dispatch prints a human report by default", () => {
+    const lines: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((...args) => {
+      lines.push(args.join(" "));
+    });
+    dispatchDoctor([projectDir]);
+    expect(lines.join("\n")).toContain("autoloop doctor");
+  });
+
+  it("dispatch shows usage with --help", () => {
+    const lines: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((...args) => {
+      lines.push(args.join(" "));
+    });
+    dispatchDoctor(["--help"]);
+    expect(lines.join("\n")).toContain("Usage: autoloop doctor");
+  });
+});

--- a/packages/cli/test/commands/init.test.ts
+++ b/packages/cli/test/commands/init.test.ts
@@ -1,0 +1,202 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as config from "@mobrienv/autoloop-core/config";
+import { loadTopology } from "@mobrienv/autoloop-core/topology";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { dispatchInit } from "../../src/commands/init.js";
+
+describe("init", () => {
+  let dir: string;
+  let logs: string[];
+  let errors: string[];
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "autoloop-init-test-"));
+    logs = [];
+    errors = [];
+    vi.spyOn(console, "log").mockImplementation((...args) => {
+      logs.push(args.join(" "));
+    });
+    vi.spyOn(console, "error").mockImplementation((...args) => {
+      errors.push(args.join(" "));
+    });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+    process.exitCode = 0;
+  });
+
+  describe("project init", () => {
+    it("writes a parseable starter autoloops.toml with next steps", () => {
+      dispatchInit([dir]);
+      const path = join(dir, "autoloops.toml");
+      expect(existsSync(path)).toBe(true);
+
+      const cfg = config.load(path);
+      expect(config.get(cfg, "event_loop.max_iterations", "")).toBe("3");
+      expect(config.get(cfg, "event_loop.completion_event", "")).toBe(
+        "task.complete",
+      );
+      expect(config.get(cfg, "event_loop.completion_promise", "")).toBe(
+        "LOOP_COMPLETE",
+      );
+      expect(config.get(cfg, "event_loop.stall_iterations", "")).toBe("0");
+      expect(config.get(cfg, "event_loop.max_cost_usd", "")).toBe("0");
+      expect(config.get(cfg, "backend.command", "")).toBe("claude");
+      expect(config.get(cfg, "backend.timeout_ms", "")).toBe("300000");
+      expect(config.get(cfg, "memory.prompt_budget_chars", "")).toBe("8000");
+
+      const out = logs.join("\n");
+      expect(out).toContain(`created ${path}`);
+      expect(out).toContain("autoloop run autocode");
+      expect(out).toContain("autoloop list");
+      expect(out).toContain("autoloop doctor");
+    });
+
+    it("never overwrites an existing autoloops.toml", () => {
+      const path = join(dir, "autoloops.toml");
+      writeFileSync(path, "# custom\n");
+      dispatchInit([dir]);
+      expect(readFileSync(path, "utf-8")).toBe("# custom\n");
+      expect(logs.join("\n")).toContain(`${path} already exists, skipped`);
+    });
+
+    it("creates .gitignore with .autoloop/ in a git repo", () => {
+      mkdirSync(join(dir, ".git"));
+      dispatchInit([dir]);
+      expect(readFileSync(join(dir, ".gitignore"), "utf-8")).toBe(
+        ".autoloop/\n",
+      );
+    });
+
+    it("appends .autoloop/ to an existing .gitignore without duplicating", () => {
+      mkdirSync(join(dir, ".git"));
+      writeFileSync(join(dir, ".gitignore"), "node_modules/"); // no trailing \n
+      dispatchInit([dir]);
+      const text = readFileSync(join(dir, ".gitignore"), "utf-8");
+      expect(text).toBe("node_modules/\n.autoloop/\n");
+
+      dispatchInit([dir]); // re-run must not duplicate
+      const again = readFileSync(join(dir, ".gitignore"), "utf-8");
+      expect(again.match(/\.autoloop\//g)).toHaveLength(1);
+      expect(logs.join("\n")).toContain("already ignores .autoloop/");
+    });
+
+    it("does not create .gitignore outside a git repo", () => {
+      dispatchInit([dir]);
+      expect(existsSync(join(dir, ".gitignore"))).toBe(false);
+    });
+
+    it("defaults the directory argument to '.'", () => {
+      const prev = process.cwd();
+      process.chdir(dir);
+      try {
+        dispatchInit([]);
+      } finally {
+        process.chdir(prev);
+      }
+      expect(existsSync(join(dir, "autoloops.toml"))).toBe(true);
+    });
+  });
+
+  describe("preset scaffold", () => {
+    it("scaffolds a preset that config and topology parsers accept", () => {
+      dispatchInit(["--preset", "myloop", dir]);
+      const presetDir = join(dir, "presets", "myloop");
+      for (const f of [
+        "autoloops.toml",
+        "harness.md",
+        "topology.toml",
+        "README.md",
+        join("roles", "builder.md"),
+        join("roles", "critic.md"),
+      ]) {
+        expect(existsSync(join(presetDir, f)), `${f} should exist`).toBe(true);
+      }
+
+      // Leading description comment for `autoloop list`.
+      const toml = readFileSync(join(presetDir, "autoloops.toml"), "utf-8");
+      expect(toml.startsWith("# myloop — ")).toBe(true);
+
+      // Config must load through the real parser.
+      const cfg = config.load(join(presetDir, "autoloops.toml"));
+      expect(config.get(cfg, "event_loop.completion_event", "")).toBe(
+        "task.complete",
+      );
+      expect(config.get(cfg, "harness.instructions_file", "")).toBe(
+        "harness.md",
+      );
+      expect(config.projectHasConfig(presetDir)).toBe(true);
+
+      // Topology must load through the real parser with both roles wired.
+      const topology = loadTopology(presetDir);
+      expect(topology.name).toBe("myloop");
+      expect(topology.completion).toBe("task.complete");
+      expect(topology.roles.map((r) => r.id)).toEqual(["builder", "critic"]);
+      expect(topology.handoff["loop.start"]).toEqual(["builder"]);
+      expect(topology.handoff["review.ready"]).toEqual(["critic"]);
+      expect(topology.handoff["review.rejected"]).toEqual(["builder"]);
+      // Role prompts resolve from prompt_file on disk.
+      expect(topology.roles[0].prompt).toContain("builder");
+      expect(topology.roles[1].emits).toContain("task.complete");
+
+      expect(logs.join("\n")).toContain(
+        'autoloop run ./presets/myloop "describe your objective"',
+      );
+    });
+
+    it("re-running skips every existing file without overwriting", () => {
+      dispatchInit(["--preset", "myloop", dir]);
+      const harness = join(dir, "presets", "myloop", "harness.md");
+      writeFileSync(harness, "customized\n");
+      logs.length = 0;
+      dispatchInit(["--preset", "myloop", dir]);
+      expect(readFileSync(harness, "utf-8")).toBe("customized\n");
+      const skips = logs.filter((l) => l.includes("already exists, skipped"));
+      expect(skips).toHaveLength(6);
+    });
+
+    it("rejects preset names with path separators", () => {
+      dispatchInit(["--preset", "../evil", dir]);
+      expect(errors.join("\n")).toContain("invalid preset name");
+      expect(process.exitCode).toBe(1);
+      expect(existsSync(join(dir, "presets"))).toBe(false);
+    });
+
+    it("errors when --preset has no name", () => {
+      dispatchInit(["--preset"]);
+      expect(errors.join("\n")).toContain("--preset requires a name");
+      expect(process.exitCode).toBe(1);
+    });
+  });
+
+  it("prints usage with --help", () => {
+    dispatchInit(["--help"]);
+    expect(logs.join("\n")).toContain("Usage: autoloop init");
+    expect(logs.join("\n")).toContain("--preset");
+  });
+
+  it("errors politely on unknown flags", () => {
+    dispatchInit(["--bogus", dir]);
+    expect(errors.join("\n")).toContain("unknown flag `--bogus`");
+    expect(errors.join("\n")).toContain("--help");
+    expect(process.exitCode).toBe(1);
+    expect(existsSync(join(dir, "autoloops.toml"))).toBe(false);
+  });
+
+  it("errors on extra positional arguments", () => {
+    dispatchInit([dir, "extra"]);
+    expect(errors.join("\n")).toContain("at most one directory");
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/packages/cli/test/commands/list.test.ts
+++ b/packages/cli/test/commands/list.test.ts
@@ -50,6 +50,27 @@ describe("dispatchList", () => {
     }
   });
 
+  it("prints a JSON array of {name, description} with --json", () => {
+    const lines: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((...args) => {
+      lines.push(args.join(" "));
+    });
+    dispatchList(["--json"], bundleRoot);
+    vi.restoreAllMocks();
+
+    const parsed = JSON.parse(lines.join("\n"));
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.length).toBeGreaterThan(0);
+    for (const entry of parsed) {
+      expect(Object.keys(entry).sort()).toEqual(["description", "name"]);
+      expect(typeof entry.name).toBe("string");
+      expect(typeof entry.description).toBe("string");
+    }
+    expect(parsed.some((e: { name: string }) => e.name === "autocode")).toBe(
+      true,
+    );
+  });
+
   it("prints help with --help", () => {
     const lines: string[] = [];
     vi.spyOn(console, "log").mockImplementation((...args) => {

--- a/packages/cli/test/commands/loops-json.test.ts
+++ b/packages/cli/test/commands/loops-json.test.ts
@@ -1,0 +1,156 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { RunRecord } from "@mobrienv/autoloop-core/registry/types";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { dispatchLoops } from "../../src/commands/loops.js";
+
+function makeRecord(id: string, overrides: Partial<RunRecord> = {}): RunRecord {
+  return {
+    run_id: id,
+    status: "completed",
+    preset: "autocode",
+    objective: "test objective",
+    trigger: "cli",
+    project_dir: "/tmp/proj",
+    work_dir: "/tmp/proj",
+    state_dir: "/tmp/proj/.autoloop",
+    journal_file: "/tmp/proj/.autoloop/journal.jsonl",
+    parent_run_id: "",
+    backend: "mock",
+    backend_args: [],
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T01:00:00Z",
+    iteration: 5,
+    max_iterations: 10,
+    stop_reason: "completion",
+    latest_event: "loop.complete",
+    isolation_mode: "shared",
+    worktree_name: "",
+    worktree_path: "",
+    ...overrides,
+  };
+}
+
+let projectDir: string;
+let lines: string[];
+let origProjectDir: string | undefined;
+let origExitCode: typeof process.exitCode;
+
+beforeEach(() => {
+  projectDir = join(
+    tmpdir(),
+    `loops-json-cmd-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(join(projectDir, ".autoloop"), { recursive: true });
+  origProjectDir = process.env.AUTOLOOP_PROJECT_DIR;
+  process.env.AUTOLOOP_PROJECT_DIR = projectDir;
+  origExitCode = process.exitCode;
+  lines = [];
+  vi.spyOn(console, "log").mockImplementation((...args) => {
+    lines.push(args.join(" "));
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.exitCode = origExitCode;
+  if (origProjectDir === undefined) delete process.env.AUTOLOOP_PROJECT_DIR;
+  else process.env.AUTOLOOP_PROJECT_DIR = origProjectDir;
+  rmSync(projectDir, { recursive: true, force: true });
+});
+
+function writeRecords(records: RunRecord[]): void {
+  writeFileSync(
+    join(projectDir, ".autoloop", "registry.jsonl"),
+    `${records.map((r) => JSON.stringify(r)).join("\n")}\n`,
+  );
+}
+
+function output(): string {
+  return lines.join("\n");
+}
+
+describe("dispatchLoops --json", () => {
+  it("loops --json prints a JSON array of active runs", () => {
+    writeRecords([
+      makeRecord("run-live", { status: "running" }),
+      makeRecord("run-done"),
+    ]);
+    dispatchLoops(["--json"]);
+    const parsed = JSON.parse(output());
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].run_id).toBe("run-live");
+  });
+
+  it("loops --json prints [] when there are no runs", () => {
+    dispatchLoops(["--json"]);
+    expect(JSON.parse(output())).toEqual([]);
+  });
+
+  it("accepts --all and --json in either order", () => {
+    writeRecords([
+      makeRecord("run-live", { status: "running" }),
+      makeRecord("run-done"),
+    ]);
+    dispatchLoops(["--all", "--json"]);
+    const first = output();
+    lines = [];
+    dispatchLoops(["--json", "--all"]);
+    expect(output()).toBe(first);
+    const parsed = JSON.parse(first);
+    expect(parsed.map((r: { run_id: string }) => r.run_id).sort()).toEqual([
+      "run-done",
+      "run-live",
+    ]);
+  });
+
+  it("loops show <id> --json prints the full record", () => {
+    writeRecords([makeRecord("run-show-1")]);
+    dispatchLoops(["show", "run-show-1", "--json"]);
+    const parsed = JSON.parse(output());
+    expect(parsed.run_id).toBe("run-show-1");
+    expect(parsed.objective).toBe("test objective");
+    expect(parsed).toHaveProperty("health");
+    expect(process.exitCode).toBe(origExitCode);
+  });
+
+  it("loops show <unknown> --json prints an error object and sets exit code 1", () => {
+    writeRecords([makeRecord("run-show-1")]);
+    dispatchLoops(["show", "zzz", "--json"]);
+    const parsed = JSON.parse(output());
+    expect(parsed.error).toContain("No run matching");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("loops artifacts <id> --json prints artifact paths", () => {
+    writeRecords([makeRecord("run-art-1")]);
+    dispatchLoops(["artifacts", "run-art-1", "--json"]);
+    const parsed = JSON.parse(output());
+    expect(parsed.run_id).toBe("run-art-1");
+    expect(parsed.journal_file).toBe("/tmp/proj/.autoloop/journal.jsonl");
+  });
+
+  it("loops health --json prints bucket counts and run ids", () => {
+    writeRecords([
+      makeRecord("run-live", {
+        status: "running",
+        updated_at: new Date().toISOString(),
+      }),
+    ]);
+    dispatchLoops(["health", "--json"]);
+    const parsed = JSON.parse(output());
+    expect(parsed.active).toEqual({ count: 1, run_ids: ["run-live"] });
+    expect(parsed.stuck).toEqual({ count: 0, run_ids: [] });
+  });
+
+  it("keeps the human table output unchanged without --json", () => {
+    writeRecords([makeRecord("run-live", { status: "running" })]);
+    dispatchLoops([]);
+    expect(output()).toContain("RUN ID");
+    expect(output()).toContain("run-live");
+    lines = [];
+    dispatchLoops(["health"]);
+    expect(output()).toMatch(/^(All clear|Health):?/);
+  });
+});

--- a/packages/cli/test/commands/memory.test.ts
+++ b/packages/cli/test/commands/memory.test.ts
@@ -1,0 +1,153 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { dispatchMemory } from "../../src/commands/memory.js";
+
+let projectDir: string;
+let memFile: string;
+let lines: string[];
+let savedMemoryFileEnv: string | undefined;
+let savedStateDirEnv: string | undefined;
+
+function writeMem(entries: string[]) {
+  mkdirSync(join(projectDir, ".autoloop"), { recursive: true });
+  writeFileSync(memFile, `${entries.join("\n")}\n`, "utf-8");
+}
+
+function learning(id: string, text: string, created?: string): string {
+  const createdField = created ? `, "created": "${created}"` : "";
+  return `{"id": "${id}", "type": "learning", "text": "${text}", "source": "s"${createdField}}`;
+}
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), "autoloop-memory-cli-test-"));
+  memFile = join(projectDir, ".autoloop", "memory.jsonl");
+  savedMemoryFileEnv = process.env.AUTOLOOP_MEMORY_FILE;
+  savedStateDirEnv = process.env.AUTOLOOP_STATE_DIR;
+  delete process.env.AUTOLOOP_MEMORY_FILE;
+  delete process.env.AUTOLOOP_STATE_DIR;
+  lines = [];
+  vi.spyOn(console, "log").mockImplementation((...args) => {
+    lines.push(args.join(" "));
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (savedMemoryFileEnv === undefined) {
+    delete process.env.AUTOLOOP_MEMORY_FILE;
+  } else {
+    process.env.AUTOLOOP_MEMORY_FILE = savedMemoryFileEnv;
+  }
+  if (savedStateDirEnv === undefined) {
+    delete process.env.AUTOLOOP_STATE_DIR;
+  } else {
+    process.env.AUTOLOOP_STATE_DIR = savedStateDirEnv;
+  }
+  rmSync(projectDir, { recursive: true, force: true });
+});
+
+describe("memory compact", () => {
+  it("tombstones duplicates and lists removed ids", () => {
+    writeMem([
+      learning("mem-1", "always run lint"),
+      learning("mem-2", "always run lint"),
+      learning("mem-3", "other lesson"),
+    ]);
+    expect(dispatchMemory(["compact", projectDir])).toBe(true);
+    const output = lines.join("\n");
+    expect(output).toContain("Scanned 3 learnings");
+    expect(output).toContain("tombstoned 1 duplicate(s)");
+    expect(output).toContain("mem-2");
+    const content = readFileSync(memFile, "utf-8");
+    expect(content).toContain('"type": "tombstone"');
+    expect(content).toContain('"target_id": "mem-2"');
+  });
+
+  it("reports when no duplicates are found", () => {
+    writeMem([learning("mem-1", "unique lesson")]);
+    dispatchMemory(["compact", projectDir]);
+    expect(lines.join("\n")).toContain(
+      "Scanned 1 learnings; no duplicates found.",
+    );
+  });
+
+  it("shows usage with --help", () => {
+    dispatchMemory(["compact", "--help"]);
+    expect(lines.join("\n")).toContain(
+      "Usage: autoloop memory compact [project-dir]",
+    );
+  });
+});
+
+describe("memory prune", () => {
+  it("tombstones old learnings and lists removed ids", () => {
+    writeMem([
+      learning("mem-1", "old lesson", "2020-01-01T00:00:00Z"),
+      learning("mem-2", "fresh lesson", new Date().toISOString()),
+    ]);
+    expect(dispatchMemory(["prune", "--max-age", "30", projectDir])).toBe(true);
+    const output = lines.join("\n");
+    expect(output).toContain("Scanned 2 learnings");
+    expect(output).toContain("tombstoned 1 older than 30 days");
+    expect(output).toContain("mem-1");
+    const content = readFileSync(memFile, "utf-8");
+    expect(content).toContain('"target_id": "mem-1"');
+    expect(content).not.toContain('"target_id": "mem-2"');
+  });
+
+  it("reports when nothing is old enough to prune", () => {
+    writeMem([learning("mem-1", "fresh lesson", new Date().toISOString())]);
+    dispatchMemory(["prune", "--max-age", "30", projectDir]);
+    expect(lines.join("\n")).toContain(
+      "Scanned 1 learnings; none older than 30 days.",
+    );
+  });
+
+  it("errors when --max-age is missing", () => {
+    writeMem([learning("mem-1", "lesson", "2020-01-01T00:00:00Z")]);
+    dispatchMemory(["prune", projectDir]);
+    const output = lines.join("\n");
+    expect(output).toContain("error: prune requires --max-age <days>");
+    expect(output).toContain("Usage: autoloop memory prune");
+    const content = readFileSync(memFile, "utf-8");
+    expect(content).not.toContain("tombstone");
+  });
+
+  it("errors on a non-numeric --max-age", () => {
+    dispatchMemory(["prune", "--max-age", "soon", projectDir]);
+    expect(lines.join("\n")).toContain(
+      "error: --max-age must be a positive integer",
+    );
+  });
+
+  it("errors on zero or negative --max-age", () => {
+    dispatchMemory(["prune", "--max-age", "0", projectDir]);
+    dispatchMemory(["prune", "--max-age", "-5", projectDir]);
+    const errors = lines.filter((l) =>
+      l.includes("--max-age must be a positive integer"),
+    );
+    expect(errors).toHaveLength(2);
+  });
+
+  it("errors when --max-age has no value", () => {
+    dispatchMemory(["prune", "--max-age"]);
+    expect(lines.join("\n")).toContain(
+      "error: --max-age must be a positive integer",
+    );
+  });
+
+  it("shows usage with --help", () => {
+    dispatchMemory(["prune", "--help"]);
+    expect(lines.join("\n")).toContain(
+      "Usage: autoloop memory prune --max-age <days> [project-dir]",
+    );
+  });
+});

--- a/packages/cli/test/commands/stats.test.ts
+++ b/packages/cli/test/commands/stats.test.ts
@@ -1,0 +1,136 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { RunRecord } from "@mobrienv/autoloop-core/registry/types";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  computeStats,
+  dispatchStats,
+  renderStats,
+} from "../../src/commands/stats.js";
+
+function record(overrides: Partial<RunRecord>): RunRecord {
+  return {
+    run_id: "run-1",
+    status: "completed",
+    preset: "autocode",
+    objective: "",
+    trigger: "cli",
+    project_dir: "",
+    work_dir: "",
+    state_dir: "",
+    journal_file: "",
+    parent_run_id: "",
+    backend: "",
+    backend_args: [],
+    created_at: "2026-06-01T00:00:00Z",
+    updated_at: "2026-06-01T00:01:40Z",
+    iteration: 4,
+    max_iterations: 10,
+    stop_reason: "",
+    latest_event: "",
+    isolation_mode: "",
+    worktree_name: "",
+    worktree_path: "",
+    ...overrides,
+  };
+}
+
+function usageLine(run: string, costUsd: string): string {
+  return JSON.stringify({
+    run,
+    iteration: "1",
+    topic: "backend.usage",
+    fields: { cost_usd: costUsd, total_tokens: "100" },
+  });
+}
+
+describe("computeStats", () => {
+  it("groups runs by preset with rates, averages, and cost", () => {
+    const records = [
+      record({ run_id: "a", preset: "autocode", status: "completed" }),
+      record({ run_id: "b", preset: "autocode", status: "failed" }),
+      record({ run_id: "c", preset: "autoqa", status: "running" }),
+    ];
+    const journals: Record<string, string[]> = {
+      a: [usageLine("a", "0.40")],
+      b: [usageLine("b", "0.10")],
+      c: [],
+    };
+    const stats = computeStats(records, (runId) => journals[runId] ?? []);
+    expect(stats).toHaveLength(2);
+    const autocode = stats.find((s) => s.preset === "autocode");
+    expect(autocode?.runs).toBe(2);
+    expect(autocode?.completed).toBe(1);
+    expect(autocode?.failed).toBe(1);
+    expect(autocode?.successRate).toBeCloseTo(0.5, 6);
+    expect(autocode?.avgIterations).toBeCloseTo(4, 6);
+    expect(autocode?.avgDurationS).toBeCloseTo(100, 6);
+    expect(autocode?.costUsd).toBeCloseTo(0.5, 6);
+    const autoqa = stats.find((s) => s.preset === "autoqa");
+    expect(autoqa?.running).toBe(1);
+    expect(autoqa?.successRate).toBeNull();
+  });
+
+  it("counts timed_out runs as failures", () => {
+    const stats = computeStats([record({ status: "timed_out" })], () => []);
+    expect(stats[0].failed).toBe(1);
+  });
+
+  it("skips unparseable durations", () => {
+    const stats = computeStats(
+      [record({ created_at: "garbage", updated_at: "garbage" })],
+      () => [],
+    );
+    expect(stats[0].avgDurationS).toBeNull();
+  });
+});
+
+describe("renderStats", () => {
+  it("explains when no runs exist", () => {
+    expect(renderStats("/tmp/p", [])).toContain("No runs recorded yet");
+  });
+
+  it("renders a table with totals", () => {
+    const stats = computeStats([record({ run_id: "a" })], () => [
+      usageLine("a", "0.25"),
+    ]);
+    const text = renderStats("/tmp/p", stats);
+    expect(text).toContain("## Run stats");
+    expect(text).toContain("autocode");
+    expect(text).toContain("100%");
+    expect(text).toContain("$0.2500 journaled cost");
+  });
+});
+
+describe("dispatchStats", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("reads the registry from disk and prints JSON", () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "autoloop-stats-test-"));
+    const stateDir = join(projectDir, ".autoloop");
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(
+      join(stateDir, "registry.jsonl"),
+      `${JSON.stringify(record({ run_id: "a" }))}\n`,
+    );
+    const lines: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((...args) => {
+      lines.push(args.join(" "));
+    });
+    dispatchStats([projectDir, "--json"]);
+    const parsed = JSON.parse(lines.join("\n"));
+    expect(parsed.presets).toHaveLength(1);
+    expect(parsed.presets[0].preset).toBe("autocode");
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it("shows usage with --help", () => {
+    const lines: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((...args) => {
+      lines.push(args.join(" "));
+    });
+    dispatchStats(["--help"]);
+    expect(lines.join("\n")).toContain("Usage: autoloop stats");
+  });
+});

--- a/packages/cli/test/commands/task.test.ts
+++ b/packages/cli/test/commands/task.test.ts
@@ -1,0 +1,112 @@
+import { mkdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { dispatchTask } from "../../src/commands/task.js";
+
+function tmpProject(): string {
+  const dir = join(
+    tmpdir(),
+    `autoloop-ts-task-cmd-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(join(dir, ".autoloop"), { recursive: true });
+  return dir;
+}
+
+describe("dispatchTask", () => {
+  let dir: string;
+  let tasksFile: string;
+  let lines: string[];
+
+  beforeEach(() => {
+    dir = tmpProject();
+    tasksFile = join(dir, ".autoloop/tasks.jsonl");
+    vi.stubEnv("AUTOLOOP_PROJECT_DIR", dir);
+    vi.stubEnv("AUTOLOOP_TASKS_FILE", tasksFile);
+    lines = [];
+    vi.spyOn(console, "log").mockImplementation((...args) => {
+      lines.push(args.join(" "));
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("add without flags creates a default task", () => {
+    dispatchTask(["add", "plain", "task"]);
+
+    expect(lines).toEqual(["task-1"]);
+    const raw = readFileSync(tasksFile, "utf-8");
+    expect(raw).toContain('"text": "plain task"');
+    expect(raw).not.toContain("priority");
+    expect(raw).not.toContain("soft");
+  });
+
+  it("add accepts --priority and --soft", () => {
+    dispatchTask(["add", "--priority", "high", "--soft", "urgent", "hint"]);
+
+    expect(lines).toEqual(["task-1"]);
+    const raw = readFileSync(tasksFile, "utf-8");
+    expect(raw).toContain('"text": "urgent hint"');
+    expect(raw).toContain('"priority": "high"');
+    expect(raw).toContain('"soft": "true"');
+  });
+
+  it("add accepts -p shorthand with flags after the text", () => {
+    dispatchTask(["add", "slow", "burner", "-p", "low"]);
+
+    expect(lines).toEqual(["task-1"]);
+    const raw = readFileSync(tasksFile, "utf-8");
+    expect(raw).toContain('"text": "slow burner"');
+    expect(raw).toContain('"priority": "low"');
+  });
+
+  it("add rejects an invalid priority value with usage", () => {
+    dispatchTask(["add", "-p", "urgent", "some", "task"]);
+
+    expect(lines[0]).toContain("Usage: autoloop task add");
+    expect(lines[0]).toContain("--priority|-p <high|normal|low>");
+    expect(lines[0]).toContain("--soft");
+  });
+
+  it("add without text prints usage", () => {
+    dispatchTask(["add"]);
+    expect(lines[0]).toContain("Usage: autoloop task add");
+  });
+
+  it("add --help prints usage", () => {
+    dispatchTask(["add", "--help"]);
+    expect(lines[0]).toContain("Usage: autoloop task add");
+  });
+
+  it("list shows priority/soft markers ordered high → normal → low", () => {
+    dispatchTask(["add", "normal", "one"]);
+    dispatchTask(["add", "-p", "low", "--soft", "low", "soft", "one"]);
+    dispatchTask(["add", "-p", "high", "high", "one"]);
+    lines = [];
+
+    dispatchTask(["list"]);
+
+    const output = lines.join("\n");
+    const openLines = output.split("\n").filter((l) => l.startsWith("- [ ]"));
+    expect(openLines).toEqual([
+      "- [ ] [task-3] [high] high one",
+      "- [ ] [task-1] normal one",
+      "- [ ] [task-2] [low] low soft one (soft)",
+    ]);
+  });
+
+  it("complete and list keep markers on done tasks", () => {
+    dispatchTask(["add", "-p", "high", "finish", "me"]);
+    dispatchTask(["complete", "task-1"]);
+    lines = [];
+
+    dispatchTask(["list"]);
+
+    const output = lines.join("\n");
+    expect(output).toContain("Done:");
+    expect(output).toContain("- [x] [task-1] [high] finish me");
+  });
+});

--- a/packages/cli/test/commands/worktree-diff.test.ts
+++ b/packages/cli/test/commands/worktree-diff.test.ts
@@ -1,0 +1,159 @@
+import { execSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createWorktree } from "@mobrienv/autoloop-core/worktree";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { dispatchWorktree } from "../../src/commands/worktree.js";
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "test",
+  GIT_AUTHOR_EMAIL: "t@t",
+  GIT_COMMITTER_NAME: "test",
+  GIT_COMMITTER_EMAIL: "t@t",
+};
+
+function makeGitRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "autoloop-ts-wt-diff-cmd-"));
+  execSync("git init && git commit --allow-empty -m init", {
+    cwd: dir,
+    stdio: "pipe",
+    env: GIT_ENV,
+  });
+  return dir;
+}
+
+function addFileAndCommit(
+  dir: string,
+  name: string,
+  content: string,
+  message: string,
+): void {
+  writeFileSync(join(dir, name), content);
+  execSync(`git add ${name} && git commit -m '${message}'`, {
+    cwd: dir,
+    stdio: "pipe",
+    env: GIT_ENV,
+  });
+}
+
+function setupRepoWithWorktree(runId: string): string {
+  const repo = makeGitRepo();
+  const wt = createWorktree({
+    mainStateDir: join(repo, ".autoloop"),
+    runId,
+    workDir: repo,
+  });
+  addFileAndCommit(
+    wt.worktreePath,
+    "feature.txt",
+    "alpha\nbeta\n",
+    "add feature",
+  );
+  return repo;
+}
+
+function captureLog(): string[] {
+  const lines: string[] = [];
+  vi.spyOn(console, "log").mockImplementation((...args) => {
+    lines.push(args.join(" "));
+  });
+  return lines;
+}
+
+describe("worktree diff command", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.AUTOLOOP_PROJECT_DIR;
+    process.exitCode = undefined;
+  });
+
+  it("prints a summary with branch, base, and diffstat table", () => {
+    const repo = setupRepoWithWorktree("run-cli-diff1");
+    process.env.AUTOLOOP_PROJECT_DIR = repo;
+
+    const lines = captureLog();
+    dispatchWorktree(["diff", "run-cli-diff1"]);
+
+    const out = lines.join("\n");
+    expect(out).toContain("autoloop/run-cli-diff1");
+    expect(out).toContain("Base:");
+    expect(out).toContain("1 file(s), +2 -0");
+    expect(out).toContain("STATUS");
+    expect(out).toContain("PATH");
+    expect(out).toMatch(/added\s+feature\.txt/);
+    // No patch by default
+    expect(out).not.toContain("diff --git");
+  });
+
+  it("appends the full patch with --patch", () => {
+    const repo = setupRepoWithWorktree("run-cli-diff2");
+    process.env.AUTOLOOP_PROJECT_DIR = repo;
+
+    const lines = captureLog();
+    dispatchWorktree(["diff", "run-cli-diff2", "--patch"]);
+
+    const out = lines.join("\n");
+    expect(out).toContain("diff --git a/feature.txt b/feature.txt");
+    expect(out).toContain("+alpha");
+    expect(out).toContain("+beta");
+  });
+
+  it("prints the structured result with --json", () => {
+    const repo = setupRepoWithWorktree("run-cli-diff3");
+    process.env.AUTOLOOP_PROJECT_DIR = repo;
+
+    const lines = captureLog();
+    dispatchWorktree(["diff", "run-cli-diff3", "--json"]);
+
+    const parsed = JSON.parse(lines.join("\n"));
+    expect(parsed.branch).toBe("autoloop/run-cli-diff3");
+    expect(parsed.filesChanged).toBe(1);
+    expect(parsed.insertions).toBe(2);
+    expect(parsed.deletions).toBe(0);
+    expect(parsed.files).toEqual([{ path: "feature.txt", status: "added" }]);
+    expect(parsed.patch).toBeUndefined();
+  });
+
+  it("includes the patch in --json output when --patch is set", () => {
+    const repo = setupRepoWithWorktree("run-cli-diff4");
+    process.env.AUTOLOOP_PROJECT_DIR = repo;
+
+    const lines = captureLog();
+    dispatchWorktree(["diff", "run-cli-diff4", "--json", "--patch"]);
+
+    const parsed = JSON.parse(lines.join("\n"));
+    expect(parsed.patch).toContain("+alpha");
+  });
+
+  it("reports a missing worktree and sets a failing exit code", () => {
+    const repo = makeGitRepo();
+    process.env.AUTOLOOP_PROJECT_DIR = repo;
+
+    const lines = captureLog();
+    dispatchWorktree(["diff", "run-missing"]);
+
+    expect(lines.join("\n")).toContain("No worktree found for run run-missing");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("prints usage when run-id is omitted", () => {
+    const repo = makeGitRepo();
+    process.env.AUTOLOOP_PROJECT_DIR = repo;
+
+    const lines = captureLog();
+    dispatchWorktree(["diff"]);
+
+    expect(lines.join("\n")).toContain(
+      "Usage: autoloop worktree diff <run-id> [--patch] [--json]",
+    );
+  });
+
+  it("mentions diff in the worktree usage text", () => {
+    const lines = captureLog();
+    dispatchWorktree(["--help"]);
+
+    expect(lines.join("\n")).toContain("autoloop worktree diff <run-id>");
+  });
+});

--- a/packages/cli/test/loops/json.test.ts
+++ b/packages/cli/test/loops/json.test.ts
@@ -1,0 +1,277 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { RunRecord } from "@mobrienv/autoloop-core/registry/types";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  artifactsJson,
+  healthJson,
+  listRunsJson,
+  showRunJson,
+} from "../../src/loops/json.js";
+
+function makeRecord(id: string, overrides: Partial<RunRecord> = {}): RunRecord {
+  return {
+    run_id: id,
+    status: "completed",
+    preset: "autocode",
+    objective: "test objective",
+    trigger: "cli",
+    project_dir: "/tmp/proj",
+    work_dir: "/tmp/proj",
+    state_dir: "/tmp/proj/.autoloop",
+    journal_file: "/tmp/proj/.autoloop/journal.jsonl",
+    parent_run_id: "",
+    backend: "mock",
+    backend_args: [],
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T01:00:00Z",
+    iteration: 5,
+    max_iterations: 10,
+    stop_reason: "completion",
+    latest_event: "loop.complete",
+    isolation_mode: "shared",
+    worktree_name: "",
+    worktree_path: "",
+    ...overrides,
+  };
+}
+
+function isoAgo(ms: number): string {
+  return new Date(Date.now() - ms).toISOString();
+}
+
+let tmpDir: string;
+let regPath: string;
+
+beforeEach(() => {
+  tmpDir = join(
+    tmpdir(),
+    `loops-json-test-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(tmpDir, { recursive: true });
+  regPath = join(tmpDir, "registry.jsonl");
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeRecords(records: RunRecord[]): void {
+  writeFileSync(
+    regPath,
+    `${records.map((r) => JSON.stringify(r)).join("\n")}\n`,
+  );
+}
+
+describe("listRunsJson", () => {
+  it("returns an empty array when no registry exists", () => {
+    const parsed = JSON.parse(listRunsJson(tmpDir, false));
+    expect(parsed).toEqual([]);
+  });
+
+  it("returns only running runs by default", () => {
+    writeRecords([
+      makeRecord("run-active-1", { status: "running" }),
+      makeRecord("run-done-1", { status: "completed" }),
+    ]);
+    const parsed = JSON.parse(listRunsJson(tmpDir, false));
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].run_id).toBe("run-active-1");
+    expect(parsed[0].status).toBe("running");
+  });
+
+  it("projects exactly the table fields and omits empty worktree fields", () => {
+    writeRecords([makeRecord("run-fields-1", { status: "running" })]);
+    const parsed = JSON.parse(listRunsJson(tmpDir, false));
+    expect(Object.keys(parsed[0]).sort()).toEqual(
+      [
+        "run_id",
+        "status",
+        "preset",
+        "iteration",
+        "max_iterations",
+        "stop_reason",
+        "latest_event",
+        "created_at",
+        "updated_at",
+        "isolation_mode",
+      ].sort(),
+    );
+    expect(parsed[0].iteration).toBe(5);
+    expect(parsed[0].max_iterations).toBe(10);
+  });
+
+  it("includes worktree fields when present", () => {
+    writeRecords([
+      makeRecord("run-wt-1", {
+        status: "running",
+        isolation_mode: "worktree",
+        worktree_name: "wt-feature",
+        worktree_path: "/tmp/proj/.worktrees/wt-feature",
+        worktree_merged: true,
+        worktree_merged_at: "2026-01-02T00:00:00Z",
+        worktree_merge_strategy: "squash",
+      }),
+    ]);
+    const parsed = JSON.parse(listRunsJson(tmpDir, false));
+    expect(parsed[0].isolation_mode).toBe("worktree");
+    expect(parsed[0].worktree_name).toBe("wt-feature");
+    expect(parsed[0].worktree_path).toBe("/tmp/proj/.worktrees/wt-feature");
+    expect(parsed[0].worktree_merged).toBe(true);
+    expect(parsed[0].worktree_merged_at).toBe("2026-01-02T00:00:00Z");
+    expect(parsed[0].worktree_merge_strategy).toBe("squash");
+  });
+
+  it("returns all runs sorted by updated_at descending with all=true", () => {
+    writeRecords([
+      makeRecord("run-old", { updated_at: "2026-01-01T01:00:00Z" }),
+      makeRecord("run-new", { updated_at: "2026-01-03T01:00:00Z" }),
+      makeRecord("run-mid", { updated_at: "2026-01-02T01:00:00Z" }),
+    ]);
+    const parsed = JSON.parse(listRunsJson(tmpDir, true));
+    expect(parsed.map((r: { run_id: string }) => r.run_id)).toEqual([
+      "run-new",
+      "run-mid",
+      "run-old",
+    ]);
+  });
+});
+
+describe("showRunJson", () => {
+  it("returns the full record plus a derived health bucket", () => {
+    writeRecords([
+      makeRecord("run-show-1", {
+        status: "running",
+        updated_at: isoAgo(0),
+      }),
+    ]);
+    const { output, exitCode } = showRunJson(tmpDir, "run-show-1");
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(output);
+    expect(parsed.run_id).toBe("run-show-1");
+    expect(parsed.objective).toBe("test objective");
+    expect(parsed.backend).toBe("mock");
+    expect(parsed.work_dir).toBe("/tmp/proj");
+    expect(parsed.health).toBe("active");
+  });
+
+  it("derives recent_completed for a recently completed run", () => {
+    writeRecords([
+      makeRecord("run-done-recent", {
+        status: "completed",
+        updated_at: isoAgo(60 * 60 * 1000),
+      }),
+    ]);
+    const parsed = JSON.parse(showRunJson(tmpDir, "run-done-recent").output);
+    expect(parsed.health).toBe("recent_completed");
+  });
+
+  it("derives null health for runs outside every bucket", () => {
+    writeRecords([
+      makeRecord("run-ancient", {
+        status: "completed",
+        updated_at: isoAgo(48 * 60 * 60 * 1000),
+      }),
+    ]);
+    const parsed = JSON.parse(showRunJson(tmpDir, "run-ancient").output);
+    expect(parsed.health).toBeNull();
+  });
+
+  it("resolves unique prefixes", () => {
+    writeRecords([makeRecord("aaa-111"), makeRecord("bbb-222")]);
+    const { output, exitCode } = showRunJson(tmpDir, "aaa");
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(output).run_id).toBe("aaa-111");
+  });
+
+  it("returns an error object and exit code 1 for unknown ids", () => {
+    writeRecords([makeRecord("abc-123")]);
+    const { output, exitCode } = showRunJson(tmpDir, "zzz");
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(output);
+    expect(parsed.error).toContain("No run matching");
+    expect(parsed.error).toContain("zzz");
+  });
+
+  it("returns an error object with matches for ambiguous prefixes", () => {
+    writeRecords([makeRecord("abc-111"), makeRecord("abc-222")]);
+    const { output, exitCode } = showRunJson(tmpDir, "abc");
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(output);
+    expect(parsed.error).toContain("Ambiguous");
+    expect(parsed.matches).toEqual(["abc-111", "abc-222"]);
+  });
+});
+
+describe("artifactsJson", () => {
+  it("returns artifact paths for a matching run", () => {
+    writeRecords([makeRecord("run-art-1")]);
+    const { output, exitCode } = artifactsJson(tmpDir, "run-art-1");
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(output);
+    expect(parsed).toEqual({
+      run_id: "run-art-1",
+      journal_file: "/tmp/proj/.autoloop/journal.jsonl",
+      state_dir: "/tmp/proj/.autoloop",
+      work_dir: "/tmp/proj",
+    });
+  });
+
+  it("returns an error object and exit code 1 for unknown ids", () => {
+    writeRecords([makeRecord("run-art-1")]);
+    const { output, exitCode } = artifactsJson(tmpDir, "zzz");
+    expect(exitCode).toBe(1);
+    expect(JSON.parse(output).error).toContain("No run matching");
+  });
+});
+
+describe("healthJson", () => {
+  it("buckets runs with counts and run ids", () => {
+    // autocode policy: warning after 5min, stuck after 12min.
+    writeRecords([
+      makeRecord("run-active", { status: "running", updated_at: isoAgo(0) }),
+      makeRecord("run-watching", {
+        status: "running",
+        updated_at: isoAgo(7 * 60 * 1000),
+      }),
+      makeRecord("run-stuck", {
+        status: "running",
+        updated_at: isoAgo(20 * 60 * 1000),
+      }),
+      makeRecord("run-failed", {
+        status: "failed",
+        updated_at: isoAgo(60 * 60 * 1000),
+      }),
+      makeRecord("run-completed", {
+        status: "completed",
+        updated_at: isoAgo(60 * 60 * 1000),
+      }),
+    ]);
+    const parsed = JSON.parse(healthJson(tmpDir));
+    expect(parsed.active).toEqual({ count: 1, run_ids: ["run-active"] });
+    expect(parsed.watching).toEqual({ count: 1, run_ids: ["run-watching"] });
+    expect(parsed.stuck).toEqual({ count: 1, run_ids: ["run-stuck"] });
+    expect(parsed.recent_failed).toEqual({
+      count: 1,
+      run_ids: ["run-failed"],
+    });
+    expect(parsed.recent_completed).toEqual({
+      count: 1,
+      run_ids: ["run-completed"],
+    });
+  });
+
+  it("returns zeroed buckets when no registry exists", () => {
+    const parsed = JSON.parse(healthJson(tmpDir));
+    for (const key of [
+      "active",
+      "watching",
+      "stuck",
+      "recent_failed",
+      "recent_completed",
+    ]) {
+      expect(parsed[key]).toEqual({ count: 0, run_ids: [] });
+    }
+  });
+});

--- a/packages/core/src/config-schema.ts
+++ b/packages/core/src/config-schema.ts
@@ -23,6 +23,10 @@ export function defaults(): Config {
       completion_promise: "LOOP_COMPLETE",
       completion_event: "task.complete",
       required_events: "",
+      // Stop after N consecutive identical backend outputs (0 = disabled).
+      stall_iterations: "0",
+      // Stop once journaled run cost reaches this USD budget (0 = disabled).
+      max_cost_usd: "0",
     },
     backend: { kind: "", command: "claude", timeout_ms: "300000" },
     parallel: {
@@ -50,6 +54,17 @@ export function getInt(config: Config, key: string, fallback: number): number {
   const raw = get(config, key, "");
   if (raw === "") return fallback;
   const parsed = parseInt(raw, 10);
+  return Number.isNaN(parsed) ? fallback : parsed;
+}
+
+export function getFloat(
+  config: Config,
+  key: string,
+  fallback: number,
+): number {
+  const raw = get(config, key, "");
+  if (raw === "") return fallback;
+  const parsed = Number.parseFloat(raw);
   return Number.isNaN(parsed) ? fallback : parsed;
 }
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -30,6 +30,7 @@ export {
   deepMerge,
   defaults,
   get,
+  getFloat,
   getInt,
   getList,
   getProfileDefaults,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,4 +16,5 @@ export * from "./helpers.js";
 export * from "./json.js";
 export * from "./markdown.js";
 export * from "./runs-health.js";
+export * from "./usage.js";
 export * from "./utils.js";

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -136,6 +136,64 @@ export function addMeta(projectDir: string, key: string, value: string): void {
   printBudgetWarning(projectDir);
 }
 
+export interface CompactSummary {
+  scanned: number;
+  duplicatesRemoved: number;
+  ids: string[];
+}
+
+export interface PruneSummary {
+  scanned: number;
+  pruned: number;
+  ids: string[];
+}
+
+export function compactMemory(projectDir: string): CompactSummary {
+  const path = resolveFile(projectDir);
+  const memory = materialize(readLines(path));
+  const seenTexts: string[] = [];
+  const ids: string[] = [];
+  for (const entry of memory.learnings) {
+    const normalized = normalizeLearningText(extractField(entry, "text"));
+    if (seenTexts.includes(normalized)) {
+      ids.push(extractField(entry, "id"));
+    } else {
+      seenTexts.push(normalized);
+    }
+  }
+  for (const id of ids) {
+    appendTombstone(path, id, "compact: duplicate learning");
+  }
+  return {
+    scanned: memory.learnings.length,
+    duplicatesRemoved: ids.length,
+    ids,
+  };
+}
+
+export function pruneMemory(
+  projectDir: string,
+  maxAgeDays: number,
+): PruneSummary {
+  const path = resolveFile(projectDir);
+  const memory = materialize(readLines(path));
+  const cutoffMs = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000;
+  const ids: string[] = [];
+  for (const entry of memory.learnings) {
+    const createdMs = Date.parse(extractField(entry, "created"));
+    if (Number.isNaN(createdMs)) continue;
+    if (createdMs < cutoffMs) ids.push(extractField(entry, "id"));
+  }
+  for (const id of ids) {
+    appendTombstone(path, id, `prune: older than ${maxAgeDays} days`);
+  }
+  return { scanned: memory.learnings.length, pruned: ids.length, ids };
+}
+
+function normalizeLearningText(text: string): string {
+  return text.trim().replace(/\s+/g, " ");
+}
+
 export function remove(projectDir: string, id: string, reason: string): void {
   const path = resolveFile(projectDir);
   const memory = materialize(readLines(path));
@@ -554,11 +612,15 @@ function nextId(path: string, prefix: string): string {
 }
 
 function removeExistingEntry(path: string, id: string, reason: string): void {
+  appendTombstone(path, id, reason);
+  console.log(`removed ${id}`);
+}
+
+function appendTombstone(path: string, id: string, reason: string): void {
   appendMemoryEntry(
     path,
     memoryLine(nextId(path, "ts"), "tombstone", tombstoneFields(id, reason)),
   );
-  console.log(`removed ${id}`);
 }
 
 function currentTime(): string {

--- a/packages/core/src/tasks-render.ts
+++ b/packages/core/src/tasks-render.ts
@@ -1,5 +1,5 @@
 import { lineSep } from "@mobrienv/autoloop-core";
-import type { MaterializedTasks } from "./tasks.js";
+import { formatTaskText, type MaterializedTasks } from "./tasks.js";
 
 export function renderTasksPrompt(
   tasks: MaterializedTasks,
@@ -12,14 +12,14 @@ export function renderTasksPrompt(
   if (tasks.open.length > 0) {
     lines.push("Open:");
     for (const t of tasks.open) {
-      lines.push(`- [ ] [${t.id}] ${t.text}`);
+      lines.push(`- [ ] [${t.id}] ${formatTaskText(t)}`);
     }
   }
 
   if (tasks.done.length > 0) {
     lines.push("Done:");
     for (const t of tasks.done) {
-      lines.push(`- [x] [${t.id}] ${t.text} (done)`);
+      lines.push(`- [x] [${t.id}] ${formatTaskText(t)} (done)`);
     }
   }
 

--- a/packages/core/src/tasks.ts
+++ b/packages/core/src/tasks.ts
@@ -4,6 +4,8 @@ import { extractField, jsonField } from "@mobrienv/autoloop-core";
 import { readLines } from "@mobrienv/autoloop-core/journal";
 import * as config from "./config.js";
 
+export type TaskPriority = "high" | "normal" | "low";
+
 export interface TaskEntry {
   id: string;
   type: "task" | "task-tombstone";
@@ -12,6 +14,28 @@ export interface TaskEntry {
   source: string;
   created: string;
   completed?: string;
+  priority?: TaskPriority;
+  soft?: boolean;
+}
+
+export interface AddTaskOpts {
+  priority?: TaskPriority;
+  soft?: boolean;
+}
+
+export function parsePriority(value: string): TaskPriority | undefined {
+  if (value === "high" || value === "normal" || value === "low") return value;
+  return undefined;
+}
+
+const PRIORITY_RANK: Record<TaskPriority, number> = {
+  high: 0,
+  normal: 1,
+  low: 2,
+};
+
+export function priorityRank(priority: TaskPriority | undefined): number {
+  return PRIORITY_RANK[priority ?? "normal"];
 }
 
 export interface MaterializedTasks {
@@ -61,9 +85,13 @@ export function materialize(lines: string[]): MaterializedTasks {
     }
   }
 
-  // Open: oldest first (by creation). Done: most recent completion first.
+  // Open: high → normal → low, oldest first (by creation) within a priority.
+  // Done: most recent completion first.
+  const openOldestFirst = open.reverse();
   return {
-    open: open.reverse(),
+    open: openOldestFirst.sort(
+      (a, b) => priorityRank(a.priority) - priorityRank(b.priority),
+    ),
     done: done.reverse(),
   };
 }
@@ -77,7 +105,25 @@ function parseEntry(line: string): TaskEntry {
     source: extractField(line, "source") || "manual",
     created: extractField(line, "created"),
     completed: extractField(line, "completed") || undefined,
+    priority: parsePriority(extractField(line, "priority")),
+    soft: extractField(line, "soft") === "true" ? true : undefined,
   };
+}
+
+// Serialize non-default priority/soft as a trailing field suffix so lines for
+// default tasks stay byte-identical to the pre-priority format.
+function priorityFields(
+  priority: TaskPriority | undefined,
+  soft: boolean | undefined,
+): string {
+  let suffix = "";
+  if (priority && priority !== "normal") {
+    suffix += `, ${jsonField("priority", priority)}`;
+  }
+  if (soft === true) {
+    suffix += `, ${jsonField("soft", "true")}`;
+  }
+  return suffix;
 }
 
 export function materializeOpen(projectDir: string): TaskEntry[] {
@@ -97,6 +143,7 @@ export function addTask(
   projectDir: string,
   text: string,
   source: string,
+  opts: AddTaskOpts = {},
 ): string {
   const path = resolveFile(projectDir);
   const id = nextId(path);
@@ -111,7 +158,8 @@ export function addTask(
         ", " +
         jsonField("source", source) +
         ", " +
-        jsonField("created", currentTime()),
+        jsonField("created", currentTime()) +
+        priorityFields(opts.priority, opts.soft),
     ),
   );
   return id;
@@ -136,7 +184,8 @@ export function completeTask(projectDir: string, id: string): boolean {
         ", " +
         jsonField("created", entry.created) +
         ", " +
-        jsonField("completed", currentTime()),
+        jsonField("completed", currentTime()) +
+        priorityFields(entry.priority, entry.soft),
     ),
   );
   return true;
@@ -163,7 +212,10 @@ export function updateTask(
         jsonField("source", entry.source) +
         ", " +
         jsonField("created", entry.created) +
-        (entry.completed ? `, ${jsonField("completed", entry.completed)}` : ""),
+        (entry.completed
+          ? `, ${jsonField("completed", entry.completed)}`
+          : "") +
+        priorityFields(entry.priority, entry.soft),
     ),
   );
   return true;
@@ -199,6 +251,14 @@ export function listTasks(projectDir: string): string {
   return renderTaskList(tasks);
 }
 
+// "[high] text (soft)" — priority marker for non-normal priorities, plus a
+// soft marker; plain text for default tasks (back-compat).
+export function formatTaskText(t: TaskEntry): string {
+  const prio = t.priority && t.priority !== "normal" ? `[${t.priority}] ` : "";
+  const soft = t.soft === true ? " (soft)" : "";
+  return `${prio}${t.text}${soft}`;
+}
+
 export function renderTaskList(tasks: MaterializedTasks): string {
   if (tasks.open.length === 0 && tasks.done.length === 0) {
     return "No tasks.";
@@ -207,14 +267,14 @@ export function renderTaskList(tasks: MaterializedTasks): string {
   if (tasks.open.length > 0) {
     lines.push("Open:");
     for (const t of tasks.open) {
-      lines.push(`- [ ] [${t.id}] ${t.text}`);
+      lines.push(`- [ ] [${t.id}] ${formatTaskText(t)}`);
     }
   }
   if (tasks.done.length > 0) {
     if (lines.length > 0) lines.push("");
     lines.push("Done:");
     for (const t of tasks.done) {
-      lines.push(`- [x] [${t.id}] ${t.text}`);
+      lines.push(`- [x] [${t.id}] ${formatTaskText(t)}`);
     }
   }
   return lines.join("\n");

--- a/packages/core/src/usage.ts
+++ b/packages/core/src/usage.ts
@@ -1,0 +1,149 @@
+// Usage and cost aggregation over journal `backend.usage` events.
+//
+// Backends that report token telemetry (the pi RPC backend today) journal one
+// `backend.usage` fields event per iteration. These helpers materialize that
+// stream into per-iteration rows and run totals so budget enforcement,
+// `inspect usage`, and `stats` all read from the same journal-derived source
+// of truth instead of keeping a parallel counter in memory.
+
+import { decodeEvent } from "./events/decode.js";
+
+export interface UsageRow {
+  iteration: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  totalTokens: number;
+  costUsd: number;
+  contextPercent?: number;
+}
+
+export interface UsageTotals {
+  iterations: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  totalTokens: number;
+  costUsd: number;
+}
+
+export interface RunUsage {
+  rows: UsageRow[];
+  totals: UsageTotals;
+}
+
+export function emptyUsageTotals(): UsageTotals {
+  return {
+    iterations: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    totalTokens: 0,
+    costUsd: 0,
+  };
+}
+
+/**
+ * Aggregate `backend.usage` events from raw journal lines.
+ * When `runId` is given, only events for that run are considered.
+ */
+export function collectUsage(lines: string[], runId?: string): RunUsage {
+  const rows: UsageRow[] = [];
+  for (const line of lines) {
+    const event = decodeEvent(line);
+    if (!event || event.shape !== "fields") continue;
+    if (event.topic !== "backend.usage") continue;
+    if (runId && event.run !== runId) continue;
+    const row: UsageRow = {
+      iteration: event.iteration ?? "",
+      inputTokens: parseNum(event.fields.input_tokens),
+      outputTokens: parseNum(event.fields.output_tokens),
+      cacheReadTokens: parseNum(event.fields.cache_read_tokens),
+      cacheWriteTokens: parseNum(event.fields.cache_write_tokens),
+      totalTokens: parseNum(event.fields.total_tokens),
+      costUsd: parseNum(event.fields.cost_usd),
+    };
+    if (event.fields.context_percent !== undefined) {
+      row.contextPercent = parseNum(event.fields.context_percent);
+    }
+    rows.push(row);
+  }
+  const totals = rows.reduce((acc, row) => {
+    acc.iterations += 1;
+    acc.inputTokens += row.inputTokens;
+    acc.outputTokens += row.outputTokens;
+    acc.cacheReadTokens += row.cacheReadTokens;
+    acc.cacheWriteTokens += row.cacheWriteTokens;
+    acc.totalTokens += row.totalTokens;
+    acc.costUsd += row.costUsd;
+    return acc;
+  }, emptyUsageTotals());
+  totals.costUsd = roundCost(totals.costUsd);
+  return { rows, totals };
+}
+
+/** Render usage as JSON or an aligned terminal/markdown table. */
+export function formatUsage(usage: RunUsage, format: string): string {
+  if (format === "json") {
+    return JSON.stringify(usage, null, 2);
+  }
+  if (usage.rows.length === 0) {
+    return [
+      "No backend usage telemetry recorded for this run.",
+      "(Token and cost stats are reported by backends with usage support — the pi backend today.)",
+    ].join("\n");
+  }
+  const header = [
+    "iter",
+    "input",
+    "output",
+    "cache_r",
+    "cache_w",
+    "total",
+    "cost_usd",
+    "ctx%",
+  ];
+  const body = usage.rows.map((r) => [
+    r.iteration || "-",
+    String(r.inputTokens),
+    String(r.outputTokens),
+    String(r.cacheReadTokens),
+    String(r.cacheWriteTokens),
+    String(r.totalTokens),
+    r.costUsd.toFixed(4),
+    r.contextPercent === undefined ? "-" : String(r.contextPercent),
+  ]);
+  const table = alignColumns([header, ...body]);
+  const t = usage.totals;
+  const summary = `totals: ${t.iterations} iteration(s), ${t.totalTokens} tokens, $${t.costUsd.toFixed(4)}`;
+  return ["## Usage", "", ...table, "", summary].join("\n");
+}
+
+function alignColumns(rows: string[][]): string[] {
+  const widths: number[] = [];
+  for (const row of rows) {
+    row.forEach((cell, i) => {
+      widths[i] = Math.max(widths[i] ?? 0, cell.length);
+    });
+  }
+  return rows.map((row) =>
+    row
+      .map((cell, i) => cell.padEnd(widths[i]))
+      .join("  ")
+      .trimEnd(),
+  );
+}
+
+function parseNum(raw: string | undefined): number {
+  if (raw === undefined || raw === "") return 0;
+  const parsed = Number.parseFloat(raw);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+/** Avoid float-noise like 0.30000000000000004 in summed costs. */
+function roundCost(value: number): number {
+  return Math.round(value * 1e6) / 1e6;
+}

--- a/packages/core/src/worktree/diff.ts
+++ b/packages/core/src/worktree/diff.ts
@@ -1,0 +1,132 @@
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { shellQuote } from "@mobrienv/autoloop-core";
+import { readMeta } from "./meta.js";
+
+export interface DiffWorktreeOpts {
+  metaDir: string;
+  workDir: string;
+  /** Include the full unified patch in the result. */
+  patch?: boolean;
+}
+
+export type DiffFileStatus =
+  | "added"
+  | "modified"
+  | "deleted"
+  | "renamed"
+  | "copied"
+  | "type-changed"
+  | "unmerged"
+  | "unknown";
+
+export interface DiffFileEntry {
+  path: string;
+  status: DiffFileStatus;
+}
+
+export interface DiffWorktreeResult {
+  branch: string;
+  base: string;
+  filesChanged: number;
+  insertions: number;
+  deletions: number;
+  files: DiffFileEntry[];
+  patch?: string;
+}
+
+export function diffWorktree(opts: DiffWorktreeOpts): DiffWorktreeResult {
+  const { metaDir, workDir, patch = false } = opts;
+
+  const meta = readMeta(metaDir);
+  if (!meta) throw new Error(`no worktree meta found in ${metaDir}`);
+
+  // Prefer running git inside the worktree itself; fall back to the project
+  // dir if the worktree directory is gone but the branch may still exist
+  // (refs are shared with the main repository).
+  const cwd = existsSync(meta.worktree_path) ? meta.worktree_path : workDir;
+  if (!existsSync(cwd)) {
+    throw new Error(
+      `worktree path ${meta.worktree_path} no longer exists for run ${meta.run_id}`,
+    );
+  }
+
+  const base = meta.base_branch;
+  const branch = meta.branch;
+  const range = shellQuote(`${base}...${branch}`);
+
+  const numstatOut = gitDiff(cwd, `git diff --numstat ${range}`, meta.run_id);
+  const nameStatusOut = gitDiff(
+    cwd,
+    `git diff --name-status ${range}`,
+    meta.run_id,
+  );
+
+  let insertions = 0;
+  let deletions = 0;
+  for (const line of splitLines(numstatOut)) {
+    const [ins, del] = line.split("\t");
+    if (ins !== "-") insertions += Number.parseInt(ins, 10) || 0;
+    if (del !== "-") deletions += Number.parseInt(del, 10) || 0;
+  }
+
+  const files: DiffFileEntry[] = splitLines(nameStatusOut).map((line) => {
+    const parts = line.split("\t");
+    const code = parts[0] ?? "";
+    // Renames/copies are "R100\told\tnew"; report the new path.
+    const path = parts[parts.length - 1] ?? "";
+    return { path, status: statusFromCode(code) };
+  });
+
+  const result: DiffWorktreeResult = {
+    branch,
+    base,
+    filesChanged: files.length,
+    insertions,
+    deletions,
+    files,
+  };
+
+  if (patch) {
+    result.patch = gitDiff(cwd, `git diff ${range}`, meta.run_id);
+  }
+
+  return result;
+}
+
+function gitDiff(cwd: string, cmd: string, runId: string): string {
+  try {
+    return execSync(cmd, { cwd, encoding: "utf-8", stdio: "pipe" });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`failed to diff worktree for run ${runId}: ${msg}`);
+  }
+}
+
+function splitLines(out: string): string[] {
+  return out
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l !== "");
+}
+
+function statusFromCode(code: string): DiffFileStatus {
+  switch (code.charAt(0)) {
+    case "A":
+      return "added";
+    case "M":
+      return "modified";
+    case "D":
+      return "deleted";
+    case "R":
+      return "renamed";
+    case "C":
+      return "copied";
+    case "T":
+      return "type-changed";
+    case "U":
+      return "unmerged";
+    default:
+      return "unknown";
+  }
+}

--- a/packages/core/src/worktree/index.ts
+++ b/packages/core/src/worktree/index.ts
@@ -6,6 +6,13 @@ export {
   resolveGitRoot,
   tryResolveGitRoot,
 } from "./create.js";
+export type {
+  DiffFileEntry,
+  DiffFileStatus,
+  DiffWorktreeOpts,
+  DiffWorktreeResult,
+} from "./diff.js";
+export { diffWorktree } from "./diff.js";
 export type { WorktreeListEntry } from "./list.js";
 export { listWorktreeMetas } from "./list.js";
 export type { MergeOpts, MergeResult } from "./merge.js";

--- a/packages/core/test/config-float.test.ts
+++ b/packages/core/test/config-float.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { defaults, getFloat, put } from "../src/config-schema.js";
+
+describe("getFloat", () => {
+  it("parses float values from config", () => {
+    const cfg = put(defaults(), "event_loop.max_cost_usd", "2.5");
+    expect(getFloat(cfg, "event_loop.max_cost_usd", 0)).toBe(2.5);
+  });
+
+  it("falls back on missing keys", () => {
+    expect(getFloat(defaults(), "event_loop.nonexistent", 1.25)).toBe(1.25);
+  });
+
+  it("falls back on malformed values", () => {
+    const cfg = put(defaults(), "event_loop.max_cost_usd", "lots");
+    expect(getFloat(cfg, "event_loop.max_cost_usd", 0.5)).toBe(0.5);
+  });
+
+  it("ships disabled-by-default guard keys", () => {
+    expect(getFloat(defaults(), "event_loop.max_cost_usd", -1)).toBe(0);
+    expect(getFloat(defaults(), "event_loop.stall_iterations", -1)).toBe(0);
+  });
+});

--- a/packages/core/test/memory-lifecycle.test.ts
+++ b/packages/core/test/memory-lifecycle.test.ts
@@ -1,0 +1,200 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { compactMemory, pruneMemory, renderFile } from "../src/memory.js";
+
+const tmpDir = join(import.meta.dirname ?? ".", ".tmp-memory-lifecycle-test");
+const memFile = join(tmpDir, ".autoloop", "memory.jsonl");
+
+function writeMem(lines: string[]) {
+  mkdirSync(join(tmpDir, ".autoloop"), { recursive: true });
+  writeFileSync(memFile, `${lines.join("\n")}\n`, "utf-8");
+}
+
+function memLine(id: string, type: string, extra: string): string {
+  return `{"id": "${id}", "type": "${type}", ${extra}}`;
+}
+
+function learning(id: string, text: string, created?: string): string {
+  const createdField = created ? `, "created": "${created}"` : "";
+  return memLine(
+    id,
+    "learning",
+    `"text": "${text}", "source": "s"${createdField}`,
+  );
+}
+
+let savedMemoryFileEnv: string | undefined;
+
+beforeEach(() => {
+  savedMemoryFileEnv = process.env.AUTOLOOP_MEMORY_FILE;
+  delete process.env.AUTOLOOP_MEMORY_FILE;
+  mkdirSync(tmpDir, { recursive: true });
+});
+
+afterEach(() => {
+  if (savedMemoryFileEnv === undefined) {
+    delete process.env.AUTOLOOP_MEMORY_FILE;
+  } else {
+    process.env.AUTOLOOP_MEMORY_FILE = savedMemoryFileEnv;
+  }
+  vi.useRealTimers();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("compactMemory", () => {
+  it("tombstones duplicate learnings, keeping the oldest", () => {
+    writeMem([
+      learning("mem-1", "always run lint"),
+      learning("mem-2", "always run lint"),
+      learning("mem-3", "always run lint"),
+      learning("mem-4", "unrelated lesson"),
+    ]);
+    const summary = compactMemory(tmpDir);
+    expect(summary.scanned).toBe(4);
+    expect(summary.duplicatesRemoved).toBe(2);
+    expect(summary.ids).toEqual(["mem-2", "mem-3"]);
+    const rendered = renderFile(memFile, 0);
+    expect(rendered).toContain("[mem-1]");
+    expect(rendered).not.toContain("[mem-2]");
+    expect(rendered).not.toContain("[mem-3]");
+    expect(rendered).toContain("[mem-4]");
+  });
+
+  it("normalizes whitespace when comparing texts", () => {
+    writeMem([
+      learning("mem-1", "always run lint"),
+      learning("mem-2", "  always   run lint  "),
+    ]);
+    const summary = compactMemory(tmpDir);
+    expect(summary.duplicatesRemoved).toBe(1);
+    expect(summary.ids).toEqual(["mem-2"]);
+  });
+
+  it("is case-sensitive", () => {
+    writeMem([
+      learning("mem-1", "always run lint"),
+      learning("mem-2", "Always Run Lint"),
+    ]);
+    const summary = compactMemory(tmpDir);
+    expect(summary.duplicatesRemoved).toBe(0);
+    expect(summary.ids).toEqual([]);
+  });
+
+  it("ignores already-tombstoned entries", () => {
+    writeMem([
+      learning("mem-1", "always run lint"),
+      learning("mem-2", "always run lint"),
+      `{"id": "ts-1", "type": "tombstone", "target_id": "mem-1", "reason": "stale"}`,
+    ]);
+    // mem-1 is tombstoned, so mem-2 is the only active copy: no duplicates.
+    const summary = compactMemory(tmpDir);
+    expect(summary.scanned).toBe(1);
+    expect(summary.duplicatesRemoved).toBe(0);
+    const rendered = renderFile(memFile, 0);
+    expect(rendered).toContain("[mem-2]");
+  });
+
+  it("does not collapse preferences or meta with matching texts", () => {
+    writeMem([
+      memLine("mem-1", "preference", '"category": "c", "text": "same text"'),
+      memLine("mem-2", "preference", '"category": "c", "text": "same text"'),
+      learning("mem-3", "same text"),
+    ]);
+    const summary = compactMemory(tmpDir);
+    expect(summary.duplicatesRemoved).toBe(0);
+    const rendered = renderFile(memFile, 0);
+    expect(rendered).toContain("[mem-1]");
+    expect(rendered).toContain("[mem-2]");
+    expect(rendered).toContain("[mem-3]");
+  });
+
+  it("appends tombstones instead of rewriting the file", () => {
+    writeMem([
+      learning("mem-1", "always run lint"),
+      learning("mem-2", "always run lint"),
+    ]);
+    compactMemory(tmpDir);
+    const content = readFileSync(memFile, "utf-8");
+    // Original entries remain in the log; a tombstone is appended.
+    expect(content).toContain('"id": "mem-1"');
+    expect(content).toContain('"id": "mem-2"');
+    expect(content).toContain('"type": "tombstone"');
+    expect(content).toContain('"target_id": "mem-2"');
+    expect(content).toContain("compact: duplicate learning");
+  });
+
+  it("returns zeros for a missing memory file", () => {
+    const summary = compactMemory(tmpDir);
+    expect(summary).toEqual({ scanned: 0, duplicatesRemoved: 0, ids: [] });
+  });
+});
+
+describe("pruneMemory", () => {
+  it("tombstones learnings strictly older than the cutoff", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-09T00:00:00Z"));
+    writeMem([
+      learning("mem-1", "ancient lesson", "2026-05-09T00:00:00Z"),
+      learning("mem-2", "exactly at cutoff", "2026-05-10T00:00:00Z"),
+      learning("mem-3", "recent lesson", "2026-06-01T00:00:00Z"),
+    ]);
+    const summary = pruneMemory(tmpDir, 30);
+    expect(summary.scanned).toBe(3);
+    expect(summary.pruned).toBe(1);
+    expect(summary.ids).toEqual(["mem-1"]);
+    const rendered = renderFile(memFile, 0);
+    expect(rendered).not.toContain("[mem-1]");
+    expect(rendered).toContain("[mem-2]");
+    expect(rendered).toContain("[mem-3]");
+    const content = readFileSync(memFile, "utf-8");
+    expect(content).toContain("prune: older than 30 days");
+  });
+
+  it("never prunes preferences or meta", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-09T00:00:00Z"));
+    writeMem([
+      memLine(
+        "mem-1",
+        "preference",
+        '"category": "c", "text": "old pref", "created": "2020-01-01T00:00:00Z"',
+      ),
+      memLine(
+        "meta-1",
+        "meta",
+        '"key": "k", "value": "old meta", "created": "2020-01-01T00:00:00Z"',
+      ),
+      learning("mem-2", "old lesson", "2020-01-01T00:00:00Z"),
+    ]);
+    const summary = pruneMemory(tmpDir, 30);
+    expect(summary.pruned).toBe(1);
+    expect(summary.ids).toEqual(["mem-2"]);
+    const rendered = renderFile(memFile, 0);
+    expect(rendered).toContain("old pref");
+    expect(rendered).toContain("old meta");
+    expect(rendered).not.toContain("old lesson");
+  });
+
+  it("skips already-tombstoned learnings", () => {
+    writeMem([
+      learning("mem-1", "old lesson", "2020-01-01T00:00:00Z"),
+      `{"id": "ts-1", "type": "tombstone", "target_id": "mem-1", "reason": "stale"}`,
+    ]);
+    const summary = pruneMemory(tmpDir, 30);
+    expect(summary.scanned).toBe(0);
+    expect(summary.pruned).toBe(0);
+    const content = readFileSync(memFile, "utf-8");
+    expect(content).not.toContain("prune:");
+  });
+
+  it("skips learnings with missing or unparseable created timestamps", () => {
+    writeMem([
+      learning("mem-1", "no timestamp"),
+      learning("mem-2", "bad timestamp", "not-a-date"),
+    ]);
+    const summary = pruneMemory(tmpDir, 30);
+    expect(summary.scanned).toBe(2);
+    expect(summary.pruned).toBe(0);
+  });
+});

--- a/packages/core/test/tasks-render.test.ts
+++ b/packages/core/test/tasks-render.test.ts
@@ -40,6 +40,57 @@ describe("renderTasksPrompt", () => {
     expect(result).toContain("- [x] [task-2] set up project (done)");
   });
 
+  it("shows priority and soft markers in the prompt", () => {
+    const tasks: MaterializedTasks = {
+      open: [
+        {
+          id: "task-1",
+          type: "task",
+          text: "fix the gate",
+          status: "open",
+          source: "manual",
+          created: "2026-01-01T00:00:00Z",
+          priority: "high",
+        },
+        {
+          id: "task-2",
+          type: "task",
+          text: "polish docs",
+          status: "open",
+          source: "manual",
+          created: "2026-01-01T00:00:00Z",
+          soft: true,
+        },
+        {
+          id: "task-3",
+          type: "task",
+          text: "plain default",
+          status: "open",
+          source: "manual",
+          created: "2026-01-01T00:00:00Z",
+        },
+      ],
+      done: [
+        {
+          id: "task-4",
+          type: "task",
+          text: "old chore",
+          status: "done",
+          source: "manual",
+          created: "2026-01-01T00:00:00Z",
+          completed: "2026-01-01T01:00:00Z",
+          priority: "low",
+        },
+      ],
+    };
+
+    const result = renderTasksPrompt(tasks, 4000);
+    expect(result).toContain("- [ ] [task-1] [high] fix the gate");
+    expect(result).toContain("- [ ] [task-2] polish docs (soft)");
+    expect(result).toContain("- [ ] [task-3] plain default");
+    expect(result).toContain("- [x] [task-4] [low] old chore (done)");
+  });
+
   it("truncates when over budget", () => {
     const tasks: MaterializedTasks = {
       open: [

--- a/packages/core/test/tasks.test.ts
+++ b/packages/core/test/tasks.test.ts
@@ -8,6 +8,7 @@ import {
   listTasks,
   materialize,
   materializeOpen,
+  parsePriority,
   removeTask,
   renderTaskList,
   updateTask,
@@ -71,6 +72,56 @@ describe("materialize", () => {
     const result = materialize(lines);
     expect(result.open[0].id).toBe("task-1");
     expect(result.open[1].id).toBe("task-2");
+  });
+
+  it("lines without priority/soft default to normal blocking tasks", () => {
+    const lines = [
+      '{"id": "task-1", "type": "task", "text": "legacy", "status": "open", "source": "manual", "created": "2026-01-01T00:00:00Z"}',
+    ];
+    const result = materialize(lines);
+    expect(result.open[0].priority).toBeUndefined();
+    expect(result.open[0].soft).toBeUndefined();
+  });
+
+  it("parses persisted priority and soft fields", () => {
+    const lines = [
+      '{"id": "task-1", "type": "task", "text": "urgent", "status": "open", "source": "manual", "created": "2026-01-01T00:00:00Z", "priority": "high", "soft": "true"}',
+    ];
+    const result = materialize(lines);
+    expect(result.open[0].priority).toBe("high");
+    expect(result.open[0].soft).toBe(true);
+  });
+
+  it("open tasks sorted high → normal → low, oldest first within priority", () => {
+    const lines = [
+      '{"id": "task-1", "type": "task", "text": "low one", "status": "open", "source": "manual", "created": "2026-01-01T00:00:00Z", "priority": "low"}',
+      '{"id": "task-2", "type": "task", "text": "normal one", "status": "open", "source": "manual", "created": "2026-01-02T00:00:00Z"}',
+      '{"id": "task-3", "type": "task", "text": "high one", "status": "open", "source": "manual", "created": "2026-01-03T00:00:00Z", "priority": "high"}',
+      '{"id": "task-4", "type": "task", "text": "high two", "status": "open", "source": "manual", "created": "2026-01-04T00:00:00Z", "priority": "high"}',
+      '{"id": "task-5", "type": "task", "text": "normal two", "status": "open", "source": "manual", "created": "2026-01-05T00:00:00Z", "priority": "normal"}',
+    ];
+    const result = materialize(lines);
+    expect(result.open.map((t) => t.id)).toEqual([
+      "task-3",
+      "task-4",
+      "task-2",
+      "task-5",
+      "task-1",
+    ]);
+  });
+});
+
+describe("parsePriority", () => {
+  it("accepts high, normal, low", () => {
+    expect(parsePriority("high")).toBe("high");
+    expect(parsePriority("normal")).toBe("normal");
+    expect(parsePriority("low")).toBe("low");
+  });
+
+  it("rejects anything else", () => {
+    expect(parsePriority("")).toBeUndefined();
+    expect(parsePriority("urgent")).toBeUndefined();
+    expect(parsePriority("HIGH")).toBeUndefined();
   });
 });
 
@@ -136,6 +187,57 @@ describe("CRUD operations", () => {
   it("removeTask returns false for unknown ID", () => {
     expect(removeTask(dir, "task-999", "nope")).toBe(false);
   });
+
+  it("addTask without opts writes no priority/soft fields (back-compat)", () => {
+    addTask(dir, "plain task", "manual");
+    const raw = readFileSync(join(dir, ".autoloop/tasks.jsonl"), "utf-8");
+    expect(raw).not.toContain("priority");
+    expect(raw).not.toContain("soft");
+  });
+
+  it("addTask persists priority and soft opts", () => {
+    addTask(dir, "urgent advisory", "manual", {
+      priority: "high",
+      soft: true,
+    });
+    const raw = readFileSync(join(dir, ".autoloop/tasks.jsonl"), "utf-8");
+    expect(raw).toContain('"priority": "high"');
+    expect(raw).toContain('"soft": "true"');
+
+    const open = materializeOpen(dir);
+    expect(open[0].priority).toBe("high");
+    expect(open[0].soft).toBe(true);
+  });
+
+  it("addTask omits normal priority and soft false", () => {
+    addTask(dir, "default-ish", "manual", { priority: "normal", soft: false });
+    const raw = readFileSync(join(dir, ".autoloop/tasks.jsonl"), "utf-8");
+    expect(raw).not.toContain("priority");
+    expect(raw).not.toContain("soft");
+  });
+
+  it("completeTask preserves priority and soft", () => {
+    addTask(dir, "marked", "manual", { priority: "low", soft: true });
+    expect(completeTask(dir, "task-1")).toBe(true);
+
+    const raw = readFileSync(join(dir, ".autoloop/tasks.jsonl"), "utf-8");
+    const doneLine = raw
+      .trim()
+      .split("\n")
+      .find((l) => l.includes('"status": "done"'));
+    expect(doneLine).toContain('"priority": "low"');
+    expect(doneLine).toContain('"soft": "true"');
+  });
+
+  it("updateTask preserves priority and soft", () => {
+    addTask(dir, "before", "manual", { priority: "high", soft: true });
+    expect(updateTask(dir, "task-1", "after")).toBe(true);
+
+    const open = materializeOpen(dir);
+    expect(open[0].text).toBe("after");
+    expect(open[0].priority).toBe("high");
+    expect(open[0].soft).toBe(true);
+  });
 });
 
 describe("renderTaskList", () => {
@@ -171,5 +273,34 @@ describe("renderTaskList", () => {
     expect(result).toContain("- [ ] [task-1] implement");
     expect(result).toContain("Done:");
     expect(result).toContain("- [x] [task-2] scaffold");
+  });
+
+  it("shows priority and soft markers", () => {
+    const result = renderTaskList({
+      open: [
+        {
+          id: "task-1",
+          type: "task",
+          text: "urgent thing",
+          status: "open",
+          source: "manual",
+          created: "2026-01-01T00:00:00Z",
+          priority: "high",
+        },
+        {
+          id: "task-2",
+          type: "task",
+          text: "nice to have",
+          status: "open",
+          source: "manual",
+          created: "2026-01-01T00:00:00Z",
+          priority: "low",
+          soft: true,
+        },
+      ],
+      done: [],
+    });
+    expect(result).toContain("- [ ] [task-1] [high] urgent thing");
+    expect(result).toContain("- [ ] [task-2] [low] nice to have (soft)");
   });
 });

--- a/packages/core/test/usage.test.ts
+++ b/packages/core/test/usage.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { encodeEvent } from "../src/events/encode.js";
+import { collectUsage, emptyUsageTotals, formatUsage } from "../src/usage.js";
+
+function usageLine(
+  run: string,
+  iteration: string,
+  fields: Record<string, string>,
+): string {
+  return encodeEvent({
+    shape: "fields",
+    run,
+    iteration,
+    topic: "backend.usage",
+    fields,
+  });
+}
+
+describe("collectUsage", () => {
+  it("aggregates backend.usage events into rows and totals", () => {
+    const lines = [
+      encodeEvent({
+        shape: "fields",
+        run: "r1",
+        iteration: "1",
+        topic: "iteration.start",
+        fields: { suggested_roles: "planner" },
+      }),
+      usageLine("r1", "1", {
+        input_tokens: "2500",
+        output_tokens: "850",
+        cache_read_tokens: "0",
+        cache_write_tokens: "500",
+        total_tokens: "3850",
+        cost_usd: "0.0192",
+        context_percent: "42",
+      }),
+      usageLine("r1", "2", {
+        input_tokens: "1000",
+        output_tokens: "200",
+        cache_read_tokens: "300",
+        cache_write_tokens: "0",
+        total_tokens: "1500",
+        cost_usd: "0.01",
+      }),
+    ];
+    const usage = collectUsage(lines);
+    expect(usage.rows).toHaveLength(2);
+    expect(usage.rows[0].iteration).toBe("1");
+    expect(usage.rows[0].contextPercent).toBe(42);
+    expect(usage.rows[1].contextPercent).toBeUndefined();
+    expect(usage.totals.iterations).toBe(2);
+    expect(usage.totals.inputTokens).toBe(3500);
+    expect(usage.totals.totalTokens).toBe(5350);
+    expect(usage.totals.costUsd).toBeCloseTo(0.0292, 6);
+  });
+
+  it("filters by runId when given", () => {
+    const lines = [
+      usageLine("r1", "1", { cost_usd: "0.5", total_tokens: "10" }),
+      usageLine("r2", "1", { cost_usd: "0.7", total_tokens: "20" }),
+    ];
+    const usage = collectUsage(lines, "r2");
+    expect(usage.rows).toHaveLength(1);
+    expect(usage.totals.costUsd).toBeCloseTo(0.7, 6);
+  });
+
+  it("treats missing or malformed numbers as zero", () => {
+    const lines = [
+      usageLine("r1", "1", { cost_usd: "not-a-number" }),
+      "not json at all",
+    ];
+    const usage = collectUsage(lines);
+    expect(usage.rows).toHaveLength(1);
+    expect(usage.totals.costUsd).toBe(0);
+    expect(usage.totals.inputTokens).toBe(0);
+  });
+
+  it("returns empty totals for an empty journal", () => {
+    const usage = collectUsage([]);
+    expect(usage.rows).toHaveLength(0);
+    expect(usage.totals).toEqual(emptyUsageTotals());
+  });
+});
+
+describe("formatUsage", () => {
+  const usage = collectUsage([
+    usageLine("r1", "1", {
+      input_tokens: "10",
+      output_tokens: "5",
+      total_tokens: "15",
+      cost_usd: "0.25",
+      context_percent: "12",
+    }),
+  ]);
+
+  it("renders a terminal table with totals", () => {
+    const text = formatUsage(usage, "terminal");
+    expect(text).toContain("## Usage");
+    expect(text).toContain("cost_usd");
+    expect(text).toContain("0.2500");
+    expect(text).toContain("totals: 1 iteration(s), 15 tokens, $0.2500");
+  });
+
+  it("renders JSON when asked", () => {
+    const parsed = JSON.parse(formatUsage(usage, "json"));
+    expect(parsed.totals.costUsd).toBeCloseTo(0.25, 6);
+    expect(parsed.rows[0].contextPercent).toBe(12);
+  });
+
+  it("explains when no telemetry exists", () => {
+    const text = formatUsage(collectUsage([]), "terminal");
+    expect(text).toContain("No backend usage telemetry");
+  });
+});

--- a/packages/core/test/worktree/diff.test.ts
+++ b/packages/core/test/worktree/diff.test.ts
@@ -1,0 +1,173 @@
+import { execSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createWorktree } from "../../src/worktree/create.js";
+import { diffWorktree } from "../../src/worktree/diff.js";
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "test",
+  GIT_AUTHOR_EMAIL: "t@t",
+  GIT_COMMITTER_NAME: "test",
+  GIT_COMMITTER_EMAIL: "t@t",
+};
+
+function makeGitRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "autoloop-ts-wt-diff-"));
+  execSync("git init && git commit --allow-empty -m init", {
+    cwd: dir,
+    stdio: "pipe",
+    env: GIT_ENV,
+  });
+  return dir;
+}
+
+function addFileAndCommit(
+  dir: string,
+  name: string,
+  content: string,
+  message: string,
+): void {
+  writeFileSync(join(dir, name), content);
+  execSync(`git add ${name} && git commit -m '${message}'`, {
+    cwd: dir,
+    stdio: "pipe",
+    env: GIT_ENV,
+  });
+}
+
+describe("diffWorktree", () => {
+  it("reports added files with insertion counts", () => {
+    const repo = makeGitRepo();
+    const stateDir = join(repo, ".autoloop");
+
+    const wt = createWorktree({
+      mainStateDir: stateDir,
+      runId: "run-diff1",
+      workDir: repo,
+    });
+
+    addFileAndCommit(
+      wt.worktreePath,
+      "feature.txt",
+      "line one\nline two\n",
+      "add feature",
+    );
+
+    const result = diffWorktree({ metaDir: wt.metaDir, workDir: repo });
+
+    expect(result.branch).toBe("autoloop/run-diff1");
+    expect(result.base).toBeTruthy();
+    expect(result.filesChanged).toBe(1);
+    expect(result.insertions).toBe(2);
+    expect(result.deletions).toBe(0);
+    expect(result.files).toEqual([{ path: "feature.txt", status: "added" }]);
+    expect(result.patch).toBeUndefined();
+  });
+
+  it("reports modifications and deletions with counts", () => {
+    const repo = makeGitRepo();
+    const stateDir = join(repo, ".autoloop");
+
+    addFileAndCommit(repo, "keep.txt", "old line\n", "add keep");
+    addFileAndCommit(repo, "gone.txt", "bye\n", "add gone");
+
+    const wt = createWorktree({
+      mainStateDir: stateDir,
+      runId: "run-diff2",
+      workDir: repo,
+    });
+
+    writeFileSync(join(wt.worktreePath, "keep.txt"), "new line\n");
+    execSync("git rm -q gone.txt && git add keep.txt && git commit -m edit", {
+      cwd: wt.worktreePath,
+      stdio: "pipe",
+      env: GIT_ENV,
+    });
+
+    const result = diffWorktree({ metaDir: wt.metaDir, workDir: repo });
+
+    expect(result.filesChanged).toBe(2);
+    expect(result.insertions).toBe(1);
+    expect(result.deletions).toBe(2);
+    expect(result.files).toContainEqual({
+      path: "keep.txt",
+      status: "modified",
+    });
+    expect(result.files).toContainEqual({
+      path: "gone.txt",
+      status: "deleted",
+    });
+  });
+
+  it("includes the full patch when requested", () => {
+    const repo = makeGitRepo();
+    const stateDir = join(repo, ".autoloop");
+
+    const wt = createWorktree({
+      mainStateDir: stateDir,
+      runId: "run-diff3",
+      workDir: repo,
+    });
+
+    addFileAndCommit(wt.worktreePath, "patched.txt", "hello patch\n", "add");
+
+    const result = diffWorktree({
+      metaDir: wt.metaDir,
+      workDir: repo,
+      patch: true,
+    });
+
+    expect(result.patch).toBeDefined();
+    expect(result.patch).toContain("diff --git a/patched.txt b/patched.txt");
+    expect(result.patch).toContain("+hello patch");
+  });
+
+  it("does not include base-only commits in the diff", () => {
+    const repo = makeGitRepo();
+    const stateDir = join(repo, ".autoloop");
+
+    const wt = createWorktree({
+      mainStateDir: stateDir,
+      runId: "run-diff4",
+      workDir: repo,
+    });
+
+    addFileAndCommit(wt.worktreePath, "wt.txt", "in worktree\n", "wt change");
+    // Advance the base branch after the worktree forked
+    addFileAndCommit(repo, "base.txt", "on base\n", "base change");
+
+    const result = diffWorktree({ metaDir: wt.metaDir, workDir: repo });
+
+    expect(result.files).toEqual([{ path: "wt.txt", status: "added" }]);
+  });
+
+  it("throws a clear error when meta is missing", () => {
+    const repo = makeGitRepo();
+    const metaDir = join(repo, ".autoloop", "worktrees", "run-nope");
+
+    expect(() => diffWorktree({ metaDir, workDir: repo })).toThrow(
+      /no worktree meta found/,
+    );
+  });
+
+  it("falls back to the project dir when the worktree dir was removed", () => {
+    const repo = makeGitRepo();
+    const stateDir = join(repo, ".autoloop");
+
+    const wt = createWorktree({
+      mainStateDir: stateDir,
+      runId: "run-diff5",
+      workDir: repo,
+    });
+
+    addFileAndCommit(wt.worktreePath, "still.txt", "kept in refs\n", "add");
+    rmSync(wt.worktreePath, { recursive: true, force: true });
+
+    // Branch refs still live in the main repo, so the diff still works.
+    const result = diffWorktree({ metaDir: wt.metaDir, workDir: repo });
+    expect(result.files).toEqual([{ path: "still.txt", status: "added" }]);
+  });
+});

--- a/packages/dashboard/src/app.ts
+++ b/packages/dashboard/src/app.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { apiRoutes } from "./routes/api.js";
 import { pageRoutes } from "./routes/pages.js";
+import { streamRoutes } from "./routes/stream.js";
 
 export interface PresetInfo {
   name: string;
@@ -43,6 +44,7 @@ export function createApp(ctx: DashboardContext): Hono {
   app.get("/healthz", (c) => c.json({ status: "ok" }));
 
   app.route("/api", apiRoutes(ctx));
+  app.route("/api", streamRoutes(ctx));
 
   pageRoutes(app, ctx.projectDir);
 

--- a/packages/dashboard/src/routes/api.ts
+++ b/packages/dashboard/src/routes/api.ts
@@ -29,22 +29,27 @@ function enrichRecords(stateDir: string, records: RunRecord[]): void {
   for (const r of records) enrichWithWorktreeMeta(stateDir, r);
 }
 
+/** Categorized + enriched run list — shared by /runs and /stream. */
+export function buildRunsPayload(
+  ctx: DashboardContext,
+): ReturnType<typeof categorizeRuns> {
+  const result = categorizeRuns(ctx.stateDir);
+  for (const bucket of [
+    result.active,
+    result.watching,
+    result.stuck,
+    result.recentFailed,
+    result.recentCompleted,
+  ]) {
+    enrichRecords(ctx.stateDir, bucket);
+  }
+  return result;
+}
+
 export function apiRoutes(ctx: DashboardContext): Hono {
   const api = new Hono();
 
-  api.get("/runs", (c) => {
-    const result = categorizeRuns(ctx.stateDir);
-    for (const bucket of [
-      result.active,
-      result.watching,
-      result.stuck,
-      result.recentFailed,
-      result.recentCompleted,
-    ]) {
-      enrichRecords(ctx.stateDir, bucket);
-    }
-    return c.json(result);
-  });
+  api.get("/runs", (c) => c.json(buildRunsPayload(ctx)));
 
   api.get("/runs/:id", (c) => {
     const id = c.req.param("id");

--- a/packages/dashboard/src/routes/stream.ts
+++ b/packages/dashboard/src/routes/stream.ts
@@ -1,0 +1,179 @@
+import { type FSWatcher, statSync, watch } from "node:fs";
+import { basename, dirname } from "node:path";
+import { Hono } from "hono";
+import type { DashboardContext } from "../app.js";
+import { buildRunsPayload } from "./api.js";
+
+/** SSE comment frame sent periodically so proxies keep the connection open. */
+export const KEEPALIVE_FRAME = ": keepalive\n\n";
+export const KEEPALIVE_INTERVAL_MS = 25_000;
+export const WATCH_DEBOUNCE_MS = 250;
+export const POLL_INTERVAL_MS = 2_000;
+
+/**
+ * Serialize a Server-Sent Events frame. Multi-line data is split into one
+ * `data:` line per line, per the SSE spec.
+ */
+export function buildSseFrame(event: string, data: string): string {
+  const dataLines = data
+    .split("\n")
+    .map((line) => `data: ${line}`)
+    .join("\n");
+  return `event: ${event}\n${dataLines}\n\n`;
+}
+
+export interface RegistryWatcher {
+  close(): void;
+}
+
+function mtimeOf(path: string): number {
+  try {
+    return statSync(path).mtimeMs;
+  } catch {
+    return -1;
+  }
+}
+
+/**
+ * Watch the registry file for changes, debouncing bursts of writes.
+ *
+ * Prefers `fs.watch` on the registry's parent directory so a not-yet-existing
+ * registry file is picked up on creation. Falls back to polling the file's
+ * mtime when `fs.watch` is unavailable (parent directory missing, or the
+ * platform watcher errors at runtime).
+ *
+ * All timers and watchers are unref'd so an open SSE connection never keeps
+ * the process alive past server close.
+ */
+export function watchRegistry(
+  registryPath: string,
+  onChange: () => void,
+  opts: { debounceMs?: number; pollMs?: number } = {},
+): RegistryWatcher {
+  const debounceMs = opts.debounceMs ?? WATCH_DEBOUNCE_MS;
+  const pollMs = opts.pollMs ?? POLL_INTERVAL_MS;
+  const dir = dirname(registryPath);
+  const fileName = basename(registryPath);
+
+  let closed = false;
+  let watcher: FSWatcher | undefined;
+  let pollTimer: ReturnType<typeof setInterval> | undefined;
+  let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+  let lastMtimeMs = mtimeOf(registryPath);
+
+  const fire = (): void => {
+    if (closed) return;
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      debounceTimer = undefined;
+      if (!closed) onChange();
+    }, debounceMs);
+    debounceTimer.unref?.();
+  };
+
+  const startPolling = (): void => {
+    if (closed || pollTimer) return;
+    pollTimer = setInterval(() => {
+      const mtime = mtimeOf(registryPath);
+      if (mtime !== lastMtimeMs) {
+        lastMtimeMs = mtime;
+        fire();
+      }
+    }, pollMs);
+    pollTimer.unref?.();
+  };
+
+  try {
+    watcher = watch(dir, (_eventType, changed) => {
+      // Some platforms report a null filename; refresh conservatively then.
+      if (changed === null || changed === fileName) fire();
+    });
+    watcher.on("error", () => {
+      watcher?.close();
+      watcher = undefined;
+      startPolling();
+    });
+    watcher.unref();
+  } catch {
+    startPolling();
+  }
+
+  return {
+    close(): void {
+      closed = true;
+      if (debounceTimer) clearTimeout(debounceTimer);
+      if (pollTimer) clearInterval(pollTimer);
+      watcher?.close();
+    },
+  };
+}
+
+export function streamRoutes(ctx: DashboardContext): Hono {
+  const routes = new Hono();
+
+  routes.get("/stream", (c) => {
+    const encoder = new TextEncoder();
+    let watcher: RegistryWatcher | undefined;
+    let keepalive: ReturnType<typeof setInterval> | undefined;
+    let closed = false;
+
+    const cleanup = (): void => {
+      if (closed) return;
+      closed = true;
+      watcher?.close();
+      watcher = undefined;
+      if (keepalive) clearInterval(keepalive);
+      keepalive = undefined;
+    };
+
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const send = (frame: string): void => {
+          if (closed) return;
+          try {
+            controller.enqueue(encoder.encode(frame));
+          } catch {
+            // Client went away mid-write; tear everything down.
+            cleanup();
+          }
+        };
+        const pushRuns = (): void =>
+          send(buildSseFrame("runs", JSON.stringify(buildRunsPayload(ctx))));
+
+        pushRuns();
+        watcher = watchRegistry(ctx.registryPath, pushRuns);
+        keepalive = setInterval(
+          () => send(KEEPALIVE_FRAME),
+          KEEPALIVE_INTERVAL_MS,
+        );
+        keepalive.unref?.();
+
+        c.req.raw.signal?.addEventListener(
+          "abort",
+          () => {
+            cleanup();
+            try {
+              controller.close();
+            } catch {
+              // already closed
+            }
+          },
+          { once: true },
+        );
+      },
+      cancel() {
+        cleanup();
+      },
+    });
+
+    return new Response(body, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      },
+    });
+  });
+
+  return routes;
+}

--- a/packages/dashboard/src/views/shell.ts
+++ b/packages/dashboard/src/views/shell.ts
@@ -497,6 +497,8 @@ function dashboard() {
     newPrompt: "",
     selectedPreset: "",
     pollInterval: null,
+    eventSource: null,
+    streamRetryDelay: 1000,
     lastUpdated: null,
     sectionOpen: { active: false, watching: false, stuck: false, failed: false, completed: false },
     sectionUserToggled: {},
@@ -551,26 +553,59 @@ function dashboard() {
     async startPolling() {
       await this.fetchPresets();
       await this.fetchRuns();
+      this.connectStream();
+    },
+
+    connectStream() {
+      if (typeof EventSource === 'undefined') { this.startFallbackPolling(); return; }
+      const es = new EventSource('/api/stream');
+      this.eventSource = es;
+      es.addEventListener('runs', (e) => {
+        this.streamRetryDelay = 1000;
+        this.stopFallbackPolling();
+        try { this.applyRuns(JSON.parse(e.data)); } catch (err) { /* ignore malformed frame */ }
+      });
+      es.onerror = () => {
+        es.close();
+        this.eventSource = null;
+        this.startFallbackPolling();
+        const delay = this.streamRetryDelay;
+        this.streamRetryDelay = Math.min(delay * 2, 30000);
+        setTimeout(() => this.connectStream(), delay);
+      };
+    },
+
+    startFallbackPolling() {
+      if (this.pollInterval) return;
       this.pollInterval = setInterval(() => this.fetchRuns(), 3000);
+    },
+
+    stopFallbackPolling() {
+      if (!this.pollInterval) return;
+      clearInterval(this.pollInterval);
+      this.pollInterval = null;
+    },
+
+    applyRuns(data) {
+      const byRecent = (a, b) => new Date(b.updated_at || 0) - new Date(a.updated_at || 0);
+      for (const key of ['active', 'watching', 'stuck', 'recentFailed', 'recentCompleted']) {
+        if (data[key]) data[key].sort(byRecent);
+      }
+      this.runs = data;
+      this.lastUpdated = new Date().toLocaleTimeString();
+      const defaultOpen = ['active', 'watching', 'stuck'];
+      for (const cat of this.categories) {
+        if (!this.sectionUserToggled[cat.key]) {
+          this.sectionOpen[cat.key] = cat.items.length > 0 && defaultOpen.includes(cat.key);
+        }
+      }
+      if (this.selectedRun) this.fetchEvents(this.selectedRun);
     },
 
     async fetchRuns() {
       try {
         const res = await fetch("/api/runs");
-        const data = await res.json();
-        const byRecent = (a, b) => new Date(b.updated_at || 0) - new Date(a.updated_at || 0);
-        for (const key of ['active', 'watching', 'stuck', 'recentFailed', 'recentCompleted']) {
-          if (data[key]) data[key].sort(byRecent);
-        }
-        this.runs = data;
-        this.lastUpdated = new Date().toLocaleTimeString();
-        const defaultOpen = ['active', 'watching', 'stuck'];
-        for (const cat of this.categories) {
-          if (!this.sectionUserToggled[cat.key]) {
-            this.sectionOpen[cat.key] = cat.items.length > 0 && defaultOpen.includes(cat.key);
-          }
-        }
-        if (this.selectedRun) this.fetchEvents(this.selectedRun);
+        this.applyRuns(await res.json());
       } catch (e) { /* retry on next poll */ }
     },
 

--- a/packages/dashboard/test/stream.test.ts
+++ b/packages/dashboard/test/stream.test.ts
@@ -1,0 +1,284 @@
+import { appendFileSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createApp, type DashboardContext } from "@mobrienv/autoloop-dashboard";
+import { describe, expect, it } from "vitest";
+import {
+  buildSseFrame,
+  KEEPALIVE_FRAME,
+  watchRegistry,
+} from "../src/routes/stream.js";
+import { htmlShell } from "../src/views/shell.js";
+
+function makeCtx(): DashboardContext & { registryPath: string } {
+  const projectDir = mkdtempSync(join(tmpdir(), "dashboard-stream-test-"));
+  const stateDir = join(projectDir, ".autoloop");
+  mkdirSync(stateDir, { recursive: true });
+  return {
+    registryPath: join(stateDir, "registry.jsonl"),
+    journalPath: join(stateDir, "journal.jsonl"),
+    stateDir,
+    bundleRoot: projectDir,
+    projectDir,
+    selfCmd: "autoloop",
+    listPresets: () => [],
+  };
+}
+
+function makeRecord(ctx: DashboardContext, runId: string): string {
+  const updatedAt = new Date().toISOString();
+  return JSON.stringify({
+    run_id: runId,
+    status: "running",
+    preset: "autocode",
+    objective: "stream test",
+    trigger: "cli",
+    project_dir: ctx.projectDir,
+    work_dir: ctx.projectDir,
+    state_dir: ctx.stateDir,
+    journal_file: ctx.journalPath,
+    parent_run_id: "",
+    backend: "mock",
+    backend_args: [],
+    created_at: updatedAt,
+    updated_at: updatedAt,
+    iteration: 1,
+    max_iterations: 10,
+    stop_reason: "",
+    latest_event: "iteration.finish",
+  });
+}
+
+/** Incrementally read SSE frames (separated by a blank line) from a Response. */
+function frameReader(res: Response) {
+  const body = res.body as ReadableStream<Uint8Array>;
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  return {
+    async next(timeoutMs = 5000): Promise<string> {
+      const deadline = Date.now() + timeoutMs;
+      for (;;) {
+        const idx = buf.indexOf("\n\n");
+        if (idx !== -1) {
+          const frame = buf.slice(0, idx);
+          buf = buf.slice(idx + 2);
+          return frame;
+        }
+        const remaining = deadline - Date.now();
+        if (remaining <= 0) throw new Error("timed out waiting for SSE frame");
+        const result = await Promise.race([
+          reader.read(),
+          new Promise<never>((_, reject) => {
+            const t = setTimeout(
+              () => reject(new Error("timed out waiting for SSE frame")),
+              remaining,
+            );
+            t.unref?.();
+          }),
+        ]);
+        if (result.done) throw new Error("stream ended unexpectedly");
+        buf += decoder.decode(result.value, { stream: true });
+      }
+    },
+    async cancel(): Promise<void> {
+      await reader.cancel();
+    },
+  };
+}
+
+function parseRunsFrame(frame: string): { event: string; data: unknown } {
+  const lines = frame.split("\n");
+  const eventLine = lines.find((l) => l.startsWith("event: "));
+  const data = lines
+    .filter((l) => l.startsWith("data: "))
+    .map((l) => l.slice("data: ".length))
+    .join("\n");
+  return {
+    event: eventLine ? eventLine.slice("event: ".length) : "",
+    data: JSON.parse(data),
+  };
+}
+
+async function waitFor(cond: () => boolean, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!cond()) {
+    if (Date.now() > deadline) throw new Error("timed out waiting");
+    await new Promise((r) => setTimeout(r, 25));
+  }
+}
+
+describe("buildSseFrame", () => {
+  it("serializes event name and single-line data", () => {
+    expect(buildSseFrame("runs", '{"active":[]}')).toBe(
+      'event: runs\ndata: {"active":[]}\n\n',
+    );
+  });
+
+  it("splits multi-line data into one data: line per line", () => {
+    expect(buildSseFrame("runs", "a\nb\nc")).toBe(
+      "event: runs\ndata: a\ndata: b\ndata: c\n\n",
+    );
+  });
+
+  it("keepalive frame is an SSE comment terminated by a blank line", () => {
+    expect(KEEPALIVE_FRAME).toBe(": keepalive\n\n");
+    expect(KEEPALIVE_FRAME.startsWith(":")).toBe(true);
+  });
+});
+
+describe("watchRegistry", () => {
+  it("fires onChange (debounced once) when the registry file changes", async () => {
+    const ctx = makeCtx();
+    writeFileSync(ctx.registryPath, "", "utf-8");
+    let calls = 0;
+    const watcher = watchRegistry(ctx.registryPath, () => calls++, {
+      debounceMs: 50,
+    });
+    try {
+      // Burst of writes should coalesce into a single onChange.
+      appendFileSync(ctx.registryPath, "line-1\n", "utf-8");
+      appendFileSync(ctx.registryPath, "line-2\n", "utf-8");
+      await waitFor(() => calls >= 1, 5000);
+      // Allow a second debounce window to elapse; no further writes occurred.
+      await new Promise((r) => setTimeout(r, 150));
+      expect(calls).toBe(1);
+    } finally {
+      watcher.close();
+    }
+  });
+
+  it("falls back to mtime polling when the parent directory does not exist", async () => {
+    const base = mkdtempSync(join(tmpdir(), "dashboard-stream-poll-"));
+    const registryPath = join(base, "missing-dir", "registry.jsonl");
+    let calls = 0;
+    const watcher = watchRegistry(registryPath, () => calls++, {
+      debounceMs: 20,
+      pollMs: 50,
+    });
+    try {
+      // Directory and file appear after the watcher started.
+      mkdirSync(join(base, "missing-dir"), { recursive: true });
+      writeFileSync(registryPath, "created\n", "utf-8");
+      await waitFor(() => calls >= 1, 5000);
+      expect(calls).toBeGreaterThanOrEqual(1);
+    } finally {
+      watcher.close();
+    }
+  });
+
+  it("does not fire after close", async () => {
+    const ctx = makeCtx();
+    writeFileSync(ctx.registryPath, "", "utf-8");
+    let calls = 0;
+    const watcher = watchRegistry(ctx.registryPath, () => calls++, {
+      debounceMs: 20,
+    });
+    watcher.close();
+    appendFileSync(ctx.registryPath, "after-close\n", "utf-8");
+    await new Promise((r) => setTimeout(r, 200));
+    expect(calls).toBe(0);
+  });
+});
+
+describe("GET /api/stream", () => {
+  it("sends SSE headers and an initial runs event matching /api/runs", async () => {
+    const ctx = makeCtx();
+    writeFileSync(ctx.registryPath, `${makeRecord(ctx, "run-sse-001")}\n`);
+    const app = createApp(ctx);
+
+    const res = await app.request("/api/stream");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+    expect(res.headers.get("cache-control")).toBe("no-cache");
+
+    const reader = frameReader(res);
+    try {
+      const frame = parseRunsFrame(await reader.next());
+      expect(frame.event).toBe("runs");
+
+      const expectedRes = await app.request("/api/runs");
+      const expected = await expectedRes.json();
+      expect(frame.data).toEqual(expected);
+
+      const allRuns = Object.values(
+        frame.data as Record<string, { run_id: string }[]>,
+      ).flat();
+      expect(allRuns.some((r) => r.run_id === "run-sse-001")).toBe(true);
+    } finally {
+      await reader.cancel();
+    }
+  });
+
+  it("pushes a fresh runs event when the registry changes", async () => {
+    const ctx = makeCtx();
+    writeFileSync(ctx.registryPath, `${makeRecord(ctx, "run-sse-first")}\n`);
+    const app = createApp(ctx);
+
+    const res = await app.request("/api/stream");
+    const reader = frameReader(res);
+    try {
+      const initial = parseRunsFrame(await reader.next());
+      expect(initial.event).toBe("runs");
+
+      appendFileSync(
+        ctx.registryPath,
+        `${makeRecord(ctx, "run-sse-second")}\n`,
+        "utf-8",
+      );
+
+      // Accept keepalives / intermediate frames until the new run shows up.
+      const deadline = Date.now() + 10_000;
+      let found = false;
+      while (!found && Date.now() < deadline) {
+        const raw = await reader.next(deadline - Date.now());
+        if (!raw.startsWith("event: runs")) continue;
+        const frame = parseRunsFrame(raw);
+        const allRuns = Object.values(
+          frame.data as Record<string, { run_id: string }[]>,
+        ).flat();
+        found = allRuns.some((r) => r.run_id === "run-sse-second");
+      }
+      expect(found).toBe(true);
+    } finally {
+      await reader.cancel();
+    }
+  });
+
+  it("streams an initial event even when the registry file does not exist yet", async () => {
+    const ctx = makeCtx();
+    // registry.jsonl intentionally not created
+    const app = createApp(ctx);
+
+    const res = await app.request("/api/stream");
+    expect(res.status).toBe(200);
+    const reader = frameReader(res);
+    try {
+      const frame = parseRunsFrame(await reader.next());
+      expect(frame.event).toBe("runs");
+      const data = frame.data as Record<string, unknown[]>;
+      expect(data.active).toEqual([]);
+    } finally {
+      await reader.cancel();
+    }
+  });
+});
+
+describe("shell SSE client", () => {
+  it("connects EventSource to /api/stream and applies runs events", () => {
+    const html = htmlShell();
+    expect(html).toContain("new EventSource('/api/stream')");
+    expect(html).toContain("es.addEventListener('runs'");
+    expect(html).toContain("this.applyRuns(JSON.parse(e.data))");
+  });
+
+  it("falls back to fetch polling with backoff on EventSource error", () => {
+    const html = htmlShell();
+    expect(html).toContain("startFallbackPolling()");
+    expect(html).toContain("stopFallbackPolling()");
+    expect(html).toContain(
+      "this.streamRetryDelay = Math.min(delay * 2, 30000)",
+    );
+    expect(html).toContain("setTimeout(() => this.connectStream(), delay)");
+  });
+});

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -43,6 +43,10 @@
       "types": "./dist/metrics.d.ts",
       "default": "./dist/metrics.js"
     },
+    "./guards": {
+      "types": "./dist/guards.d.ts",
+      "default": "./dist/guards.js"
+    },
     "./scratchpad": {
       "types": "./dist/scratchpad.d.ts",
       "default": "./dist/scratchpad.js"

--- a/packages/harness/src/config-helpers.ts
+++ b/packages/harness/src/config-helpers.ts
@@ -522,6 +522,8 @@ export function reloadLoop(loop: LoopContext): LoopContext {
     topology: updatedTopology,
     limits: {
       maxIterations: config.getInt(cfg, "event_loop.max_iterations", 3),
+      stallIterations: config.getInt(cfg, "event_loop.stall_iterations", 0),
+      maxCostUsd: config.getFloat(cfg, "event_loop.max_cost_usd", 0),
     },
     completion: {
       promise: config.get(

--- a/packages/harness/src/emit.ts
+++ b/packages/harness/src/emit.ts
@@ -104,12 +104,15 @@ export function emit(
     return acceptEmit(journalFile, topic, payload, validation);
   }
 
-  // Task completion gate: block completion if open tasks remain
+  // Task completion gate: block completion if open blocking tasks remain.
+  // Soft tasks (soft === true) are advisory and never block completion.
   if (topic === validation.completionEvent) {
     const tasksFile = config.resolveTasksFile(projectDir);
-    const openTasks = materializeOpenFrom(tasksFile);
-    if (openTasks.length > 0) {
-      return rejectTaskGate(journalFile, topic, openTasks, validation);
+    const blockingTasks = materializeOpenFrom(tasksFile).filter(
+      (t) => t.soft !== true,
+    );
+    if (blockingTasks.length > 0) {
+      return rejectTaskGate(journalFile, topic, blockingTasks, validation);
     }
   }
 

--- a/packages/harness/src/guards.ts
+++ b/packages/harness/src/guards.ts
@@ -1,0 +1,56 @@
+// Run-level guard checks evaluated between iterations.
+//
+// Both guards are journal-derived (no in-memory counters), so they survive
+// context reloads and apply uniformly to every continue path — routed events,
+// rejected emits, and plain continues alike.
+
+import { collectUsage, decodeEvent } from "@mobrienv/autoloop-core";
+
+export interface StallCheck {
+  stalled: boolean;
+  repeats: number;
+}
+
+/**
+ * Detect a no-progress loop: `threshold` (or more) consecutive iterations
+ * whose backend output is byte-identical. A threshold of 0 disables the
+ * check. Empty outputs never count as a stall — backend failures and
+ * timeouts already have their own stop reasons.
+ */
+export function detectStall(runLines: string[], threshold: number): StallCheck {
+  if (threshold <= 0) return { stalled: false, repeats: 0 };
+  const outputs: string[] = [];
+  for (const line of runLines) {
+    const event = decodeEvent(line);
+    if (!event || event.shape !== "fields") continue;
+    if (event.topic !== "iteration.finish") continue;
+    outputs.push((event.fields.output ?? "").trim());
+  }
+  if (outputs.length === 0) return { stalled: false, repeats: 0 };
+  const last = outputs[outputs.length - 1];
+  if (last === "") return { stalled: false, repeats: 0 };
+  let repeats = 1;
+  for (let i = outputs.length - 2; i >= 0 && outputs[i] === last; i--) {
+    repeats++;
+  }
+  return { stalled: repeats >= threshold, repeats };
+}
+
+export interface CostBudgetCheck {
+  exceeded: boolean;
+  costUsd: number;
+}
+
+/**
+ * Check accumulated run cost (from `backend.usage` events) against a USD
+ * budget. A budget of 0 disables the check. Backends without usage telemetry
+ * report zero cost, so the budget never fires for them.
+ */
+export function checkCostBudget(
+  runLines: string[],
+  maxCostUsd: number,
+): CostBudgetCheck {
+  if (maxCostUsd <= 0) return { exceeded: false, costUsd: 0 };
+  const { totals } = collectUsage(runLines);
+  return { exceeded: totals.costUsd >= maxCostUsd, costUsd: totals.costUsd };
+}

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -1,6 +1,5 @@
 import { existsSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import type { AcpSession } from "@mobrienv/autoloop-backends/acp-client";
 import { terminateAcpSession } from "@mobrienv/autoloop-backends/acp-client";
 import {
   abortPiTurn,
@@ -8,14 +7,13 @@ import {
   terminatePiSession,
 } from "@mobrienv/autoloop-backends/pi-rpc-client";
 import * as config from "@mobrienv/autoloop-core/config";
-import { readIfExists } from "@mobrienv/autoloop-core/journal";
+import { readIfExists, readRunLines } from "@mobrienv/autoloop-core/journal";
 import {
   cleanWorktrees,
   mergeWorktree,
   readMeta,
   updateStatus as updateWorktreeStatus,
 } from "@mobrienv/autoloop-core/worktree";
-import { collectArtifacts, formatArtifacts } from "./artifacts.js";
 import {
   applyRuntimeModeOverrides,
   buildLoopContext,
@@ -34,8 +32,10 @@ import {
 import { piControlAdapter } from "./control/pi-adapter.js";
 import { log } from "./display.js";
 import { emit as emitCmd } from "./emit.js";
+import { checkCostBudget, detectStall } from "./guards.js";
 import { runIteration } from "./iteration.js";
 import { maybeRunMetareview } from "./metareview.js";
+import { runFinishNotification } from "./notify.js";
 import {
   appendLoopStart,
   branchStopReason,
@@ -46,7 +46,12 @@ import {
   writeParallelBranchSummary,
 } from "./parallel.js";
 import { registryStart, registryStop } from "./registry-bridge.js";
-import { completeLoop, stopMaxIterations } from "./stop.js";
+import {
+  completeLoop,
+  stopCostBudget,
+  stopMaxIterations,
+  stopStalled,
+} from "./stop.js";
 import type { LoopContext, RunOptions, RunSummary } from "./types.js";
 
 export type { LoopContext, RunOptions, RunSummary };
@@ -256,6 +261,15 @@ export async function run(
     }
   }
 
+  runFinishNotification({
+    projectDir: loop.paths.mainProjectDir,
+    journalFile: loop.paths.journalFile,
+    runId: loop.runtime.runId,
+    preset: loop.launch.preset,
+    stopReason: summary.stopReason,
+    iterations: summary.iterations,
+  });
+
   loop.onEvent?.({
     type: "summary",
     runId: loop.runtime.runId,
@@ -410,6 +424,27 @@ async function runReviewThenIterate(
 
   if (iteration > reviewed.limits.maxIterations) {
     return stopMaxIterations(reviewed, iteration);
+  }
+  // Guard checks between iterations: both are journal-derived so they cover
+  // every continue path (routed, rejected, plain) without in-memory state.
+  if (iteration > 1) {
+    const runLines = readRunLines(
+      reviewed.paths.journalFile,
+      reviewed.runtime.runId,
+    );
+    const stall = detectStall(runLines, reviewed.limits.stallIterations ?? 0);
+    if (stall.stalled) {
+      return stopStalled(reviewed, iteration - 1, stall.repeats);
+    }
+    const budget = checkCostBudget(runLines, reviewed.limits.maxCostUsd ?? 0);
+    if (budget.exceeded) {
+      return stopCostBudget(
+        reviewed,
+        iteration - 1,
+        budget.costUsd,
+        reviewed.limits.maxCostUsd ?? 0,
+      );
+    }
   }
   return runIteration(reviewed, iteration, recurse);
 }

--- a/packages/harness/src/notify.ts
+++ b/packages/harness/src/notify.ts
@@ -1,0 +1,138 @@
+// Finish notifications: run a user-configured command when a loop ends.
+//
+// Config (autoloops.toml):
+//   notify.command    — shell command to run; "" (default) disables notifications
+//   notify.on         — CSV of stop-reason classes to notify on
+//                       (completed | failed | stopped); default "completed,failed"
+//   notify.timeout_ms — max time the command may run; default 10000
+//
+// The command receives AUTOLOOP_* env vars and a JSON payload on stdin.
+// Everything here is best-effort: this module never throws.
+
+import { spawnSync } from "node:child_process";
+import { jsonField } from "@mobrienv/autoloop-core";
+import * as config from "@mobrienv/autoloop-core/config";
+import { appendEvent } from "@mobrienv/autoloop-core/journal";
+
+export interface FinishNotificationOptions {
+  projectDir: string;
+  journalFile: string;
+  runId: string;
+  preset: string;
+  stopReason: string;
+  iterations: number;
+}
+
+export interface FinishNotificationResult {
+  status: "disabled" | "skipped" | "sent" | "failed";
+  detail?: string;
+}
+
+export type StopReasonClass = "completed" | "failed" | "stopped";
+
+export function classifyStopReason(stopReason: string): StopReasonClass {
+  if (stopReason === "completed" || stopReason.startsWith("completion"))
+    return "completed";
+  if (stopReason === "backend_failed" || stopReason === "backend_timeout")
+    return "failed";
+  return "stopped";
+}
+
+export function runFinishNotification(
+  opts: FinishNotificationOptions,
+): FinishNotificationResult {
+  let command = "";
+  try {
+    const cfg = config.loadProject(opts.projectDir);
+    command = config.get(cfg, "notify.command", "").trim();
+    if (!command) return { status: "disabled" };
+
+    const onClasses = config
+      .get(cfg, "notify.on", "completed,failed")
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+    const reasonClass = classifyStopReason(opts.stopReason);
+    if (!onClasses.includes(reasonClass))
+      return { status: "skipped", detail: reasonClass };
+
+    const timeoutMs = config.getInt(cfg, "notify.timeout_ms", 10000);
+    const payload = JSON.stringify({
+      run_id: opts.runId,
+      stop_reason: opts.stopReason,
+      iterations: opts.iterations,
+      preset: opts.preset,
+      project_dir: opts.projectDir,
+    });
+
+    const result = spawnSync(command, {
+      shell: true,
+      input: payload,
+      timeout: timeoutMs,
+      env: {
+        ...process.env,
+        AUTOLOOP_RUN_ID: opts.runId,
+        AUTOLOOP_STOP_REASON: opts.stopReason,
+        AUTOLOOP_ITERATIONS: String(opts.iterations),
+        AUTOLOOP_PRESET: opts.preset,
+        AUTOLOOP_PROJECT_DIR: opts.projectDir,
+      },
+    });
+
+    if (result.error || result.status !== 0) {
+      const detail = result.error
+        ? result.error.message
+        : `exit ${result.status ?? `signal ${result.signal}`}: ${result.stderr?.toString() ?? ""}`;
+      journalFailed(opts, command, detail);
+      return { status: "failed", detail: tail(detail, 200) };
+    }
+
+    journalSent(opts, command);
+    return { status: "sent" };
+  } catch (err: unknown) {
+    const detail = err instanceof Error ? err.message : String(err);
+    journalFailed(opts, command, detail);
+    return { status: "failed", detail: tail(detail, 200) };
+  }
+}
+
+function journalSent(opts: FinishNotificationOptions, command: string): void {
+  try {
+    appendEvent(
+      opts.journalFile,
+      opts.runId,
+      "",
+      "notify.sent",
+      jsonField("command", command) +
+        ", " +
+        jsonField("stop_reason", opts.stopReason),
+    );
+  } catch {
+    /* best-effort */
+  }
+}
+
+function journalFailed(
+  opts: FinishNotificationOptions,
+  command: string,
+  error: string,
+): void {
+  try {
+    appendEvent(
+      opts.journalFile,
+      opts.runId,
+      "",
+      "notify.failed",
+      jsonField("command", command) +
+        ", " +
+        jsonField("error", tail(error, 200)),
+    );
+  } catch {
+    /* best-effort */
+  }
+}
+
+function tail(text: string, max: number): string {
+  const trimmed = text.trim();
+  return trimmed.length <= max ? trimmed : trimmed.slice(-max);
+}

--- a/packages/harness/src/stop.ts
+++ b/packages/harness/src/stop.ts
@@ -114,6 +114,77 @@ export function stopBackendTimeout(
   return { iterations: iteration, stopReason: "backend_timeout" };
 }
 
+export function stopStalled(
+  loop: LoopContext,
+  completed: number,
+  repeats: number,
+): RunSummary {
+  log(
+    loop,
+    "warn",
+    `loop stop reason=stalled identical_outputs=${repeats} threshold=${loop.limits.stallIterations ?? 0}`,
+  );
+  loop.onEvent?.({
+    type: "progress",
+    runId: loop.runtime.runId,
+    iteration: completed,
+    recentEvent: "loop.stop",
+    allowedRoles: [],
+    outcome: "stop:stalled",
+  });
+  appendEvent(
+    loop.paths.journalFile,
+    loop.runtime.runId,
+    "",
+    "loop.stop",
+    jsonField("reason", "stalled") +
+      ", " +
+      jsonField("completed_iterations", String(completed)) +
+      ", " +
+      jsonField("identical_outputs", String(repeats)) +
+      ", " +
+      jsonField("stall_iterations", String(loop.limits.stallIterations ?? 0)),
+  );
+  registryStop(loop, completed, "stalled");
+  return { iterations: completed, stopReason: "stalled" };
+}
+
+export function stopCostBudget(
+  loop: LoopContext,
+  completed: number,
+  costUsd: number,
+  maxCostUsd: number,
+): RunSummary {
+  log(
+    loop,
+    "warn",
+    `loop stop reason=cost_budget cost_usd=${costUsd.toFixed(4)} max_cost_usd=${maxCostUsd}`,
+  );
+  loop.onEvent?.({
+    type: "progress",
+    runId: loop.runtime.runId,
+    iteration: completed,
+    recentEvent: "loop.stop",
+    allowedRoles: [],
+    outcome: "stop:cost_budget",
+  });
+  appendEvent(
+    loop.paths.journalFile,
+    loop.runtime.runId,
+    "",
+    "loop.stop",
+    jsonField("reason", "cost_budget") +
+      ", " +
+      jsonField("completed_iterations", String(completed)) +
+      ", " +
+      jsonField("cost_usd", costUsd.toFixed(6)) +
+      ", " +
+      jsonField("max_cost_usd", String(maxCostUsd)),
+  );
+  registryStop(loop, completed, "cost_budget");
+  return { iterations: completed, stopReason: "cost_budget" };
+}
+
 export function completeLoop(
   loop: LoopContext,
   iteration: number,

--- a/packages/harness/src/types.ts
+++ b/packages/harness/src/types.ts
@@ -34,7 +34,13 @@ export interface Verdict {
 export interface LoopContext {
   objective: string;
   topology: topo.Topology;
-  limits: { maxIterations: number };
+  limits: {
+    maxIterations: number;
+    /** Stop after N consecutive identical backend outputs (0 = disabled). */
+    stallIterations?: number;
+    /** Stop once journaled run cost reaches this USD budget (0 = disabled). */
+    maxCostUsd?: number;
+  };
   completion: { promise: string; event: string; requiredEvents: string[] };
   backend: {
     kind: string;

--- a/packages/harness/test/harness/guards.test.ts
+++ b/packages/harness/test/harness/guards.test.ts
@@ -1,0 +1,107 @@
+import { encodeEvent } from "@mobrienv/autoloop-core";
+import {
+  checkCostBudget,
+  detectStall,
+} from "@mobrienv/autoloop-harness/guards";
+import { describe, expect, it } from "vitest";
+
+function finishLine(iteration: string, output: string): string {
+  return encodeEvent({
+    shape: "fields",
+    run: "r1",
+    iteration,
+    topic: "iteration.finish",
+    fields: { exit_code: "0", timed_out: "false", output },
+  });
+}
+
+function usageLine(iteration: string, costUsd: string): string {
+  return encodeEvent({
+    shape: "fields",
+    run: "r1",
+    iteration,
+    topic: "backend.usage",
+    fields: { cost_usd: costUsd, total_tokens: "100" },
+  });
+}
+
+describe("detectStall", () => {
+  it("is disabled when threshold is zero", () => {
+    const lines = [finishLine("1", "same"), finishLine("2", "same")];
+    expect(detectStall(lines, 0)).toEqual({ stalled: false, repeats: 0 });
+  });
+
+  it("does not stall while outputs differ", () => {
+    const lines = [
+      finishLine("1", "working on step 1"),
+      finishLine("2", "working on step 2"),
+      finishLine("3", "working on step 1"),
+    ];
+    const check = detectStall(lines, 2);
+    expect(check.stalled).toBe(false);
+    expect(check.repeats).toBe(1);
+  });
+
+  it("stalls after N consecutive identical outputs", () => {
+    const lines = [
+      finishLine("1", "different"),
+      finishLine("2", "I cannot proceed."),
+      finishLine("3", "I cannot proceed."),
+      finishLine("4", "I cannot proceed."),
+    ];
+    const check = detectStall(lines, 3);
+    expect(check.stalled).toBe(true);
+    expect(check.repeats).toBe(3);
+  });
+
+  it("ignores leading whitespace differences", () => {
+    const lines = [finishLine("1", "  stuck "), finishLine("2", "stuck")];
+    expect(detectStall(lines, 2).stalled).toBe(true);
+  });
+
+  it("never stalls on empty outputs", () => {
+    const lines = [
+      finishLine("1", ""),
+      finishLine("2", ""),
+      finishLine("3", ""),
+    ];
+    expect(detectStall(lines, 2).stalled).toBe(false);
+  });
+
+  it("handles journals with no iteration.finish events", () => {
+    expect(detectStall(["not json"], 2)).toEqual({
+      stalled: false,
+      repeats: 0,
+    });
+  });
+});
+
+describe("checkCostBudget", () => {
+  it("is disabled when budget is zero", () => {
+    const lines = [usageLine("1", "5.00")];
+    expect(checkCostBudget(lines, 0)).toEqual({ exceeded: false, costUsd: 0 });
+  });
+
+  it("stays under budget while cost accumulates", () => {
+    const lines = [usageLine("1", "0.30"), usageLine("2", "0.30")];
+    const check = checkCostBudget(lines, 1.0);
+    expect(check.exceeded).toBe(false);
+    expect(check.costUsd).toBeCloseTo(0.6, 6);
+  });
+
+  it("trips once accumulated cost reaches the budget", () => {
+    const lines = [
+      usageLine("1", "0.50"),
+      usageLine("2", "0.30"),
+      usageLine("3", "0.25"),
+    ];
+    const check = checkCostBudget(lines, 1.0);
+    expect(check.exceeded).toBe(true);
+    expect(check.costUsd).toBeCloseTo(1.05, 6);
+  });
+
+  it("never trips for backends without usage telemetry", () => {
+    const lines = [finishLine("1", "output only")];
+    expect(checkCostBudget(lines, 0.01).exceeded).toBe(false);
+  });
+});

--- a/packages/harness/test/harness/notify.test.ts
+++ b/packages/harness/test/harness/notify.test.ts
@@ -1,0 +1,180 @@
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { decodeEvent } from "@mobrienv/autoloop-core";
+import { describe, expect, it } from "vitest";
+import {
+  classifyStopReason,
+  type FinishNotificationOptions,
+  runFinishNotification,
+} from "../../src/notify.js";
+
+function makeProject(notifyToml: string): { dir: string; journal: string } {
+  const dir = mkdtempSync(join(tmpdir(), "autoloop-notify-test-"));
+  writeFileSync(join(dir, "autoloops.toml"), notifyToml);
+  return { dir, journal: join(dir, "journal.jsonl") };
+}
+
+function baseOpts(
+  dir: string,
+  journal: string,
+  overrides: Partial<FinishNotificationOptions> = {},
+): FinishNotificationOptions {
+  return {
+    projectDir: dir,
+    journalFile: journal,
+    runId: "run-notify-1",
+    preset: "default",
+    stopReason: "completed",
+    iterations: 3,
+    ...overrides,
+  };
+}
+
+function journalEvents(journal: string) {
+  if (!existsSync(journal)) return [];
+  return readFileSync(journal, "utf-8")
+    .split("\n")
+    .filter((line) => line.trim())
+    .map((line) => decodeEvent(line))
+    .filter((event) => event !== null);
+}
+
+describe("classifyStopReason", () => {
+  it("classifies completion variants as completed", () => {
+    expect(classifyStopReason("completed")).toBe("completed");
+    expect(classifyStopReason("completion_promise")).toBe("completed");
+  });
+
+  it("classifies backend failures as failed", () => {
+    expect(classifyStopReason("backend_failed")).toBe("failed");
+    expect(classifyStopReason("backend_timeout")).toBe("failed");
+  });
+
+  it("classifies everything else as stopped", () => {
+    expect(classifyStopReason("max_iterations")).toBe("stopped");
+    expect(classifyStopReason("interrupted")).toBe("stopped");
+    expect(classifyStopReason("cost_budget")).toBe("stopped");
+  });
+});
+
+describe("runFinishNotification", () => {
+  it("is disabled when notify.command is unset", () => {
+    const { dir, journal } = makeProject('[backend]\ncommand = "echo"\n');
+    const result = runFinishNotification(baseOpts(dir, journal));
+    expect(result.status).toBe("disabled");
+    expect(journalEvents(journal)).toHaveLength(0);
+  });
+
+  it("skips when the stop-reason class is not in notify.on", () => {
+    const { dir, journal } = makeProject(
+      `[notify]\ncommand = "touch ${join(tmpdir(), "should-not-exist")}"\non = "completed"\n`,
+    );
+    const result = runFinishNotification(
+      baseOpts(dir, journal, { stopReason: "backend_failed" }),
+    );
+    expect(result.status).toBe("skipped");
+    expect(result.detail).toBe("failed");
+    expect(journalEvents(journal)).toHaveLength(0);
+  });
+
+  it("passes env vars and a JSON stdin payload to the command", () => {
+    const { dir, journal } = makeProject("");
+    const envOut = join(dir, "env.out");
+    const stdinOut = join(dir, "stdin.out");
+    writeFileSync(
+      join(dir, "autoloops.toml"),
+      `[notify]\ncommand = "env | grep ^AUTOLOOP_ > ${envOut}; cat > ${stdinOut}"\n`,
+    );
+
+    const result = runFinishNotification(
+      baseOpts(dir, journal, { stopReason: "completed", iterations: 7 }),
+    );
+    expect(result.status).toBe("sent");
+
+    const env = readFileSync(envOut, "utf-8");
+    expect(env).toContain("AUTOLOOP_RUN_ID=run-notify-1");
+    expect(env).toContain("AUTOLOOP_STOP_REASON=completed");
+    expect(env).toContain("AUTOLOOP_ITERATIONS=7");
+    expect(env).toContain("AUTOLOOP_PRESET=default");
+    expect(env).toContain(`AUTOLOOP_PROJECT_DIR=${dir}`);
+
+    const payload = JSON.parse(readFileSync(stdinOut, "utf-8"));
+    expect(payload).toEqual({
+      run_id: "run-notify-1",
+      stop_reason: "completed",
+      iterations: 7,
+      preset: "default",
+      project_dir: dir,
+    });
+
+    const events = journalEvents(journal);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.topic).toBe("notify.sent");
+    expect(events[0]?.run).toBe("run-notify-1");
+    if (events[0]?.shape === "fields") {
+      expect(events[0].fields.stop_reason).toBe("completed");
+      expect(events[0].fields.command).toContain("env | grep ^AUTOLOOP_");
+    } else {
+      throw new Error("expected fields event");
+    }
+  });
+
+  it("journals notify.failed on non-zero exit", () => {
+    const { dir, journal } = makeProject(
+      '[notify]\ncommand = "echo boom >&2; exit 3"\n',
+    );
+    const result = runFinishNotification(
+      baseOpts(dir, journal, { stopReason: "backend_failed" }),
+    );
+    expect(result.status).toBe("failed");
+    expect(result.detail).toContain("exit 3");
+
+    const events = journalEvents(journal);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.topic).toBe("notify.failed");
+    if (events[0]?.shape === "fields") {
+      expect(events[0].fields.command).toBe("echo boom >&2; exit 3");
+      expect(events[0].fields.error).toContain("boom");
+      expect(events[0].fields.error.length).toBeLessThanOrEqual(200);
+    } else {
+      throw new Error("expected fields event");
+    }
+  });
+
+  it("enforces notify.timeout_ms and journals notify.failed", () => {
+    const { dir, journal } = makeProject(
+      '[notify]\ncommand = "sleep 5"\ntimeout_ms = 200\n',
+    );
+    const started = Date.now();
+    const result = runFinishNotification(baseOpts(dir, journal));
+    const elapsed = Date.now() - started;
+
+    expect(result.status).toBe("failed");
+    expect(elapsed).toBeLessThan(4000);
+
+    const events = journalEvents(journal);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.topic).toBe("notify.failed");
+    if (events[0]?.shape === "fields") {
+      expect(events[0].fields.error).toContain("ETIMEDOUT");
+    } else {
+      throw new Error("expected fields event");
+    }
+  });
+
+  it("respects notify.on=stopped for non-terminal-class reasons", () => {
+    const { dir, journal } = makeProject("");
+    const marker = join(dir, "stopped.marker");
+    writeFileSync(
+      join(dir, "autoloops.toml"),
+      `[notify]\ncommand = "touch ${marker}"\non = "stopped"\n`,
+    );
+    const result = runFinishNotification(
+      baseOpts(dir, journal, { stopReason: "max_iterations" }),
+    );
+    expect(result.status).toBe("sent");
+    expect(existsSync(marker)).toBe(true);
+    expect(journalEvents(journal)[0]?.topic).toBe("notify.sent");
+  });
+});

--- a/packages/harness/test/harness/task-gate.test.ts
+++ b/packages/harness/test/harness/task-gate.test.ts
@@ -94,4 +94,56 @@ describe("task completion gate", () => {
 
     expect(result.ok).toBe(true);
   });
+
+  it("allows completion when only soft tasks remain open", () => {
+    addTask(dir, "advisory cleanup", "manual", { soft: true });
+    addTask(dir, "advisory docs", "manual", { soft: true, priority: "low" });
+
+    const result = emit(dir, "task.complete", "done");
+
+    expect(result.ok).toBe(true);
+    const journal = readFileSync(journalFile, "utf-8");
+    expect(journal).not.toContain("task.gate");
+  });
+
+  it("blocks on mixed soft and blocking tasks, listing only blocking ids", () => {
+    addTask(dir, "soft advisory", "manual", { soft: true });
+    addTask(dir, "must finish", "manual");
+    addTask(dir, "urgent must finish", "manual", { priority: "high" });
+
+    const result = emit(dir, "task.complete", "done");
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("Cannot complete: 2 open tasks remain");
+    expect(result.error).toContain("task-2");
+    expect(result.error).toContain("task-3");
+    expect(result.error).not.toContain("task-1");
+
+    // task.gate event lists only blocking ids
+    const journal = readFileSync(journalFile, "utf-8");
+    const gateLine = journal.split("\n").find((l) => l.includes("task.gate"));
+    expect(gateLine).toBeDefined();
+    expect(gateLine).toContain("task-2");
+    expect(gateLine).toContain("task-3");
+    expect(gateLine).not.toMatch(/task-1/);
+  });
+
+  it("blocks on default (non-soft) tasks exactly as before", () => {
+    addTask(dir, "legacy default task", "manual");
+
+    const result = emit(dir, "task.complete", "done");
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("task-1");
+  });
+
+  it("allows completion after blocking tasks are done and only soft remain", () => {
+    addTask(dir, "blocking", "manual");
+    addTask(dir, "soft leftover", "manual", { soft: true });
+    completeTask(dir, "task-1");
+
+    const result = emit(dir, "task.complete", "done");
+
+    expect(result.ok).toBe(true);
+  });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -58,6 +58,7 @@ export default defineConfig({
       "@mobrienv/autoloop-harness/coordination": `${HARNESS}/coordination.ts`,
       "@mobrienv/autoloop-harness/display": `${HARNESS}/display.ts`,
       "@mobrienv/autoloop-harness/metrics": `${HARNESS}/metrics.ts`,
+      "@mobrienv/autoloop-harness/guards": `${HARNESS}/guards.ts`,
       "@mobrienv/autoloop-harness/scratchpad": `${HARNESS}/scratchpad.ts`,
       "@mobrienv/autoloop-harness/metareview": `${HARNESS}/metareview.ts`,
       "@mobrienv/autoloop-harness/parallel": `${HARNESS}/parallel.ts`,


### PR DESCRIPTION
## Summary

Loop runtime guards (journal-derived, cover every continue path):
- `event_loop.max_cost_usd` stops a run (`cost_budget`) once journaled `backend.usage` cost reaches the budget
- `event_loop.stall_iterations` stops a run (`stalled`) after N consecutive byte-identical backend outputs
- `[notify]` command runs on loop finish (`on=` stop-reason classes, `timeout_ms`), env vars + JSON payload on stdin, journaled as `notify.sent`/`notify.failed`

Operator commands:
- `autoloop doctor`: env + state health (node/git/backend, registry integrity, dead running runs, stale wave markers, orphaned worktrees)
- `autoloop stats`: per-preset success rate, avg iterations/duration, cost
- `autoloop init [--preset <name>]`: starter config + runnable preset scaffold, .gitignore handling, never overwrites
- `autoloop inspect usage`: per-iteration token/cost from `backend.usage`
- `autoloop worktree diff <run-id> [--patch|--json]`: preview before merge
- `autoloop chain run --dry-run [--json]`: plan + budget validation; root chains now enforce `max_steps` and `max_runtime_ms` (`budget_exceeded`)
- `autoloop memory compact` / `prune --max-age`: append-only tombstone cleanup of duplicate/stale learnings

Agent ergonomics:
- `--json` on loops (list/show/artifacts/health) and list
- "did you mean" suggestions for presets and inspect targets
- `task add --priority high|normal|low` and `--soft`; completion gate blocks only on non-soft tasks; priority-sorted prompts/listings

Dashboard:
- `/api/stream` SSE endpoint (registry watch + polling fallback, debounce, keepalives) with EventSource client and polling fallback

## Test plan
- 134 new tests; full suite 131 files / 1378 tests green with coverage gates intact
- Docs: features/operability page, README, CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)