### PR TITLE
feat(observability): structured --events stream + versioned journal contract (#30, #31)

### DIFF
--- a/packages/cli/src/cli/events-sink.ts
+++ b/packages/cli/src/cli/events-sink.ts
@@ -1,0 +1,58 @@
+// Structured NDJSON event sink — the machine-readable counterpart to the human
+// cliPrintEvent renderer.
+//
+// `autoloop run --events <path>` writes every LoopEvent to `path` as one NDJSON
+// line, in addition to the normal terminal rendering. This lets an external
+// parent (e.g. ralph driving autoloop as a subprocess) consume a stable,
+// structured event stream instead of scraping terminal text or tailing the
+// internal journal. The terminal `progress` event (resolved routing + outcome)
+// is only available on this stream, not in the journal.
+//
+// The final `loop.finish` / `summary` events carry the machine-readable run
+// result (runId, iterations, stopReason), so a consumer gets the outcome from
+// the stream without parsing the journal.
+
+import { closeSync, openSync, writeSync } from "node:fs";
+import type { LoopEvent } from "@mobrienv/autoloop-harness/events";
+
+export interface EventSink {
+  onEvent: (event: LoopEvent) => void;
+  close: () => void;
+}
+
+/**
+ * Append every LoopEvent to `path` as one NDJSON line. Writes are synchronous
+ * and newline-framed (one `writeSync` per event) so a concurrent reader that
+ * consumes only newline-terminated lines never observes a torn record. The sink
+ * is best-effort: a write failure is swallowed so it can never crash the loop.
+ */
+export function ndjsonEventSink(path: string): EventSink {
+  const fd = openSync(path, "a");
+  return {
+    onEvent(event: LoopEvent): void {
+      try {
+        writeSync(fd, `${JSON.stringify(event)}\n`);
+      } catch {
+        // Best-effort: never let the events sink crash the loop.
+      }
+    },
+    close(): void {
+      try {
+        closeSync(fd);
+      } catch {
+        // Already closed / invalid fd — nothing to do.
+      }
+    },
+  };
+}
+
+/** Compose two event emitters into one that invokes both, in order. */
+export function teeEvents(
+  first: (e: LoopEvent) => void,
+  second: (e: LoopEvent) => void,
+): (e: LoopEvent) => void {
+  return (e: LoopEvent) => {
+    first(e);
+    second(e);
+  };
+}

--- a/packages/cli/src/commands/capabilities.ts
+++ b/packages/cli/src/commands/capabilities.ts
@@ -6,6 +6,7 @@
 // Output is JSON-only and deterministic (no timestamps, stable ordering).
 
 import { createRequire } from "node:module";
+import { JOURNAL_CONTRACT_VERSION } from "@mobrienv/autoloop-core";
 import { EXIT_ENV, EXIT_OK, EXIT_USAGE } from "../cli/fail.js";
 
 export const CONTRACT_VERSION = 1;
@@ -164,6 +165,7 @@ export function capabilitiesJson(): string {
       name: "autoloop",
       version: cliVersion(),
       contract_version: CONTRACT_VERSION,
+      journal_contract_version: JOURNAL_CONTRACT_VERSION,
       exit_codes: {
         [String(EXIT_OK)]: "success",
         [String(EXIT_USAGE)]:
@@ -181,6 +183,8 @@ export function capabilitiesJson(): string {
         stderr: "diagnostics, warnings, and errors",
         json_flag:
           "--json on: list, loops, loops health, stats, doctor, chain run, config show, triage",
+        events_stream:
+          "run --events <path>: NDJSON LoopEvent stream (incl. progress + final loop.finish/summary)",
       },
       commands: commandCapabilities(),
     },

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -3,9 +3,12 @@ import { joinCsv } from "@mobrienv/autoloop-core";
 import * as config from "@mobrienv/autoloop-core/config";
 import * as harness from "@mobrienv/autoloop-harness";
 import { claudeBackend } from "@mobrienv/autoloop-harness/config-helpers";
+import type { LoopEvent } from "@mobrienv/autoloop-harness/events";
 import * as chains from "../chains.js";
 import { cliPrintEvent } from "../cli/event-printer.js";
+import type { EventSink } from "../cli/events-sink.js";
 import { ndjsonEventSink, teeEvents } from "../cli/events-sink.js";
+import { EXIT_ENV } from "../cli/fail.js";
 import {
   missingPresetError,
   printRunUsage,
@@ -50,65 +53,96 @@ export async function dispatchRun(
   const options = parseRunArgs(args, bundleRoot);
   if (options.usageError) return true;
 
-  if (options.chain) {
-    await runInlineChain(options.chain, options.projectDir, selfCmd, options);
-    return true;
-  }
-
-  // --automerge sugar: build inline chain [preset, automerge]
-  if (options.automerge) {
-    const presetName = basename(options.projectDir);
-    const chainCsv = `${presetName},automerge`;
-    const chainProjectDir = defaultChainProjectDir(bundleRoot);
-    await runInlineChain(chainCsv, chainProjectDir, selfCmd, options);
-    return true;
-  }
-
-  // Install SIGINT/SIGTERM handlers that abort the harness via AbortSignal.
-  // Previously the harness installed process.on handlers itself; the CLI
-  // now owns that so the harness is embed-able from SDK consumers.
-  const abort = new AbortController();
-  let caughtSignal: NodeJS.Signals | null = null;
-  const onSig = (sig: NodeJS.Signals) => {
-    if (caughtSignal) return;
-    caughtSignal = sig;
-    abort.abort();
-  };
-  process.on("SIGINT", onSig);
-  process.on("SIGTERM", onSig);
-
   // Optional structured event stream: write every LoopEvent as NDJSON to
-  // --events <path>, in addition to (not replacing) terminal rendering.
-  const eventSink = options.eventsPath
-    ? ndjsonEventSink(options.eventsPath)
-    : null;
+  // --events <path>, in addition to (not replacing) terminal rendering. Built
+  // up front so it covers the chain/automerge paths too. A bad path fails fast
+  // with a clean message rather than an unhandled exception.
+  let eventSink: EventSink | null = null;
+  if (options.eventsPath) {
+    try {
+      eventSink = ndjsonEventSink(options.eventsPath);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `error: cannot open --events file '${options.eventsPath}': ${msg}\n`,
+      );
+      process.exitCode = EXIT_ENV;
+      return true;
+    }
+  }
   const onEvent = eventSink
     ? teeEvents(cliPrintEvent, eventSink.onEvent)
     : cliPrintEvent;
 
   try {
-    await harness.run(
-      options.projectDir,
-      normalizePrompt(options.prompt),
-      selfCmd,
-      {
-        ...options,
-        profiles: options.profiles.length > 0 ? options.profiles : undefined,
-        noDefaultProfiles: options.noDefaultProfiles || undefined,
-        signal: abort.signal,
+    if (options.chain) {
+      await runInlineChain(
+        options.chain,
+        options.projectDir,
+        selfCmd,
+        options,
         onEvent,
-        ...chainableOptions(options),
-      },
-    );
+      );
+      return true;
+    }
+
+    // --automerge sugar: build inline chain [preset, automerge]
+    if (options.automerge) {
+      const presetName = basename(options.projectDir);
+      const chainCsv = `${presetName},automerge`;
+      const chainProjectDir = defaultChainProjectDir(bundleRoot);
+      await runInlineChain(
+        chainCsv,
+        chainProjectDir,
+        selfCmd,
+        options,
+        onEvent,
+      );
+      return true;
+    }
+
+    // Install SIGINT/SIGTERM handlers that abort the harness via AbortSignal.
+    // Previously the harness installed process.on handlers itself; the CLI
+    // now owns that so the harness is embed-able from SDK consumers.
+    const abort = new AbortController();
+    let caughtSignal: NodeJS.Signals | null = null;
+    const onSig = (sig: NodeJS.Signals) => {
+      if (caughtSignal) return;
+      caughtSignal = sig;
+      abort.abort();
+    };
+    process.on("SIGINT", onSig);
+    process.on("SIGTERM", onSig);
+
+    try {
+      await harness.run(
+        options.projectDir,
+        normalizePrompt(options.prompt),
+        selfCmd,
+        {
+          ...options,
+          profiles: options.profiles.length > 0 ? options.profiles : undefined,
+          noDefaultProfiles: options.noDefaultProfiles || undefined,
+          signal: abort.signal,
+          onEvent,
+          ...chainableOptions(options),
+        },
+      );
+    } finally {
+      process.removeListener("SIGINT", onSig);
+      process.removeListener("SIGTERM", onSig);
+      // Preserve historical exit-code behavior: re-raise the signal so the
+      // process exits with 128+signum rather than 0 on Ctrl-C. Close the sink
+      // first since the re-raised signal terminates the process.
+      if (caughtSignal) {
+        eventSink?.close();
+        process.kill(process.pid, caughtSignal);
+      }
+    }
+    return true;
   } finally {
     eventSink?.close();
-    process.removeListener("SIGINT", onSig);
-    process.removeListener("SIGTERM", onSig);
-    // Preserve historical exit-code behavior: re-raise the signal so the
-    // process exits with 128+signum rather than 0 on Ctrl-C.
-    if (caughtSignal) process.kill(process.pid, caughtSignal);
   }
-  return true;
 }
 
 function parseRunArgs(args: string[], bundleRoot: string): RunOptions {
@@ -374,6 +408,7 @@ async function runInlineChain(
   projectDir: string,
   selfCmd: string,
   options: RunOptions,
+  onEvent?: (e: LoopEvent) => void,
 ): Promise<void> {
   const chainSpec = chains.parseInlineChain(chainCsv, projectDir);
   const stepNames = chainSpec.steps.map((s) => s.name);
@@ -386,8 +421,12 @@ async function runInlineChain(
     console.log(`Known presets: ${joinCsv(chains.listKnownPresets())}`);
     return;
   }
+  // Forward the structured event sink so --events also captures chain steps.
+  // Each step spreads these options into harness.run (chains/run.ts), so onEvent
+  // propagates to every step's loop.
   await chains.runChain(chainSpec, projectDir, selfCmd, {
     prompt: normalizePrompt(options.prompt),
+    onEvent,
     ...chainableOptions(options),
   });
 }

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -5,6 +5,7 @@ import * as harness from "@mobrienv/autoloop-harness";
 import { claudeBackend } from "@mobrienv/autoloop-harness/config-helpers";
 import * as chains from "../chains.js";
 import { cliPrintEvent } from "../cli/event-printer.js";
+import { ndjsonEventSink, teeEvents } from "../cli/events-sink.js";
 import {
   missingPresetError,
   printRunUsage,
@@ -29,6 +30,7 @@ interface RunOptions {
   mergeStrategy?: string;
   automerge?: boolean;
   keepWorktree?: boolean;
+  eventsPath?: string;
 }
 
 export async function dispatchRun(
@@ -75,6 +77,15 @@ export async function dispatchRun(
   process.on("SIGINT", onSig);
   process.on("SIGTERM", onSig);
 
+  // Optional structured event stream: write every LoopEvent as NDJSON to
+  // --events <path>, in addition to (not replacing) terminal rendering.
+  const eventSink = options.eventsPath
+    ? ndjsonEventSink(options.eventsPath)
+    : null;
+  const onEvent = eventSink
+    ? teeEvents(cliPrintEvent, eventSink.onEvent)
+    : cliPrintEvent;
+
   try {
     await harness.run(
       options.projectDir,
@@ -85,11 +96,12 @@ export async function dispatchRun(
         profiles: options.profiles.length > 0 ? options.profiles : undefined,
         noDefaultProfiles: options.noDefaultProfiles || undefined,
         signal: abort.signal,
-        onEvent: cliPrintEvent,
+        onEvent,
         ...chainableOptions(options),
       },
     );
   } finally {
+    eventSink?.close();
     process.removeListener("SIGINT", onSig);
     process.removeListener("SIGTERM", onSig);
     // Preserve historical exit-code behavior: re-raise the signal so the
@@ -244,6 +256,17 @@ function parseRunArgs(args: string[], bundleRoot: string): RunOptions {
     if (token === "--keep-worktree") {
       options.keepWorktree = true;
       i++;
+      continue;
+    }
+    if (token === "--events") {
+      const path = args[i + 1];
+      if (!path) {
+        console.log("missing path after --events");
+        options.usageError = true;
+        return options;
+      }
+      options.eventsPath = path;
+      i += 2;
       continue;
     }
 

--- a/packages/cli/src/usage.ts
+++ b/packages/cli/src/usage.ts
@@ -145,6 +145,9 @@ export function printRunUsage(): void {
   );
   console.log("  --automerge            Auto-merge worktree on completion");
   console.log("  --keep-worktree        Keep worktree after run completes");
+  console.log(
+    "  --events <path>        Append the NDJSON LoopEvent stream to <path>",
+  );
   console.log("");
   console.log("Examples:");
   console.log("  autoloop run autocode");

--- a/packages/cli/test/cli/events-sink.test.ts
+++ b/packages/cli/test/cli/events-sink.test.ts
@@ -1,0 +1,84 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { LoopEvent } from "@mobrienv/autoloop-harness/events";
+import { describe, expect, it } from "vitest";
+import { ndjsonEventSink, teeEvents } from "../../src/cli/events-sink.js";
+
+function tmpFile(name: string): string {
+  return join(mkdtempSync(join(tmpdir(), "autoloop-events-")), name);
+}
+
+const sampleEvents: LoopEvent[] = [
+  { type: "iteration.start", iteration: 1, maxIterations: 3, runId: "r1" },
+  {
+    type: "progress",
+    runId: "r1",
+    iteration: 1,
+    recentEvent: "loop.start",
+    allowedRoles: ["planner"],
+    emittedTopic: "tasks.ready",
+    outcome: "continue:routed_event",
+  },
+  { type: "loop.finish", iterations: 1, stopReason: "completed", runId: "r1" },
+];
+
+describe("ndjsonEventSink", () => {
+  it("writes one valid NDJSON line per event", () => {
+    const path = tmpFile("events.ndjson");
+    const sink = ndjsonEventSink(path);
+    for (const e of sampleEvents) sink.onEvent(e);
+    sink.close();
+
+    const lines = readFileSync(path, "utf-8")
+      .split("\n")
+      .filter((l) => l.trim() !== "");
+    expect(lines).toHaveLength(3);
+    const parsed = lines.map((l) => JSON.parse(l));
+    expect(parsed.map((e) => e.type)).toEqual([
+      "iteration.start",
+      "progress",
+      "loop.finish",
+    ]);
+    // The final event carries the machine-readable run result.
+    expect(parsed[2]).toMatchObject({
+      type: "loop.finish",
+      iterations: 1,
+      stopReason: "completed",
+      runId: "r1",
+    });
+    // The progress event (resolved routing/outcome) survives structurally.
+    expect(parsed[1]).toMatchObject({
+      type: "progress",
+      emittedTopic: "tasks.ready",
+      outcome: "continue:routed_event",
+    });
+  });
+
+  it("appends rather than truncates", () => {
+    const path = tmpFile("append.ndjson");
+    const a = ndjsonEventSink(path);
+    a.onEvent(sampleEvents[0]);
+    a.close();
+    const b = ndjsonEventSink(path);
+    b.onEvent(sampleEvents[2]);
+    b.close();
+
+    const lines = readFileSync(path, "utf-8")
+      .split("\n")
+      .filter((l) => l.trim() !== "");
+    expect(lines).toHaveLength(2);
+  });
+});
+
+describe("teeEvents", () => {
+  it("invokes both emitters in order", () => {
+    const calls: string[] = [];
+    const tee = teeEvents(
+      () => calls.push("a"),
+      () => calls.push("b"),
+    );
+    tee(sampleEvents[0]);
+    expect(calls).toEqual(["a", "b"]);
+  });
+});

--- a/packages/cli/test/commands/run-chain-options.test.ts
+++ b/packages/cli/test/commands/run-chain-options.test.ts
@@ -127,4 +127,45 @@ describe("runInlineChain option propagation", () => {
 
     expect(runOptions.noWorktree).toBe(true);
   });
+
+  it("forwards --events onEvent sink through to chains.runChain", async () => {
+    await dispatchRun(
+      [
+        "--chain",
+        "autocode,autoqa",
+        "--events",
+        "/tmp/al-chain-events.ndjson",
+        ".",
+      ],
+      [],
+      ".",
+      "autoloop",
+    );
+
+    expect(chains.runChain).toHaveBeenCalledTimes(1);
+    const callArgs = vi.mocked(chains.runChain).mock.calls[0];
+    const runOptions = callArgs[3];
+
+    // The sink is threaded as onEvent so chain steps also land on the stream.
+    expect(typeof runOptions.onEvent).toBe("function");
+  });
+
+  it("forwards --events onEvent sink through the --automerge chain", async () => {
+    await dispatchRun(
+      [
+        "autocode",
+        "--automerge",
+        "--events",
+        "/tmp/al-automerge-events.ndjson",
+      ],
+      [],
+      ".",
+      "autoloop",
+    );
+
+    expect(chains.runChain).toHaveBeenCalledTimes(1);
+    const callArgs = vi.mocked(chains.runChain).mock.calls[0];
+    const runOptions = callArgs[3];
+    expect(typeof runOptions.onEvent).toBe("function");
+  });
 });

--- a/packages/core/src/events/encode.ts
+++ b/packages/core/src/events/encode.ts
@@ -1,10 +1,44 @@
 import { jsonBool, jsonField, jsonFieldRaw } from "../json.js";
 import type { JournalEvent } from "./types.js";
 
-export function encodeEvent(event: JournalEvent): string {
+/**
+ * Schema version of the journal JSONL contract. Every encoded line carries a
+ * top-level `"v"` field set to this value so an external consumer (e.g. a tailer
+ * driving autoloop as a subprocess) can detect a breaking change to the record
+ * shape. Bump this whenever the on-disk record shape changes incompatibly.
+ *
+ * ## Journal contract (v1)
+ *
+ * Each line is one complete, newline-terminated JSON object. `appendEvent`
+ * writes exactly one line per `appendFileSync`, so a reader that consumes only
+ * newline-terminated lines never observes a torn record. Every line carries:
+ *
+ * - `"v"`: this contract version (number).
+ * - `"ts"`: ISO-8601 timestamp (millisecond precision) at append time.
+ * - `"run"`: the run id.
+ * - `"topic"`: the event topic.
+ * - `"iteration"`: the iteration index as a string, when applicable.
+ * - then either `"fields"` (an object map) or `"payload"`+`"source"`.
+ *
+ * Field order is not part of the contract; consumers must parse by key.
+ */
+export const JOURNAL_CONTRACT_VERSION = 1;
+
+/** Default wall-clock source; overridable in `encodeEvent` for deterministic tests. */
+function defaultNow(): string {
+  return new Date().toISOString();
+}
+
+export function encodeEvent(
+  event: JournalEvent,
+  now: () => string = defaultNow,
+): string {
   const base = [jsonField("run", event.run)];
   if (event.iteration) base.push(jsonField("iteration", event.iteration));
   base.push(jsonField("topic", String(event.topic)));
+  // Versioned, timestamped contract fields (see JOURNAL_CONTRACT_VERSION).
+  base.push(jsonField("ts", now()));
+  base.push(jsonFieldRaw("v", String(JOURNAL_CONTRACT_VERSION)));
 
   if (event.shape === "payload") {
     base.push(jsonField("payload", event.payload));

--- a/packages/core/test/events/encode.test.ts
+++ b/packages/core/test/events/encode.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { encodeEvent } from "../../src/events/encode.js";
+import {
+  encodeEvent,
+  JOURNAL_CONTRACT_VERSION,
+} from "../../src/events/encode.js";
 
 describe("encodeEvent edge cases", () => {
   it("encodes a fields event without iteration", () => {
@@ -79,5 +82,55 @@ describe("encodeEvent edge cases", () => {
     });
     expect(line).toMatch(/\n$/);
     expect(line).not.toMatch(/\n\n$/);
+  });
+
+  it("stamps the contract version on every line (v1)", () => {
+    const line = encodeEvent({
+      shape: "fields",
+      run: "r1",
+      topic: "loop.start",
+      fields: {},
+    });
+    const parsed = JSON.parse(line);
+    expect(parsed.v).toBe(JOURNAL_CONTRACT_VERSION);
+    expect(parsed.v).toBe(1);
+  });
+
+  it("stamps an injectable ISO timestamp on every line", () => {
+    const fixed = "2026-06-24T12:34:56.789Z";
+    const line = encodeEvent(
+      { shape: "payload", run: "r1", topic: "tasks.ready", payload: "go" },
+      () => fixed,
+    );
+    const parsed = JSON.parse(line);
+    expect(parsed.ts).toBe(fixed);
+    // Default source produces a parseable ISO-8601 timestamp.
+    const dflt = JSON.parse(
+      encodeEvent({ shape: "fields", run: "r1", topic: "x", fields: {} }),
+    );
+    expect(Number.isNaN(Date.parse(dflt.ts))).toBe(false);
+  });
+
+  it("remains a single valid JSON object with the documented keys", () => {
+    const line = encodeEvent(
+      {
+        shape: "fields",
+        run: "r1",
+        iteration: "2",
+        topic: "iteration.finish",
+        fields: { exit_code: "0" },
+        rawFields: { exit_code: 0 },
+      },
+      () => "2026-06-24T00:00:00.000Z",
+    );
+    const parsed = JSON.parse(line);
+    expect(parsed).toMatchObject({
+      v: 1,
+      ts: "2026-06-24T00:00:00.000Z",
+      run: "r1",
+      iteration: "2",
+      topic: "iteration.finish",
+      fields: { exit_code: 0 },
+    });
   });
 });

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -186,6 +186,19 @@ export async function run(
   };
   try {
     summary = await trackedIterate(loop, 1);
+  } catch (err: unknown) {
+    // An unexpected throw (e.g. init/store failure outside per-iteration error
+    // handling) must still produce a terminal event so an external --events
+    // consumer always learns the run ended, instead of waiting forever for a
+    // loop.finish. Data already written is flushed (synchronous appends); we
+    // emit the terminal marker and re-raise.
+    loop.onEvent?.({
+      type: "loop.finish",
+      iterations: currentIteration > 0 ? currentIteration - 1 : 0,
+      stopReason: "error",
+      runId: loop.runtime.runId,
+    });
+    throw err;
   } finally {
     if (loop.acpSession.current) {
       try {

--- a/test/integration/run-loop.test.ts
+++ b/test/integration/run-loop.test.ts
@@ -257,6 +257,62 @@ describe("integration: run loop with mock backend", () => {
     expect(res.stdout).toContain("Task completed successfully.");
   });
 
+  it("writes the structured NDJSON LoopEvent stream to --events <path>", () => {
+    const project = makeTempProject("events-stream");
+    const fixture = join(FIXTURES_DIR, "complete-success.json");
+    const eventsPath = join(project, "events.ndjson");
+    const res = runCli(
+      ["run", project, "events stream", "--events", eventsPath],
+      { MOCK_FIXTURE_PATH: fixture },
+    );
+
+    expect(res.status).toBe(0);
+    expect(pathExists(eventsPath)).toBe(true);
+
+    const events = readText(eventsPath)
+      .split("\n")
+      .filter((l) => l.trim() !== "")
+      .map((l) => JSON.parse(l));
+
+    // Every line is a structured LoopEvent.
+    expect(events.length).toBeGreaterThan(0);
+    expect(events.every((e) => typeof e.type === "string")).toBe(true);
+
+    // The resolved routing/outcome `progress` event is on the stream (it is
+    // NOT in the journal — this is the whole point of the structured stream).
+    expect(events.some((e) => e.type === "progress")).toBe(true);
+
+    // A final machine-readable run result is present (loop.finish or summary).
+    const result = events.find(
+      (e) => e.type === "loop.finish" || e.type === "summary",
+    );
+    expect(result).toBeTruthy();
+    expect(result.runId).toBeTruthy();
+    expect(typeof result.iterations).toBe("number");
+    expect(result.stopReason).toBeTruthy();
+  });
+
+  it("stamps every journal line with the versioned, timestamped contract (#31)", () => {
+    const project = makeTempProject("journal-contract");
+    const fixture = join(FIXTURES_DIR, "complete-success.json");
+    const res = runCli(["run", project, "journal contract"], {
+      MOCK_FIXTURE_PATH: fixture,
+    });
+    expect(res.status).toBe(0);
+
+    const lines = readText(join(project, ".autoloop/journal.jsonl"))
+      .split("\n")
+      .filter((l) => l.trim() !== "")
+      .map((l) => JSON.parse(l));
+
+    expect(lines.length).toBeGreaterThan(0);
+    for (const ev of lines) {
+      expect(ev.v).toBe(1);
+      expect(typeof ev.ts).toBe("string");
+      expect(Number.isNaN(Date.parse(ev.ts))).toBe(false);
+    }
+  });
+
   it("inspect commands render metrics, scratchpad, and memory", () => {
     const project = makeTempProject("inspect");
     const fixture = join(FIXTURES_DIR, "complete-success.json");

--- a/test/integration/run-loop.test.ts
+++ b/test/integration/run-loop.test.ts
@@ -292,6 +292,23 @@ describe("integration: run loop with mock backend", () => {
     expect(result.stopReason).toBeTruthy();
   });
 
+  it("fails cleanly (no stack trace) when the --events path is unwritable", () => {
+    const project = makeTempProject("events-unwritable");
+    const fixture = join(FIXTURES_DIR, "complete-success.json");
+    // Parent directories do not exist -> openSync('a') throws ENOENT.
+    const badPath = join(project, "no", "such", "dir", "events.ndjson");
+    const res = runCli(
+      ["run", project, "events unwritable", "--events", badPath],
+      { MOCK_FIXTURE_PATH: fixture },
+    );
+
+    expect(res.stderr).toContain("cannot open --events file");
+    // Clean message, not a raw thrown stack.
+    expect(res.stderr).not.toMatch(/\n\s+at\s+.+:\d+:\d+/);
+    // The loop never started.
+    expect(pathExists(join(project, ".autoloop/journal.jsonl"))).toBe(false);
+  });
+
   it("stamps every journal line with the versioned, timestamped contract (#31)", () => {
     const project = makeTempProject("journal-contract");
     const fixture = join(FIXTURES_DIR, "complete-success.json");


### PR DESCRIPTION
## Summary

Adds the cross-process observability backbone that an external parent (e.g. [ralph-orchestrator](https://github.com/mikeyobrien/ralph-orchestrator) driving autoloop as a subprocess for its v3 cutover) needs, instead of scraping terminal text or tailing an unversioned internal file.

Closes #30, closes #31. Part of #29.

### #30 — structured `--events` stream
- `autoloop run --events <path>` appends every `LoopEvent` as NDJSON, **in addition to** (not replacing) terminal rendering — composed via `teeEvents(cliPrintEvent, sink)` in `cli/events-sink.ts`.
- The resolved `progress` event (routing + outcome) is only on this stream, never in the journal — this is the whole point.
- The final `loop.finish`/`summary` event carries the machine-readable run result (`runId`/`iterations`/`stopReason`), so a consumer gets the outcome from the stream without parsing the journal.
- Threaded through `--chain` and `--automerge` (each step's `harness.run` receives `onEvent`), surfaced in `capabilities` output and `run --help`.

### #31 — versioned, durable journal contract
- Every journal line now carries a top-level `"v"` (`JOURNAL_CONTRACT_VERSION = 1`, exported from `@mobrienv/autoloop-core`) and an ISO-8601 `"ts"` (injectable for deterministic tests), via the single `encodeEvent` chokepoint.
- The contract is documented on the version constant: one newline-framed JSON object per `appendFileSync`; parse **by key, not position**.
- `capabilities` reports `journal_contract_version`.
- **Backward-compatible**: every existing journal consumer is key-based (verified across `json.ts`, `decode.ts`, `registry/derive.ts`, `journal.ts`, dashboard, inspect); field additions are purely additive.

## Robustness (from adversarial review)
- `harness.run` emits a terminal `loop.finish` (stopReason `error`) if it throws, so a consumer never waits forever for a terminal event.
- An unwritable `--events` path fails fast with a clean `cannot open --events file` message + `EXIT_ENV`, not a raw stack trace.

## Testing
- Unit: `events-sink.test.ts` (NDJSON framing, append, tee ordering), `encode.test.ts` (`v`/`ts`/JSON validity), `run-chain-options.test.ts` (`onEvent` forwarding through chain + automerge).
- Integration (real CLI + mock backend): `--events` stream shape incl. `progress` + machine-readable result; every journal line stamped `v=1` + parseable `ts`; unwritable path fails cleanly.
- **Full suite: 1488 pass.** The single failure is a pre-existing dashboard SSE flake (`stream.test.ts`) that passes 11/11 in isolation and is unrelated to this change (it operates on registry RunRecords, not journal `v`/`ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
