### PR TITLE
fix(cli): --chain misroots to bundle (require in ESM build always throws)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+### Fixed
+- **`--chain` now roots at the target project dir instead of the bundled presets dir.**
+  `looksLikeProjectDir` used CommonJS `require("node:fs")` inside the ESM build, so every
+  call threw `ReferenceError: require is not defined`, the `catch` returned `false`, and the
+  function always reported "not a project dir." As a result `autoloop run --chain <presets>
+  <project-dir>` (and chain runs from a project cwd) ignored an explicit/cwd `autoloops.toml`
+  and always fell back to `defaultChainProjectDir` → the bundled-presets dir, misrooting chain
+  state (`.autoloop/chains`, runs) into the install instead of the user's repo. Fixed by
+  importing `statSync` from `node:fs` via ESM. Affects both source and npm installs
+  (`@mobrienv/autoloop-cli`'s published dist carried the same bug).
+
 ## [0.8.0] - 2026-06-12
 ### Added
 - **Runtime budgets.** Two new duration keys under `[event_loop]`, accepting duration strings (`"3d"`, `"12h"`, `"1h30m"`) or millisecond integers: `max_iteration_runtime` caps a single iteration's runtime (overriding `backend.timeout_ms` — iterations can now legitimately run for days while waiting on long-running workflows or PR reviews), and `max_runtime` bounds the whole loop's wall-clock time, stopping with reason `max_runtime`. The loop guard is journal-derived from the `loop.start` timestamp (survives reloads, covers every continue path), each iteration's timeout is clamped to the remaining loop budget so the run never overshoots, and `autoloop doctor` gains a `runtime limits` check (invalid durations, iteration cap > loop budget, ~24.8-day Node timer cap).

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,3 +1,4 @@
+import { statSync } from "node:fs";
 import { basename, resolve } from "node:path";
 import { joinCsv } from "@mobrienv/autoloop-core";
 import * as config from "@mobrienv/autoloop-core/config";
@@ -422,7 +423,7 @@ function acpBackendOverride(
 
 function looksLikeProjectDir(path: string): boolean {
   try {
-    if (!require("node:fs").statSync(path).isDirectory()) return false;
+    if (!statSync(path).isDirectory()) return false;
   } catch {
     return false;
   }

--- a/packages/cli/test/commands/run-chain-projectdir.test.ts
+++ b/packages/cli/test/commands/run-chain-projectdir.test.ts
@@ -1,0 +1,67 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Regression test for the ESM `require("node:fs")` bug in looksLikeProjectDir.
+ *
+ * The package is built as ESM, where `require` is undefined; the previous
+ * `require("node:fs").statSync(...)` threw on every call, the catch swallowed
+ * it, and looksLikeProjectDir always returned false. That made `--chain` ignore
+ * an explicit project dir (or cwd) containing autoloops.toml and always fall
+ * back to the bundled-presets dir, so chain state misrooted into the install
+ * instead of the user's repo.
+ *
+ * Here we pass a real temp dir that contains autoloops.toml as the chain
+ * project-dir and assert it is forwarded to chains.runChain as projectDir.
+ * Before the fix this assertion fails (projectDir is the bundle root).
+ */
+
+vi.mock("../../src/chains.js", () => ({
+  parseInlineChain: vi.fn((_csv: string, _dir: string) => ({
+    name: "inline",
+    steps: [{ name: "autocode" }, { name: "autoqa" }],
+  })),
+  validatePresetVocabulary: vi.fn(() => ({ ok: true })),
+  runChain: vi.fn(() => ({ completed: [], outcome: "ok" })),
+  listKnownPresets: vi.fn(() => ["autocode", "autoqa"]),
+}));
+
+vi.mock("@mobrienv/autoloop-harness", () => ({
+  run: vi.fn(),
+}));
+
+import * as chains from "../../src/chains.js";
+import { dispatchRun } from "../../src/commands/run.js";
+
+describe("chain project-dir resolution", () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    projectDir = mkdtempSync(join(tmpdir(), "autoloop-chain-projectdir-"));
+    writeFileSync(
+      join(projectDir, "autoloops.toml"),
+      'backend.command = "claude"\n',
+    );
+  });
+
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it("roots the chain at a project dir containing autoloops.toml", () => {
+    dispatchRun(
+      ["--chain", "autocode,autoqa", projectDir],
+      [],
+      ".",
+      "autoloop",
+    );
+
+    expect(chains.runChain).toHaveBeenCalledTimes(1);
+    const callArgs = vi.mocked(chains.runChain).mock.calls[0];
+    // runChain(chainSpec, projectDir, selfCommand, runOptions)
+    expect(callArgs[1]).toBe(projectDir);
+  });
+});


### PR DESCRIPTION
## Summary

`autoloop run --chain <presets> <project-dir>` (and chain runs launched from a project's
cwd) ignore an explicit/cwd `autoloops.toml` and always misroot their state into the bundled
presets dir instead of the user's repo. Root cause is a CommonJS `require` in the ESM build.

## Root cause

`looksLikeProjectDir` in `packages/cli/src/commands/run.ts`:

```ts
function looksLikeProjectDir(path: string): boolean {
  try {
    if (!require("node:fs").statSync(path).isDirectory()) return false;
  } catch {
    return false;
  }
  return config.projectHasConfig(path);
}
```

The package is ESM (`"type": "module"`), so `require` is not defined at runtime — every call
throws `ReferenceError: require is not defined`, the `catch` swallows it, and the function
**always returns `false`**. Because both the positional-project-dir branch and
`defaultChainProjectDir(".")` gate on `looksLikeProjectDir`, a chain can never resolve a real
project dir and always falls back to the bundled-presets dir. Chain state (`.autoloop/chains`,
runs, journal) is then written into the install/bundle rather than the target repo.

Single `autoloop run <preset>` is unaffected (its rooting uses `workDir="."`, not this
function), which is why this only surfaced for `--chain`.

## Fix

Import `statSync` via ESM and use it directly:

```ts
import { statSync } from "node:fs";
// ...
if (!statSync(path).isDirectory()) return false;
```

## Impact: source **and** npm installs

This is not source-only. The published `@mobrienv/autoloop-cli@0.8.0` dist
(`dist/commands/run.js`) carries the identical `require("node:fs")` line, and
`@mobrienv/autoloop` depends on it, so `npm install -g @mobrienv/autoloop` reproduces the bug.

## Verification

- Repro before fix: `autoloop run --chain autospec,autocode <repo>` created `.autoloop` under
  the bundled presets dir; `<repo>/.autoloop` was never created.
- After fix + rebuild: `.autoloop` is created in `<repo>` and the bundle stays clean.
- Added `packages/cli/test/commands/run-chain-projectdir.test.ts`: asserts a chain run with a
  project dir containing `autoloops.toml` forwards that dir to `chains.runChain` as
  `projectDir`. Fails before the fix, passes after.
- `npm run build` (tsc) clean; `biome check` clean on changed files.

## Notes

I grepped `packages/*/src` for other `require(` usages in ESM source; `looksLikeProjectDir`
was the affected call site for this bug. Happy to adjust per any conventions I missed.
