### PR TITLE
docs: changelog entry for the run --help fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Fixed
 - **Live steering now reaches the in-flight turn.** `autoloop control guide --no-interrupt` queued the request but never signaled the harness, so live steer could only apply at the next iteration boundary (where no turn is active) — for every backend. The CLI now pokes the harness on every guide request; the signal only triggers a control-queue drain, and the backend adapter decides whether to steer or interrupt.
+
 - **`autoloop run <preset> --help` no longer starts a loop.** `--help`/`-h` anywhere among the run args shows usage instead of burning iterations against the backend.
 
 ## [0.7.4] - 2026-05-07


### PR DESCRIPTION
One-line CHANGELOG remainder from the CLI agent-ergonomics pass.

#20 was branched from the shared checkout after the ergonomics commits had landed locally, so its squash merge (f6d3f46) already shipped the entire pass (stderr/exit-code error contract, did-you-mean typo guards, capabilities/robot-docs/triage, config unset, audit workspace). This entry documenting the `run <preset> --help` fix was the only line its squash missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)