### PR TITLE
[v3] Surface cumulative cost_usd in run summary + terminal LoopEvents

### DIFF
--- a/packages/harness/src/display.ts
+++ b/packages/harness/src/display.ts
@@ -1,5 +1,6 @@
 import { execSync } from "node:child_process";
-import { lineSep, listText } from "@mobrienv/autoloop-core";
+import { collectUsage, lineSep, listText } from "@mobrienv/autoloop-core";
+import { readRunLines } from "@mobrienv/autoloop-core/journal";
 import type { IterationContext } from "./prompt.js";
 import type { LoopContext, RunSummary } from "./types.js";
 
@@ -11,6 +12,7 @@ export function printSummary(summary: RunSummary, loop: LoopContext): void {
     `run_id: ${loop.runtime.runId}`,
     `iterations: ${summary.iterations}`,
     `stop_reason: ${summary.stopReason}`,
+    `cost_usd: ${runCostUsd(loop).toFixed(6)}`,
     `journal: ${loop.paths.journalFile}`,
     `memory: ${loop.paths.memoryFile}`,
     `review_every: ${loop.review.every}`,
@@ -18,6 +20,20 @@ export function printSummary(summary: RunSummary, loop: LoopContext): void {
     ...hint,
   ];
   for (const l of lines) console.log(l);
+}
+
+/**
+ * Cumulative run cost in USD, summed from journaled `backend.usage` events.
+ * Returns 0 when no usage was recorded (e.g. the `command`/`acp` backends, or a
+ * torn journal) so the summary always carries a parseable `cost_usd` field.
+ */
+export function runCostUsd(loop: LoopContext): number {
+  try {
+    const lines = readRunLines(loop.paths.journalFile, loop.runtime.runId);
+    return collectUsage(lines, loop.runtime.runId).totals.costUsd;
+  } catch {
+    return 0;
+  }
 }
 
 function stopReasonHint(reason: string): string[] {

--- a/packages/harness/src/events.ts
+++ b/packages/harness/src/events.ts
@@ -20,6 +20,7 @@ export type LoopEvent =
       iterations: number;
       stopReason: string;
       runId: string;
+      costUsd: number;
     }
   // Display-requested — the harness asks the caller to render something.
   | {
@@ -49,6 +50,7 @@ export type LoopEvent =
       runId: string;
       iterations: number;
       stopReason: string;
+      costUsd: number;
       journalFile: string;
       memoryFile: string;
       reviewEvery: number;

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -200,6 +200,7 @@ export async function run(
       iterations: currentIteration > 0 ? currentIteration - 1 : 0,
       stopReason: "error",
       runId: loop.runtime.runId,
+      costUsd: runCostUsd(loop),
     });
     throw err;
   } finally {

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -36,7 +36,7 @@ import {
   publishCapabilities,
 } from "./control/dispatch.js";
 import { piControlAdapter } from "./control/pi-adapter.js";
-import { log } from "./display.js";
+import { log, runCostUsd } from "./display.js";
 import { emit as emitCmd } from "./emit.js";
 import { checkCostBudget, checkRuntimeBudget, detectStall } from "./guards.js";
 import { runIteration } from "./iteration.js";
@@ -292,11 +292,13 @@ export async function run(
     iterations: summary.iterations,
   });
 
+  const costUsd = runCostUsd(loop);
   loop.onEvent?.({
     type: "summary",
     runId: loop.runtime.runId,
     iterations: summary.iterations,
     stopReason: summary.stopReason,
+    costUsd,
     journalFile: loop.paths.journalFile,
     memoryFile: loop.paths.memoryFile,
     reviewEvery: loop.review.every,
@@ -307,6 +309,7 @@ export async function run(
     iterations: summary.iterations,
     stopReason: summary.stopReason,
     runId: loop.runtime.runId,
+    costUsd,
   });
   return { ...summary, runId: loop.runtime.runId };
 }

--- a/packages/harness/test/harness/abort-signal.test.ts
+++ b/packages/harness/test/harness/abort-signal.test.ts
@@ -47,6 +47,7 @@ vi.mock("../../src/metareview.js", () => ({
 vi.mock("../../src/display.js", () => ({
   printSummary: vi.fn(),
   log: vi.fn(),
+  runCostUsd: vi.fn(() => 0),
   printProjectedMarkdown: vi.fn(),
   printProjectedText: vi.fn(),
 }));

--- a/packages/harness/test/harness/automerge-chain.test.ts
+++ b/packages/harness/test/harness/automerge-chain.test.ts
@@ -40,6 +40,7 @@ vi.mock("../../src/metareview.js", () => ({
 vi.mock("../../src/display.js", () => ({
   printSummary: vi.fn(),
   log: vi.fn(),
+  runCostUsd: vi.fn(() => 0),
   printProjectedMarkdown: vi.fn(),
   printProjectedText: vi.fn(),
 }));

--- a/packages/harness/test/harness/display-summary.test.ts
+++ b/packages/harness/test/harness/display-summary.test.ts
@@ -1,0 +1,67 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { appendEvent } from "@mobrienv/autoloop-core/journal";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { printSummary } from "../../src/display.js";
+import type { LoopContext, RunSummary } from "../../src/types.js";
+
+// printSummary surfaces cumulative run cost so subprocess drivers (ralph v3)
+// can parse it from the summary block — see autoloop#34.
+
+function usageFields(cost: number): string {
+  return (
+    `"input_tokens": 0, "output_tokens": 0, "cache_read_tokens": 0, ` +
+    `"cache_write_tokens": 0, "total_tokens": 0, "cost_usd": ${cost}`
+  );
+}
+
+function fakeLoop(dir: string, runId: string): LoopContext {
+  return {
+    runtime: { runId },
+    paths: {
+      journalFile: join(dir, "journal.jsonl"),
+      memoryFile: join(dir, "memory.jsonl"),
+      toolPath: "autoloop",
+    },
+    review: { every: 0 },
+  } as unknown as LoopContext;
+}
+
+function captureSummary(summary: RunSummary, loop: LoopContext): string[] {
+  const logged: string[] = [];
+  vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
+    logged.push(String(line));
+  });
+  printSummary(summary, loop);
+  return logged;
+}
+
+describe("printSummary cost_usd", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("emits cumulative cost_usd summed from backend.usage events", () => {
+    const dir = mkdtempSync(join(tmpdir(), "al-summary-"));
+    const runId = "run-cost-1";
+    const journalFile = join(dir, "journal.jsonl");
+    appendEvent(journalFile, runId, "1", "backend.usage", usageFields(0.05));
+    appendEvent(journalFile, runId, "2", "backend.usage", usageFields(0.03));
+
+    const logged = captureSummary(
+      { iterations: 2, stopReason: "completed" },
+      fakeLoop(dir, runId),
+    );
+
+    expect(logged).toContain("cost_usd: 0.080000");
+  });
+
+  it("emits cost_usd: 0.000000 when no usage was recorded", () => {
+    const dir = mkdtempSync(join(tmpdir(), "al-summary-empty-"));
+    const logged = captureSummary(
+      { iterations: 0, stopReason: "max_iterations" },
+      fakeLoop(dir, "run-empty"),
+    );
+
+    expect(logged).toContain("cost_usd: 0.000000");
+  });
+});

--- a/packages/harness/test/harness/runtime-budget.test.ts
+++ b/packages/harness/test/harness/runtime-budget.test.ts
@@ -44,6 +44,7 @@ vi.mock("../../src/metareview.js", () => ({
 vi.mock("../../src/display.js", () => ({
   printSummary: vi.fn(),
   log: vi.fn(),
+  runCostUsd: vi.fn(() => 0),
   lastNChars: vi.fn((s: string) => s),
   printProjectedMarkdown: vi.fn(),
   printProjectedText: vi.fn(),


### PR DESCRIPTION
Part of #34 (the `command`-backend cost telemetry tracking issue), scoped to the piece ralph v3 needs first: **make cumulative run cost observable to subprocess drivers**.

## Why
ralph drives `autoloop run` as a subprocess and needs cumulative cost to (a) report spend in its own run summary and (b) reconcile its `max_cost_usd` budget across the boundary. Cost is *already* journaled per iteration (`backend.usage`), aggregated (`collectUsage`), and cost-budget termination already works — but cost was absent from **both** the printed summary block **and** the structured `LoopEvent` run-result that consumers read. (Found while wiring ralph's completion coordinator: it had to hardcode cost = 0.)

## What
- `printSummary` emits a `cost_usd:` line, summed via `collectUsage` over the run journal. `0.000000` when the backend reports no usage (e.g. `command`/`acp`) or on a torn journal — always present and parseable.
- The `summary` and `loop.finish` `LoopEvent`s now carry `costUsd`, so the **preferred** structured `--events` channel is consistent with the text block (an adversarial review flagged that cost was only on the brittle text channel the v3 migration is trying to demote).
- Export `runCostUsd` so the terminal-event emit and `printSummary` share one journal-derived computation.

## Not in scope (still #34)
- Real cost extraction for the `command`/`acp` backends (those still report 0).
- Live control / interrupt for the `command` backend.

## Test
- New `display-summary.test.ts` asserts the summed `cost_usd` line (present and zero cases) against a real temp journal.
- Full harness suite **338 green** (updated three partial `display.js` mocks for the new `runCostUsd` export).
- `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)