### PR TITLE
test: hermetic env so the suite ignores global config + local timezone

### DIFF
--- a/test/setup/hermetic-env.ts
+++ b/test/setup/hermetic-env.ts
@@ -1,0 +1,24 @@
+// Hermetic test environment: isolate the suite from the developer's machine so
+// `npm test` is reproducible regardless of a global ~/.config/autoloop/config.toml
+// or a non-UTC local timezone. Without this, a dev with e.g.
+// `[backend] kind="claude"` or `[profiles] default="user:intent"` in their global
+// config, or a TZ like AEST, sees spurious failures in config-helpers / profiles /
+// sdk-smoke / loops-render that pass cleanly in CI.
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Pin the timezone (some renderers format timestamps in local time).
+process.env.TZ = "UTC";
+
+// Point autoloop at an empty config so the developer's global [backend]/[profiles]
+// defaults can't leak into unit tests. An explicit AUTOLOOP_CONFIG is left untouched
+// so individual tests can still supply their own config when they need one.
+if (!process.env.AUTOLOOP_CONFIG) {
+  const cfg = join(
+    mkdtempSync(join(tmpdir(), "autoloop-hermetic-")),
+    "config.toml",
+  );
+  writeFileSync(cfg, "");
+  process.env.AUTOLOOP_CONFIG = cfg;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -71,6 +71,10 @@ export default defineConfig({
   },
   test: {
     include: ["test/**/*.test.ts", "packages/*/test/**/*.test.ts"],
+    // Hermetic env: isolate from the developer's global autoloop config + local TZ
+    // so the suite is reproducible (see test/setup/hermetic-env.ts).
+    setupFiles: ["./test/setup/hermetic-env.ts"],
+    env: { TZ: "UTC" },
     // Integration tests under test/worktree and test/integration spawn git/node
     // subprocesses. Cap worker pool so subprocess-heavy tests don't starve each
     // other; bump testTimeout to absorb spiky CI/load.


### PR DESCRIPTION
## Problem

A handful of unit tests read the developer's real `~/.config/autoloop/config.toml`
and local timezone, so they fail on a machine with a global config or non-UTC TZ —
while passing cleanly in CI:

- `harness/config-helpers` default-backend tests → get `command` instead of `claude-sdk` when the dev has `[backend] kind="claude"` set globally
- `core/profiles` `--no-default-profiles` → sees a global `[profiles] default="user:intent"`
- `sdk/embed-smoke` "zero stdout/stderr" → the global profile emits a `profile warning` line
- `cli/loops/render` created_at timestamp → date shifts under a non-UTC TZ (e.g. AEST)

## Fix

A vitest `setupFiles` (`test/setup/hermetic-env.ts`) that:
- points `AUTOLOOP_CONFIG` at an empty temp config **unless one is explicitly set**, so global `[backend]`/`[profiles]` defaults can't leak into unit tests, and
- pins `TZ=UTC`;

plus `test.env.TZ=UTC` in `vitest.config.ts` for reliable `Date` behavior from worker start.

`npm test` is now reproducible regardless of the developer's environment. Full suite passes locally (136 files / 1478 tests); previously 5 failed purely from env coupling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)