### PR TITLE
[v3] Resumable runs: `autoloop resume <run-id>`

### DIFF
--- a/packages/cli/src/commands/resume.ts
+++ b/packages/cli/src/commands/resume.ts
@@ -1,0 +1,253 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { findRunByPrefix } from "@mobrienv/autoloop-core/registry/read";
+import type { RunRecord } from "@mobrienv/autoloop-core/registry/types";
+import * as harness from "@mobrienv/autoloop-harness";
+import { cliPrintEvent } from "../cli/event-printer.js";
+import { EXIT_ENV, EXIT_USAGE, fail } from "../cli/fail.js";
+import { backendOverrideSpec } from "./run.js";
+
+interface ResumeArgs {
+  runId: string | null;
+  addIterations?: number;
+  backendOverride?: Record<string, unknown>;
+  logLevel: string | null;
+  usageError: boolean;
+}
+
+export async function dispatchResume(args: string[]): Promise<void> {
+  if (args.some((a) => a === "--help" || a === "-h")) {
+    printResumeUsage();
+    return;
+  }
+
+  const parsed = parseResumeArgs(args);
+  if (parsed.usageError) return;
+  if (!parsed.runId) {
+    fail(
+      [
+        "error: missing required run-id",
+        "Usage: autoloop resume <run-id> [--add-iterations N] [-b <backend>] [-v]",
+      ],
+      EXIT_USAGE,
+    );
+    return;
+  }
+
+  const projectDir = process.env.AUTOLOOP_PROJECT_DIR || ".";
+  const stateDir = join(projectDir, ".autoloop");
+  const registryFile = join(stateDir, "registry.jsonl");
+
+  const lookup = findRunByPrefix(registryFile, parsed.runId);
+  if (!lookup) {
+    fail(
+      [
+        `error: no run matching \`${parsed.runId}\``,
+        "Run `autoloop loops --all` to list runs.",
+      ],
+      EXIT_ENV,
+    );
+    return;
+  }
+  if (Array.isArray(lookup)) {
+    fail(
+      [
+        `error: \`${parsed.runId}\` is ambiguous (${lookup.length} matches):`,
+        ...lookup.map((r) => `  ${r.run_id}`),
+        "Provide a longer prefix.",
+      ],
+      EXIT_USAGE,
+    );
+    return;
+  }
+
+  const record = lookup;
+  const validation = validateResumable(record, parsed);
+  if (validation) {
+    fail([validation.message], validation.code);
+    return;
+  }
+
+  // Mirror dispatchRun's signal ownership: CLI installs SIGINT/SIGTERM, aborts
+  // the harness via AbortSignal, and re-raises the signal on exit.
+  const abort = new AbortController();
+  let caughtSignal: NodeJS.Signals | null = null;
+  const onSig = (sig: NodeJS.Signals) => {
+    if (caughtSignal) return;
+    caughtSignal = sig;
+    abort.abort();
+  };
+  process.on("SIGINT", onSig);
+  process.on("SIGTERM", onSig);
+
+  try {
+    const result = await harness.resume(record, {
+      addIterations: parsed.addIterations,
+      backendOverride: parsed.backendOverride,
+      logLevel: parsed.logLevel,
+      baseStateDir: stateDir,
+      signal: abort.signal,
+      onEvent: cliPrintEvent,
+    });
+    console.log(
+      `resumed ${record.run_id} from iteration ${result.resumedFromIteration} ` +
+        `(was: ${record.stop_reason || "unknown"}); ` +
+        `stop_reason=${result.stopReason} iterations=${result.iterations} ` +
+        `new_max_iterations=${result.newMaxIterations}`,
+    );
+  } finally {
+    process.removeListener("SIGINT", onSig);
+    process.removeListener("SIGTERM", onSig);
+    if (caughtSignal) process.kill(process.pid, caughtSignal);
+  }
+}
+
+interface Validation {
+  message: string;
+  code: number;
+}
+
+/** Returns a validation failure, or null when the run is safe to resume. */
+function validateResumable(
+  record: RunRecord,
+  parsed: ResumeArgs,
+): Validation | null {
+  if (record.status === "completed") {
+    return {
+      message: `error: run ${record.run_id} already completed; cannot resume`,
+      code: EXIT_ENV,
+    };
+  }
+  if (record.status === "running" && record.pid && pidAlive(record.pid)) {
+    return {
+      message: `error: run ${record.run_id} is still running (PID ${record.pid})`,
+      code: EXIT_ENV,
+    };
+  }
+  if (!record.journal_file || !existsSync(record.journal_file)) {
+    return {
+      message: `error: journal not found for run ${record.run_id}`,
+      code: EXIT_ENV,
+    };
+  }
+  const stateDir = record.state_dir || dirOf(record.journal_file);
+  if (!stateDir || !existsSync(stateDir)) {
+    return {
+      message: `error: state directory for run ${record.run_id} not found`,
+      code: EXIT_ENV,
+    };
+  }
+  if (record.isolation_mode === "worktree") {
+    if (!record.worktree_path || !existsSync(record.worktree_path)) {
+      return {
+        message: `error: worktree for run ${record.run_id} was cleaned up; cannot resume`,
+        code: EXIT_ENV,
+      };
+    }
+  }
+  if (parsed.addIterations !== undefined && parsed.addIterations <= 0) {
+    return {
+      message: "error: no iterations to run (--add-iterations must be > 0)",
+      code: EXIT_USAGE,
+    };
+  }
+  return null;
+}
+
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function dirOf(path: string): string {
+  const idx = path.lastIndexOf("/");
+  return idx > 0 ? path.slice(0, idx) : "";
+}
+
+function parseResumeArgs(args: string[]): ResumeArgs {
+  const out: ResumeArgs = {
+    runId: null,
+    logLevel: null,
+    usageError: false,
+  };
+
+  let i = 0;
+  while (i < args.length) {
+    const token = args[i];
+    if (token === "resume") {
+      i++;
+      continue;
+    }
+    if (token === "-v" || token === "--verbose") {
+      out.logLevel = "debug";
+      i++;
+      continue;
+    }
+    if (token === "--add-iterations") {
+      const value = args[i + 1];
+      if (value === undefined) {
+        fail(`missing count after ${token}`, EXIT_USAGE);
+        out.usageError = true;
+        return out;
+      }
+      const n = Number(value);
+      if (!Number.isInteger(n)) {
+        fail(`invalid --add-iterations value: ${value}`, EXIT_USAGE);
+        out.usageError = true;
+        return out;
+      }
+      out.addIterations = n;
+      i += 2;
+      continue;
+    }
+    if (token === "-b" || token === "--backend") {
+      const backend = args[i + 1];
+      if (!backend) {
+        fail(`missing backend after ${token}`, EXIT_USAGE);
+        out.usageError = true;
+        return out;
+      }
+      out.backendOverride = backendOverrideSpec(backend);
+      i += 2;
+      continue;
+    }
+    if (out.runId === null && !token.startsWith("-")) {
+      out.runId = token;
+      i++;
+      continue;
+    }
+    i++;
+  }
+
+  return out;
+}
+
+export function printResumeUsage(): void {
+  console.log(
+    "Usage: autoloop resume <run-id> [--add-iterations N] [-b <backend>] [-v]",
+  );
+  console.log("");
+  console.log(
+    "Continue a previously-terminated run from where it left off, reusing the",
+  );
+  console.log("run_id, journal, memory, working files, and worktree.");
+  console.log("");
+  console.log("Flags:");
+  console.log(
+    "  --add-iterations N    Iterations to grant beyond the resume point",
+  );
+  console.log(
+    "                        (default: the run's original max_iterations)",
+  );
+  console.log(
+    "  -b, --backend <name>  Resume with a different backend (claude-sdk, pi, ...)",
+  );
+  console.log("  -v, --verbose         Set log level to debug");
+  console.log("  -h, --help            Show this help");
+  console.log("");
+  console.log("The <run-id> may be a full id or any unambiguous prefix.");
+}

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -374,7 +374,7 @@ function normalizePrompt(prompt: string | null): string | null {
   return prompt;
 }
 
-function backendOverrideSpec(backend: string): Record<string, unknown> {
+export function backendOverrideSpec(backend: string): Record<string, unknown> {
   if (backend === "pi") {
     return { kind: "pi", command: "pi", args: [], prompt_mode: "arg" };
   }

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -20,6 +20,7 @@ import { dispatchList } from "./commands/list.js";
 import { dispatchLoops } from "./commands/loops.js";
 import { dispatchMemory } from "./commands/memory.js";
 import { dispatchPiAdapter } from "./commands/pi-adapter.js";
+import { dispatchResume } from "./commands/resume.js";
 import { dispatchRobotDocs } from "./commands/robot-docs.js";
 import { dispatchRun } from "./commands/run.js";
 import { dispatchRuns } from "./commands/runs.js";
@@ -74,6 +75,9 @@ async function dispatch(args: string[], argv: string[]): Promise<void> {
       return;
     case "run":
       await dispatchRun(args.slice(1), argv, bundleRoot, selfCmd);
+      return;
+    case "resume":
+      await dispatchResume(args.slice(1));
       return;
     case "emit": {
       if (!args[1] || args[1] === "--help" || args[1] === "-h") {
@@ -209,6 +213,7 @@ function runtimeArgv(argv: string[]): string[] {
 
 const CLI_COMMANDS = [
   "run",
+  "resume",
   "emit",
   "inspect",
   "memory",

--- a/packages/cli/src/usage.ts
+++ b/packages/cli/src/usage.ts
@@ -8,6 +8,9 @@ export function printUsage(): void {
   console.log("");
   console.log("Usage:");
   console.log("  autoloop run <preset-name|preset-dir> [prompt...] [flags]");
+  console.log(
+    "  autoloop resume <run-id> [--add-iterations N] [-b <backend>] [-v]",
+  );
   console.log("  autoloop init [--preset <name>] [dir]");
   console.log("  autoloop emit <topic> [summary]");
   console.log(

--- a/packages/cli/test/commands/resume.test.ts
+++ b/packages/cli/test/commands/resume.test.ts
@@ -1,0 +1,220 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { RunRecord } from "@mobrienv/autoloop-core/registry/types";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the harness so we capture what dispatchResume forwards without driving
+// a real loop.
+const resumeSpy = vi.fn(async () => ({
+  iterations: 5,
+  stopReason: "completed",
+  runId: "run-aaaa",
+  resumedFromIteration: 4,
+  newMaxIterations: 5,
+}));
+vi.mock("@mobrienv/autoloop-harness", () => ({
+  resume: (...args: unknown[]) => resumeSpy(...args),
+}));
+
+vi.mock("../../src/cli/event-printer.js", () => ({
+  cliPrintEvent: vi.fn(),
+}));
+
+import { dispatchResume } from "../../src/commands/resume.js";
+
+let projectDir: string;
+const origProjectDir = process.env.AUTOLOOP_PROJECT_DIR;
+
+function baseRecord(overrides: Partial<RunRecord> = {}): RunRecord {
+  const stateDir = join(projectDir, ".autoloop");
+  return {
+    run_id: "run-aaaa",
+    status: "stopped",
+    preset: "test",
+    objective: "obj",
+    trigger: "cli",
+    project_dir: projectDir,
+    work_dir: projectDir,
+    state_dir: stateDir,
+    journal_file: join(stateDir, "journal.jsonl"),
+    parent_run_id: "",
+    backend: "echo",
+    backend_args: [],
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    iteration: 3,
+    max_iterations: 3,
+    stop_reason: "max_iterations",
+    latest_event: "loop.stop",
+    isolation_mode: "run-scoped",
+    worktree_name: "",
+    worktree_path: "",
+    ...overrides,
+  };
+}
+
+function writeRegistry(records: RunRecord[]): void {
+  const stateDir = join(projectDir, ".autoloop");
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(
+    join(stateDir, "registry.jsonl"),
+    records.map((r) => JSON.stringify(r)).join("\n") + "\n",
+    "utf-8",
+  );
+  // Ensure the journal file referenced by records exists (validation checks it).
+  for (const r of records) {
+    if (r.journal_file) writeFileSync(r.journal_file, "", "utf-8");
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.exitCode = 0;
+  projectDir = mkdtempSync(join(tmpdir(), "autoloop-resume-cli-"));
+  process.env.AUTOLOOP_PROJECT_DIR = projectDir;
+});
+
+afterEach(() => {
+  process.exitCode = 0;
+  if (origProjectDir === undefined) delete process.env.AUTOLOOP_PROJECT_DIR;
+  else process.env.AUTOLOOP_PROJECT_DIR = origProjectDir;
+  rmSync(projectDir, { recursive: true, force: true });
+});
+
+describe("dispatchResume", () => {
+  it("resumes a terminated run, forwarding add-iterations and baseStateDir", async () => {
+    writeRegistry([baseRecord()]);
+    await dispatchResume(["run-aaaa", "--add-iterations", "2"]);
+
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    const [record, opts] = resumeSpy.mock.calls[0] as [
+      RunRecord,
+      Record<string, unknown>,
+    ];
+    expect(record.run_id).toBe("run-aaaa");
+    expect(opts.addIterations).toBe(2);
+    expect(opts.baseStateDir).toBe(join(projectDir, ".autoloop"));
+    expect(process.exitCode ?? 0).toBe(0);
+  });
+
+  it("resolves a run by prefix", async () => {
+    writeRegistry([baseRecord()]);
+    await dispatchResume(["run-a"]);
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards a -b backend override spec", async () => {
+    writeRegistry([baseRecord()]);
+    await dispatchResume(["run-aaaa", "-b", "pi"]);
+    const [, opts] = resumeSpy.mock.calls[0] as [
+      RunRecord,
+      Record<string, unknown>,
+    ];
+    expect(opts.backendOverride).toMatchObject({ kind: "pi", command: "pi" });
+  });
+
+  it("refuses to resume a completed run", async () => {
+    writeRegistry([baseRecord({ status: "completed" })]);
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    await dispatchResume(["run-aaaa"]);
+    expect(resumeSpy).not.toHaveBeenCalled();
+    expect(stderr).toHaveBeenCalledWith(
+      expect.stringContaining("already completed"),
+    );
+    expect(process.exitCode).toBe(2);
+    stderr.mockRestore();
+  });
+
+  it("refuses to resume a run still running with a live pid", async () => {
+    writeRegistry([baseRecord({ status: "running", pid: process.pid })]);
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    await dispatchResume(["run-aaaa"]);
+    expect(resumeSpy).not.toHaveBeenCalled();
+    expect(stderr).toHaveBeenCalledWith(
+      expect.stringContaining("still running"),
+    );
+    stderr.mockRestore();
+  });
+
+  it("resumes a crashed running run whose pid is dead", async () => {
+    // pid 1 is init; process.kill(1, 0) throws EPERM for an unprivileged
+    // process, which our liveness check treats as not-our-process. Use a pid
+    // that is virtually guaranteed dead.
+    writeRegistry([baseRecord({ status: "running", pid: 2 ** 30 })]);
+    await dispatchResume(["run-aaaa"]);
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses when the run id is unknown", async () => {
+    writeRegistry([baseRecord()]);
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    await dispatchResume(["run-zzzz"]);
+    expect(resumeSpy).not.toHaveBeenCalled();
+    expect(stderr).toHaveBeenCalledWith(
+      expect.stringContaining("no run matching"),
+    );
+    stderr.mockRestore();
+  });
+
+  it("refuses an ambiguous prefix", async () => {
+    writeRegistry([
+      baseRecord({ run_id: "run-abc" }),
+      baseRecord({ run_id: "run-abd" }),
+    ]);
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    await dispatchResume(["run-ab"]);
+    expect(resumeSpy).not.toHaveBeenCalled();
+    expect(stderr).toHaveBeenCalledWith(expect.stringContaining("ambiguous"));
+    stderr.mockRestore();
+  });
+
+  it("refuses --add-iterations 0", async () => {
+    writeRegistry([baseRecord()]);
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    await dispatchResume(["run-aaaa", "--add-iterations", "0"]);
+    expect(resumeSpy).not.toHaveBeenCalled();
+    expect(stderr).toHaveBeenCalledWith(
+      expect.stringContaining("no iterations to run"),
+    );
+    stderr.mockRestore();
+  });
+
+  it("refuses a worktree-mode run whose worktree was cleaned up", async () => {
+    writeRegistry([
+      baseRecord({
+        isolation_mode: "worktree",
+        worktree_path: join(projectDir, "gone-worktree"),
+      }),
+    ]);
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    await dispatchResume(["run-aaaa"]);
+    expect(resumeSpy).not.toHaveBeenCalled();
+    expect(stderr).toHaveBeenCalledWith(
+      expect.stringContaining("was cleaned up"),
+    );
+    stderr.mockRestore();
+  });
+
+  it("prints usage for --help without resuming", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    await dispatchResume(["--help"]);
+    expect(resumeSpy).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("autoloop resume"),
+    );
+    log.mockRestore();
+  });
+});

--- a/packages/core/src/registry/derive.ts
+++ b/packages/core/src/registry/derive.ts
@@ -63,6 +63,26 @@ export function deriveRunRecords(lines: string[]): RunRecord[] {
       continue;
     }
 
+    if (topic === "loop.resume") {
+      // A terminated run is being continued. Flip it back to running and clear
+      // the prior stop reason; subsequent iteration.finish / loop.* events
+      // update iteration and final status as usual. The resume point is the
+      // iteration the loop re-enters at, so the next completed iteration is
+      // resumed_from_iteration - 1 + 1 = resumed_from_iteration.
+      record.status = "running";
+      record.stop_reason = "";
+      record.updated_at = record.created_at;
+      record.latest_event = topic;
+      const resumedFrom = fieldValue(event, "resumed_from_iteration");
+      const newMax = Number(fieldValue(event, "new_max_iterations"));
+      if (resumedFrom) {
+        const iter = parseInt(resumedFrom, 10);
+        if (!Number.isNaN(iter)) record.iteration = iter - 1;
+      }
+      if (!Number.isNaN(newMax) && newMax > 0) record.max_iterations = newMax;
+      continue;
+    }
+
     if (topic === "loop.complete") {
       record.status = "completed";
       record.stop_reason = fieldValue(event, "reason");

--- a/packages/core/test/registry/derive.test.ts
+++ b/packages/core/test/registry/derive.test.ts
@@ -68,6 +68,15 @@ function loopStopLine(
   }).trim();
 }
 
+function loopResumeLine(runId: string, fields: Record<string, string>): string {
+  return encodeEvent({
+    shape: "fields",
+    run: runId,
+    topic: "loop.resume",
+    fields,
+  }).trim();
+}
+
 describe("deriveRunRecords", () => {
   it("creates a running record from loop.start", () => {
     const lines = [loopStartLine("run-1")];
@@ -158,6 +167,48 @@ describe("deriveRunRecords", () => {
     const records = deriveRunRecords(lines);
     expect(records[0].status).toBe("stopped");
     expect(records[0].stop_reason).toBe("max_iterations");
+  });
+
+  it("transitions a stopped run back to running on loop.resume", () => {
+    const lines = [
+      loopStartLine("run-1", { max_iterations: "3" }),
+      iterationFinishLine("run-1", "1"),
+      iterationFinishLine("run-1", "2"),
+      iterationFinishLine("run-1", "3"),
+      loopStopLine("run-1", "3", "max_iterations"),
+      loopResumeLine("run-1", {
+        resumed_from_iteration: "4",
+        previous_stop_reason: "max_iterations",
+        add_iterations: "2",
+        new_max_iterations: "5",
+      }),
+    ];
+    const records = deriveRunRecords(lines);
+    expect(records[0].status).toBe("running");
+    expect(records[0].stop_reason).toBe("");
+    expect(records[0].latest_event).toBe("loop.resume");
+    // iteration set to resumed_from - 1 (the last completed iteration)
+    expect(records[0].iteration).toBe(3);
+    expect(records[0].max_iterations).toBe(5);
+  });
+
+  it("continues normal lifecycle after a resume to a later completion", () => {
+    const lines = [
+      loopStartLine("run-1", { max_iterations: "3" }),
+      loopStopLine("run-1", "3", "max_iterations"),
+      loopResumeLine("run-1", {
+        resumed_from_iteration: "4",
+        previous_stop_reason: "max_iterations",
+        add_iterations: "2",
+        new_max_iterations: "5",
+      }),
+      iterationFinishLine("run-1", "4"),
+      loopCompleteLine("run-1", "4", "completion_event"),
+    ];
+    const records = deriveRunRecords(lines);
+    expect(records[0].status).toBe("completed");
+    expect(records[0].stop_reason).toBe("completion_event");
+    expect(records[0].iteration).toBe(4);
   });
 
   it("handles multiple runs", () => {

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -86,6 +86,22 @@ export async function run(
     publishCapabilities(loop.paths.stateDir, loop.controlAdapter);
   }
 
+  return driveLoop(loop, runOptions, 1);
+}
+
+/**
+ * Drive the iteration loop for an already-built, already-registered
+ * LoopContext, starting at `startIteration`. Owns abort/teardown wiring,
+ * the tracked-iterate recursion, session cleanup, post-run worktree
+ * lifecycle, and finish notifications. Shared by `run()` and `resume()` so
+ * both paths exercise identical signal handlers, stop handlers, and
+ * registry/journal behavior.
+ */
+export async function driveLoop(
+  loop: LoopContext,
+  runOptions: RunOptions,
+  startIteration: number,
+): Promise<RunSummary> {
   // Track current iteration for abort handler (must be mutable)
   let currentIteration = 0;
   let aborted = false;
@@ -185,7 +201,7 @@ export async function run(
     return iterateWith(ctx, iter, trackedIterate);
   };
   try {
-    summary = await trackedIterate(loop, 1);
+    summary = await trackedIterate(loop, startIteration);
   } finally {
     if (loop.acpSession.current) {
       try {
@@ -311,6 +327,13 @@ export async function run(
   return { ...summary, runId: loop.runtime.runId };
 }
 
+export {
+  buildResumeContext,
+  determineResumeIteration,
+  type ResumeOptions,
+  type ResumeResult,
+  resume,
+} from "./resume.js";
 export { emitCmd as emit };
 
 export async function runParallelBranchCli(
@@ -495,7 +518,7 @@ function iterate(loop: LoopContext, iteration: number): Promise<RunSummary> {
   return iterateWith(loop, iteration, iterate);
 }
 
-function buildControlAdapter(
+export function buildControlAdapter(
   loop: LoopContext,
 ): LiveControlAdapter | undefined {
   if (loop.backend.kind === "acp") {

--- a/packages/harness/src/resume.ts
+++ b/packages/harness/src/resume.ts
@@ -1,0 +1,306 @@
+import { existsSync } from "node:fs";
+import { basename, join } from "node:path";
+import { jsonField } from "@mobrienv/autoloop-core";
+import * as config from "@mobrienv/autoloop-core/config";
+import {
+  appendEvent,
+  extractIteration,
+  extractTopic,
+  readRunLines,
+} from "@mobrienv/autoloop-core/journal";
+import type { RunRecord } from "@mobrienv/autoloop-core/registry/types";
+import { updateStatus as updateWorktreeStatus } from "@mobrienv/autoloop-core/worktree";
+import {
+  ensureLayout,
+  initStore,
+  installRuntimeTools,
+  reloadLoop,
+} from "./config-helpers.js";
+import { publishCapabilities } from "./control/dispatch.js";
+import { log } from "./display.js";
+import { buildControlAdapter, driveLoop } from "./index.js";
+import { registryStart } from "./registry-bridge.js";
+import type { LoopContext, RunOptions, RunSummary } from "./types.js";
+
+export interface ResumeOptions {
+  /** Additional iterations to grant beyond the resume point. */
+  addIterations?: number;
+  /** Backend override (parsed `-b` spec), applied via reloadLoop. */
+  backendOverride?: Record<string, unknown>;
+  /** Log level override (e.g. "debug" for -v). */
+  logLevel?: string | null;
+  /**
+   * Main repo state dir holding the registry the record was read from. Used
+   * to anchor registryFile and worktree cleanup. When omitted it is derived
+   * from the record (project_dir + state dir name).
+   */
+  baseStateDir?: string;
+  /** Abort signal (CLI owns process signal handling). */
+  signal?: AbortSignal;
+  /** Structured-event listener. */
+  onEvent?: RunOptions["onEvent"];
+}
+
+export interface ResumeResult extends RunSummary {
+  resumedFromIteration: number;
+  newMaxIterations: number;
+}
+
+/**
+ * Compute the iteration to resume at, given the terminating stop reason and
+ * the last iteration recorded in the registry.
+ *
+ * - `max_iterations`: the registry iteration is the last *completed* one; the
+ *   blocked iteration is the next one (registryIteration + 1).
+ * - `backend_failed` / `backend_timeout`: the registry iteration is the one
+ *   that failed mid-flight; retry it (registryIteration).
+ * - `interrupted` / `stopped` (or anything else): scan the journal — if an
+ *   `iteration.finish` exists for registryIteration it completed, so resume at
+ *   the next one; otherwise it was in-flight, so retry it.
+ */
+export function determineResumeIteration(
+  journalFile: string,
+  runId: string,
+  stopReason: string,
+  registryIteration: number,
+): number {
+  if (stopReason === "max_iterations") {
+    return registryIteration + 1;
+  }
+  if (stopReason === "backend_failed" || stopReason === "backend_timeout") {
+    return registryIteration;
+  }
+  // interrupted / stopped / unknown: trust the journal.
+  const lines = readRunLines(journalFile, runId);
+  const finished = lines.some(
+    (line) =>
+      extractTopic(line) === "iteration.finish" &&
+      extractIteration(line) === String(registryIteration),
+  );
+  return finished ? registryIteration + 1 : registryIteration;
+}
+
+/**
+ * Build a LoopContext that reuses an existing run's identity (run_id, journal,
+ * memory, working files, worktree) instead of generating fresh ones. Mirrors
+ * `buildLoopContext` but skips run-id generation and worktree creation; the
+ * one-time setup that resume needs (loading config, deriving paths, filling
+ * topology/backend/limits) is delegated to `reloadLoop`.
+ */
+export function buildResumeContext(
+  record: RunRecord,
+  options: ResumeOptions = {},
+): { loop: LoopContext; resumeIteration: number; addIterations: number } {
+  const projectDir = record.project_dir;
+  if (!projectDir) {
+    throw new Error(`run ${record.run_id} has no project_dir; cannot resume`);
+  }
+
+  // findRunByPrefix reads the registry directly, so a resumable run always
+  // carries the real state_dir that registryStart wrote (.autoloop/ for shared
+  // and worktree modes, .autoloop/runs/<id>/ for run-scoped). Never guess it
+  // from the journal path — for run-scoped runs the journal lives at the
+  // top-level .autoloop/ while the state dir is .autoloop/runs/<id>/, so a
+  // dirname() guess would point at the wrong directory.
+  const stateDir = record.state_dir;
+  if (!stateDir) {
+    throw new Error(`run ${record.run_id} has no state_dir; cannot resume`);
+  }
+  const journalFile = record.journal_file;
+
+  const isolationMode = record.isolation_mode || "run-scoped";
+  const worktreeMode = isolationMode === "worktree";
+
+  const workDir = worktreeMode
+    ? record.worktree_path || record.work_dir
+    : record.work_dir;
+
+  // Recompute config-anchored paths exactly as buildLoopContext does, but
+  // rooted in this run's existing state dir rather than a freshly-created one.
+  const stateDirName = basename(stateDir);
+  const cfg = config.loadProject(projectDir, {
+    presetName: record.preset || basename(projectDir),
+    workDir,
+  });
+  const memoryRel = config.get(
+    cfg,
+    "core.memory_file",
+    join(stateDirName, "memory.jsonl"),
+  );
+  const memoryFile = join(workDir, memoryRel);
+
+  // baseStateDir is the main repo's state dir (registry + worktree metadata
+  // live here). Prefer the caller-supplied path (the registry the record was
+  // read from); fall back to deriving it. In worktree mode the per-run journal
+  // lives under the worktree tree, so the main state dir is the project root's.
+  const baseStateDir =
+    options.baseStateDir ||
+    (worktreeMode ? join(record.project_dir, stateDirName) : stateDir);
+  const registryFile = join(baseStateDir, "registry.jsonl");
+
+  const backendOverride = options.backendOverride || {};
+  const logLevel =
+    options.logLevel || config.get(cfg, "core.log_level", "info");
+
+  const resumeIteration = determineResumeIteration(
+    journalFile,
+    record.run_id,
+    record.stop_reason,
+    record.iteration,
+  );
+
+  // Budget is additive from the resume point. Default add-iterations to the
+  // run's original max_iterations (so a max_iterations stop, by default, grants
+  // another full run's worth of budget beyond what was completed).
+  const addIterations =
+    options.addIterations && options.addIterations > 0
+      ? options.addIterations
+      : record.max_iterations ||
+        config.getInt(cfg, "event_loop.max_iterations", 3);
+  const newMaxIterations = resumeIteration - 1 + addIterations;
+
+  // The budget must survive reloadLoop (called at the start of every
+  // iteration), which re-reads event_loop.max_iterations from config. Layer it
+  // in as a run config override so each reload sees the additive budget rather
+  // than the static config value.
+  const configOverride = config.put(
+    {},
+    "event_loop.max_iterations",
+    String(newMaxIterations),
+  );
+
+  const seed = {
+    paths: {
+      projectDir,
+      workDir,
+      stateDir,
+      journalFile,
+      memoryFile,
+      runMemoryFile: join(stateDir, "memory.jsonl"),
+      tasksFile: join(stateDir, "tasks.jsonl"),
+      registryFile,
+      toolPath: join(stateDir, "autoloops"),
+      piAdapterPath: join(stateDir, "pi-adapter"),
+      baseStateDir,
+      mainProjectDir: projectDir,
+      worktreeBranch: worktreeMode ? record.worktree_name : "",
+      worktreePath: worktreeMode ? record.worktree_path : "",
+      worktreeMetaDir: worktreeMode
+        ? join(baseStateDir, "worktrees", record.run_id)
+        : "",
+      configWorkDir: workDir,
+    },
+    runtime: {
+      runId: record.run_id,
+      selfCommand: "",
+      promptOverride: null,
+      backendOverride,
+      configOverride,
+      logLevel,
+      branchMode: false,
+      isolationMode,
+    },
+    launch: {
+      preset: record.preset || basename(projectDir),
+      trigger: record.trigger || "cli",
+      createdAt: record.created_at || new Date().toISOString(),
+      parentRunId: record.parent_run_id || "",
+    },
+    profiles: {
+      active: [] as string[],
+      fragments: new Map<string, string>(),
+      warnings: [] as string[],
+    },
+    store: {},
+  } as unknown as LoopContext;
+
+  let loop = reloadLoop(seed);
+  // Override the iteration budget: reloadLoop reads it fresh from config; resume
+  // needs the additive budget from the resume point.
+  loop = {
+    ...loop,
+    limits: { ...loop.limits, maxIterations: newMaxIterations },
+  };
+
+  return { loop, resumeIteration, addIterations };
+}
+
+/**
+ * Resume a terminated run from where it left off. Validation (status, pid
+ * liveness, missing files) is the caller's responsibility (see the CLI
+ * command); this entry assumes the record is resumable and drives the same
+ * iteration loop `run()` uses.
+ */
+export async function resume(
+  record: RunRecord,
+  options: ResumeOptions = {},
+): Promise<ResumeResult> {
+  const {
+    loop: built,
+    resumeIteration,
+    addIterations,
+  } = buildResumeContext(record, options);
+
+  let loop = built;
+  loop.onEvent = options.onEvent;
+  loop = initStore(loop);
+  ensureLayout(loop.paths.stateDir);
+  installRuntimeTools(loop);
+
+  // Append the resume marker before any iteration so the scratchpad and derive
+  // path see it. It's a system topic — routing ignores it.
+  appendEvent(
+    loop.paths.journalFile,
+    loop.runtime.runId,
+    "",
+    "loop.resume",
+    jsonField("resumed_from_iteration", String(resumeIteration)) +
+      ", " +
+      jsonField("previous_stop_reason", record.stop_reason || "") +
+      ", " +
+      jsonField("add_iterations", String(addIterations)) +
+      ", " +
+      jsonField("new_max_iterations", String(loop.limits.maxIterations)),
+  );
+
+  // Registry: append a fresh record (status running, pid = this process). The
+  // registry is last-write-wins per run_id, so this transitions the run back to
+  // running exactly as the normal start path does.
+  registryStart(loop);
+
+  // Worktree mode: flip meta status back to running so the run isn't stuck as
+  // "failed" if it crashed mid-flight.
+  if (loop.paths.worktreeMetaDir && existsSync(loop.paths.worktreeMetaDir)) {
+    try {
+      updateWorktreeStatus(loop.paths.worktreeMetaDir, "running");
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  loop.controlAdapter = buildControlAdapter(loop);
+  if (loop.controlAdapter) {
+    publishCapabilities(loop.paths.stateDir, loop.controlAdapter);
+  }
+
+  log(
+    loop,
+    "info",
+    `resume run_id=${loop.runtime.runId} from_iteration=${resumeIteration} new_max_iterations=${loop.limits.maxIterations} (was: ${record.stop_reason || "unknown"})`,
+  );
+
+  const runOptions: RunOptions = {
+    workDir: loop.paths.workDir,
+    backendOverride: options.backendOverride,
+    logLevel: options.logLevel,
+    signal: options.signal,
+    onEvent: options.onEvent,
+  };
+
+  const summary = await driveLoop(loop, runOptions, resumeIteration);
+  return {
+    ...summary,
+    resumedFromIteration: resumeIteration,
+    newMaxIterations: loop.limits.maxIterations,
+  };
+}

--- a/packages/harness/src/scratchpad.ts
+++ b/packages/harness/src/scratchpad.ts
@@ -5,11 +5,20 @@ import {
   lineSep,
 } from "@mobrienv/autoloop-core";
 
-interface ScratchpadEntry {
+interface IterationEntry {
+  kind: "iteration";
   iteration: string;
   exitCode: string;
   output: string;
 }
+
+interface ResumeMarker {
+  kind: "resume";
+  previousStopReason: string;
+  addIterations: string;
+}
+
+type ScratchpadEntry = IterationEntry | ResumeMarker;
 
 export function renderRunScratchpadFull(lines: string[]): string {
   const entries = collectScratchpadEntries(lines);
@@ -36,17 +45,21 @@ function collectScratchpadEntries(lines: string[]): ScratchpadEntry[] {
   const entries: ScratchpadEntry[] = [];
   for (const line of lines) {
     const event = decodeEvent(line);
-    if (
-      !event ||
-      event.shape !== "fields" ||
-      event.topic !== "iteration.finish"
-    )
-      continue;
-    entries.push({
-      iteration: event.iteration ?? "",
-      exitCode: event.fields.exit_code ?? "",
-      output: event.fields.output ?? "",
-    });
+    if (!event || event.shape !== "fields") continue;
+    if (event.topic === "iteration.finish") {
+      entries.push({
+        kind: "iteration",
+        iteration: event.iteration ?? "",
+        exitCode: event.fields.exit_code ?? "",
+        output: event.fields.output ?? "",
+      });
+    } else if (event.topic === "loop.resume") {
+      entries.push({
+        kind: "resume",
+        previousStopReason: event.fields.previous_stop_reason ?? "",
+        addIterations: event.fields.add_iterations ?? "",
+      });
+    }
   }
   return entries;
 }
@@ -56,6 +69,9 @@ function renderScratchpadEntries(entries: ScratchpadEntry[]): string {
 }
 
 function scratchpadEntryText(entry: ScratchpadEntry): string {
+  if (entry.kind === "resume") {
+    return `${resumeMarkerText(entry)}\n\n`;
+  }
   return (
     heading(2, `Iteration ${entry.iteration}`) +
     "\n\n" +
@@ -67,7 +83,16 @@ function scratchpadEntryText(entry: ScratchpadEntry): string {
   );
 }
 
+function resumeMarkerText(entry: ResumeMarker): string {
+  const reason = entry.previousStopReason || "unknown";
+  const adding = entry.addIterations || "0";
+  return `--- resumed (was: ${reason}, adding ${adding} iterations) ---`;
+}
+
 function compactScratchpadItem(entry: ScratchpadEntry): string {
+  if (entry.kind === "resume") {
+    return resumeMarkerText(entry);
+  }
   return (
     "Iteration " +
     entry.iteration +
@@ -78,7 +103,7 @@ function compactScratchpadItem(entry: ScratchpadEntry): string {
   );
 }
 
-function scratchpadEntrySummary(entry: ScratchpadEntry): string {
+function scratchpadEntrySummary(entry: IterationEntry): string {
   const lines = entry.output.split(lineSep());
   for (const line of lines) {
     const trimmed = line.trim();

--- a/packages/harness/test/harness/resume-iteration.test.ts
+++ b/packages/harness/test/harness/resume-iteration.test.ts
@@ -1,0 +1,85 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { encodeEvent } from "@mobrienv/autoloop-core";
+import { determineResumeIteration } from "@mobrienv/autoloop-harness";
+import { describe, expect, it } from "vitest";
+
+/**
+ * determineResumeIteration — the four stop-reason branches from the RFC.
+ * Uses a real on-disk journal because the function reads run lines from it
+ * for the interrupted/stopped case.
+ */
+
+const RUN = "run-x";
+
+function writeJournal(lines: string[]): string {
+  const dir = mkdtempSync(join(tmpdir(), "autoloop-resume-iter-"));
+  const file = join(dir, "journal.jsonl");
+  writeFileSync(file, `${lines.join("\n")}\n`, "utf-8");
+  return file;
+}
+
+function finish(iteration: string): string {
+  return encodeEvent({
+    shape: "fields",
+    run: RUN,
+    iteration,
+    topic: "iteration.finish",
+    fields: { exit_code: "0", output: "ok" },
+  });
+}
+
+function start(iteration: string): string {
+  return encodeEvent({
+    shape: "fields",
+    run: RUN,
+    iteration,
+    topic: "iteration.start",
+    fields: {},
+  });
+}
+
+describe("determineResumeIteration", () => {
+  it("max_iterations resumes at the blocked iteration (registry + 1)", () => {
+    // Completed 7 of 10; registry iteration = 7. Blocked iteration is 8.
+    const journal = writeJournal([finish("6"), finish("7")]);
+    expect(determineResumeIteration(journal, RUN, "max_iterations", 7)).toBe(8);
+  });
+
+  it("backend_failed retries the failed iteration (registry)", () => {
+    // Iteration 4 started, no finish — it failed. Retry 4.
+    const journal = writeJournal([finish("3"), start("4")]);
+    expect(determineResumeIteration(journal, RUN, "backend_failed", 4)).toBe(4);
+  });
+
+  it("backend_timeout retries the timed-out iteration (registry)", () => {
+    const journal = writeJournal([finish("2"), start("3")]);
+    expect(determineResumeIteration(journal, RUN, "backend_timeout", 3)).toBe(
+      3,
+    );
+  });
+
+  it("interrupted with an iteration.finish for N resumes at N + 1", () => {
+    // Iteration 5 finished before the interrupt landed → resume at 6.
+    const journal = writeJournal([finish("4"), start("5"), finish("5")]);
+    expect(determineResumeIteration(journal, RUN, "interrupted", 5)).toBe(6);
+  });
+
+  it("interrupted without an iteration.finish for N retries N", () => {
+    // Iteration 5 was in-flight when interrupted (start, no finish) → retry 5.
+    const journal = writeJournal([finish("4"), start("5")]);
+    expect(determineResumeIteration(journal, RUN, "interrupted", 5)).toBe(5);
+  });
+
+  it("stopped falls through the journal-scan branch like interrupted", () => {
+    const journalFinished = writeJournal([start("3"), finish("3")]);
+    expect(determineResumeIteration(journalFinished, RUN, "stopped", 3)).toBe(
+      4,
+    );
+    const journalInFlight = writeJournal([start("3")]);
+    expect(determineResumeIteration(journalInFlight, RUN, "stopped", 3)).toBe(
+      3,
+    );
+  });
+});

--- a/packages/harness/test/harness/resume.test.ts
+++ b/packages/harness/test/harness/resume.test.ts
@@ -1,0 +1,196 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { appendEvent } from "@mobrienv/autoloop-core/journal";
+import type { RunRecord } from "@mobrienv/autoloop-core/registry/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Integration: run a real harness loop to a max_iterations stop (real journal
+ * via a mocked iteration runner that writes iteration.finish events), then
+ * resume() with --add-iterations. Asserts resume:
+ *   (a) continues from the correct iteration and does NOT re-run completed ones
+ *   (b) appends a loop.resume event to the journal
+ *   (c) applies the additive max_iterations budget
+ *
+ * The worktree/metareview/display/registry-bridge mocks mirror the
+ * runtime-budget and abort-signal templates.
+ */
+
+vi.mock("@mobrienv/autoloop-core/worktree", () => ({
+  mergeWorktree: vi.fn(),
+  updateStatus: vi.fn(),
+  readMeta: vi.fn(() => null),
+  metaDirForRun: vi.fn(() => "/tmp/fake-meta"),
+  writeMeta: vi.fn(),
+  isOrphanWorktree: vi.fn(() => false),
+  createWorktree: vi.fn(() => ({
+    worktreePath: "/tmp/fake-worktree",
+    branch: "autoloop/fake-run",
+    metaDir: "/tmp/fake-meta",
+  })),
+  resolveGitRoot: vi.fn((cwd: string) => cwd),
+  tryResolveGitRoot: vi.fn((cwd: string) => cwd),
+  cleanWorktrees: vi.fn(),
+  listWorktreeMetas: vi.fn(() => []),
+}));
+
+// Mocked iteration runner: writes a real iteration.finish event (so the
+// journal carries the routing/scratchpad state resume reads) then recurses.
+// It never emits the completion event, so the loop runs to max_iterations.
+const runIteration = vi.hoisted(() =>
+  vi.fn(
+    (
+      loop: {
+        paths: { journalFile: string };
+        runtime: { runId: string };
+      },
+      iter: number,
+      recurse: (l: unknown, i: number) => unknown,
+    ) => {
+      appendEvent(
+        loop.paths.journalFile,
+        loop.runtime.runId,
+        String(iter),
+        "iteration.finish",
+        `"exit_code": "0", "output": "iter ${iter} output"`,
+      );
+      return recurse(loop, iter + 1);
+    },
+  ),
+);
+vi.mock("../../src/iteration.js", () => ({ runIteration }));
+
+vi.mock("../../src/metareview.js", () => ({
+  maybeRunMetareview: vi.fn((loop: unknown) => loop),
+}));
+
+vi.mock("../../src/display.js", () => ({
+  printSummary: vi.fn(),
+  log: vi.fn(),
+  lastNChars: vi.fn((s: string) => s),
+  printProjectedMarkdown: vi.fn(),
+  printProjectedText: vi.fn(),
+}));
+
+vi.mock("../../src/registry-bridge.js", () => ({
+  registryStart: vi.fn(),
+  registryStop: vi.fn(),
+  registryComplete: vi.fn(),
+  registryProgress: vi.fn(),
+}));
+
+import { resume, run } from "@mobrienv/autoloop-harness";
+
+function makeProject(maxIterations: number): string {
+  const dir = mkdtempSync(join(tmpdir(), "autoloop-resume-"));
+  writeFileSync(
+    join(dir, "autoloops.toml"),
+    [
+      '[backend]\ncommand = "echo"',
+      "[event_loop]",
+      `max_iterations = ${maxIterations}`,
+      "[review]",
+      "enabled = false",
+    ].join("\n"),
+  );
+  writeFileSync(join(dir, "topology.toml"), '[[role]]\nname = "builder"\n');
+  mkdirSync(join(dir, ".autoloop"), { recursive: true });
+  return dir;
+}
+
+function recordFor(dir: string): RunRecord {
+  return {
+    run_id: "run-resume-test",
+    status: "stopped",
+    preset: "test",
+    objective: "do the thing",
+    trigger: "cli",
+    project_dir: dir,
+    work_dir: dir,
+    state_dir: join(dir, ".autoloop"),
+    journal_file: join(dir, ".autoloop", "journal.jsonl"),
+    parent_run_id: "",
+    backend: "echo",
+    backend_args: [],
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    iteration: 3,
+    max_iterations: 3,
+    stop_reason: "max_iterations",
+    latest_event: "loop.stop",
+    isolation_mode: "run-scoped",
+    worktree_name: "",
+    worktree_path: "",
+  };
+}
+
+describe("harness.resume integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("runs the original loop to max_iterations, then resume continues from the right iteration", async () => {
+    const dir = makeProject(3);
+
+    // 1) Original run: 3 iterations, no completion → max_iterations stop.
+    const first = await run(dir, "prompt", "autoloop", { workDir: dir });
+    expect(first.stopReason).toBe("max_iterations");
+    expect(first.iterations).toBe(3);
+    expect(runIteration).toHaveBeenCalledTimes(3);
+    // Iterations ran with 1, 2, 3 — never beyond.
+    const firstIters = runIteration.mock.calls.map((c) => c[1]);
+    expect(firstIters).toEqual([1, 2, 3]);
+
+    runIteration.mockClear();
+
+    // 2) Resume with --add-iterations 2. Registry recorded iteration=3 from
+    //    a max_iterations stop → resume at iteration 4, new budget 3 + 2 = 5.
+    const record = recordFor(dir);
+    const result = await resume(record, { addIterations: 2 });
+
+    expect(result.resumedFromIteration).toBe(4);
+    expect(result.newMaxIterations).toBe(5);
+    expect(result.stopReason).toBe("max_iterations");
+
+    // (a) Resume re-entered at iteration 4 and did NOT re-run 1..3.
+    const resumeIters = runIteration.mock.calls.map((c) => c[1]);
+    expect(resumeIters[0]).toBe(4);
+    expect(resumeIters).toEqual([4, 5]);
+    expect(resumeIters).not.toContain(1);
+    expect(resumeIters).not.toContain(2);
+    expect(resumeIters).not.toContain(3);
+
+    const journal = readFileSync(
+      join(dir, ".autoloop", "journal.jsonl"),
+      "utf-8",
+    );
+
+    // (b) A loop.resume event was appended with the expected fields.
+    expect(journal).toContain('"topic": "loop.resume"');
+    expect(journal).toContain('"resumed_from_iteration": "4"');
+    expect(journal).toContain('"previous_stop_reason": "max_iterations"');
+    expect(journal).toContain('"add_iterations": "2"');
+    expect(journal).toContain('"new_max_iterations": "5"');
+
+    // (c) The journal carries iteration.finish for 1..5 across both segments,
+    //     proving completed iterations were preserved and resume appended 4..5.
+    for (const n of [1, 2, 3, 4, 5]) {
+      expect(journal).toContain(`"iteration": "${n}"`);
+    }
+  });
+
+  it("defaults add-iterations to the run's original max_iterations", async () => {
+    const dir = makeProject(3);
+    await run(dir, "prompt", "autoloop", { workDir: dir });
+    runIteration.mockClear();
+
+    // No addIterations → default to record.max_iterations (3).
+    // Resume at 4, new budget = 4 - 1 + 3 = 6.
+    const result = await resume(recordFor(dir), {});
+    expect(result.resumedFromIteration).toBe(4);
+    expect(result.newMaxIterations).toBe(6);
+    const resumeIters = runIteration.mock.calls.map((c) => c[1]);
+    expect(resumeIters).toEqual([4, 5, 6]);
+  });
+});

--- a/packages/harness/test/harness/scratchpad.test.ts
+++ b/packages/harness/test/harness/scratchpad.test.ts
@@ -31,6 +31,22 @@ function otherLine(topic: string): string {
   }).trim();
 }
 
+function resumeLine(previousStopReason: string, addIterations: string): string {
+  return encodeEvent({
+    shape: "fields",
+    run: "r1",
+    topic: "loop.resume",
+    fields: {
+      previous_stop_reason: previousStopReason,
+      add_iterations: addIterations,
+    },
+    rawFields: {
+      previous_stop_reason: previousStopReason,
+      add_iterations: addIterations,
+    },
+  }).trim();
+}
+
 describe("renderRunScratchpadFull", () => {
   it("returns empty string for no lines", () => {
     expect(renderRunScratchpadFull([])).toBe("");
@@ -138,5 +154,49 @@ describe("renderRunScratchpadPrompt", () => {
     ];
     const result = renderRunScratchpadPrompt(lines);
     expect(result).toContain("(no output)");
+  });
+});
+
+describe("loop.resume scratchpad marker", () => {
+  it("renders a visible resume separator inline between iterations", () => {
+    const lines = [
+      iterFinishLine("1", "0", "first"),
+      resumeLine("max_iterations", "10"),
+      iterFinishLine("2", "0", "second"),
+    ];
+    const result = renderRunScratchpadFull(lines);
+    expect(result).toContain(
+      "--- resumed (was: max_iterations, adding 10 iterations) ---",
+    );
+    // Ordered between iteration 1 and iteration 2.
+    const pos1 = result.indexOf("Iteration 1");
+    const posResume = result.indexOf("--- resumed");
+    const pos2 = result.indexOf("Iteration 2");
+    expect(pos1).toBeLessThan(posResume);
+    expect(posResume).toBeLessThan(pos2);
+  });
+
+  it("falls back to 'unknown' reason and '0' when fields are absent", () => {
+    const lines = [resumeLine("", "")];
+    const result = renderRunScratchpadFull(lines);
+    expect(result).toContain(
+      "--- resumed (was: unknown, adding 0 iterations) ---",
+    );
+  });
+
+  it("renders the resume marker in the compacted earlier section", () => {
+    const lines = [
+      iterFinishLine("1", "0", "a"),
+      resumeLine("interrupted", "5"),
+      iterFinishLine("2", "0", "b"),
+      iterFinishLine("3", "0", "c"),
+      iterFinishLine("4", "0", "d"),
+      iterFinishLine("5", "0", "e"),
+    ];
+    const result = renderRunScratchpadPrompt(lines);
+    expect(result).toContain("Earlier iterations (compacted)");
+    expect(result).toContain(
+      "--- resumed (was: interrupted, adding 5 iterations) ---",
+    );
   });
 });


### PR DESCRIPTION
Implements the `autoloops-resume` RFC (`docs/rfcs/autoloops-resume.md`). Part of #38 — the resumable-runs piece ralph v3 needs to retire its in-house `ralph resume`.

## Why
Runs terminate permanently on `max_iterations` / `backend_failed` / `backend_timeout` / `interrupted`, even though all state survives on disk (journal, registry, memory, working files, worktree). There was no way to continue from where a run left off. Resume is a **lifecycle** concern, not state reconstruction — the harness already re-derives all routing/scratchpad state from the journal every iteration.

## CLI
```
autoloop resume <run-id> [--add-iterations N] [-b <backend>] [-v]
```
`<run-id>` is a full or prefix match. Budget is additive from the resume point; `--add-iterations` defaults to the run's original `max_iterations`.

## What
- **`harness/resume.ts`** — `determineResumeIteration()` (max_iterations → N+1; backend_* → retry N; interrupted/stopped → N+1 if an `iteration.finish` exists for N, else retry N), `buildResumeContext()` (reuses the run's identity + `state_dir`; injects the additive budget via `runtime.configOverride` so `reloadLoop` doesn't clobber it each iteration), `resume()` (appends a `loop.resume` event, flips registry + worktree meta back to `running`).
- **`harness/index.ts`** — extracted the post-setup iteration loop into `driveLoop()` so `run()` and `resume()` share **identical** signal/stop/registry/journal behavior; `run()` starts at iteration 1, `resume()` at the computed iteration.
- **`cli/commands/resume.ts`** — arg parsing, prefix lookup, all RFC validations (refuse on completed / live-pid / missing journal|state|worktree / `--add-iterations 0` — all **before** any mutation), SIGINT/SIGTERM → AbortSignal.
- **`registry/derive.ts`** — `loop.resume` → status back to `running`, iteration/max updated.
- **`scratchpad.ts`** — renders `loop.resume` as a visible `--- resumed (was: <reason>, adding <N> iterations) ---` marker.

## Guarantee: never redo completed work
Adversarially reviewed against the real journal-recording code. The integration test runs a real loop to a `max_iterations` stop (iterations `[1,2,3]`), then resumes and asserts the loop runs exactly `[4,5]` and **never** re-runs `[1,2,3]`, that `loop.resume` is appended with correct fields, and that the additive budget is right.

## Tests / build
- `determineResumeIteration` (6, all stop-reason branches) · resume integration (2) · `dispatchResume` (11, happy path + every refusal) · `deriveRunRecords` resume lifecycle · scratchpad marker (3). Targeted suites **49 green**; `npm run build` clean.
- Pre-existing flaky root-level `test/integration/*` subprocess tests race under full-suite parallel load (pass in isolation, on a clean tree too) — untouched by this change.

## Not in scope / left for follow-up
- Topology-drift advisory warning (RFC §Topology Drift) — `reloadLoop` already tolerates drift; the advisory print is not implemented.
- Worktree reattach is wired (path/branch/meta reused, cleaned-up worktree refused) but not exercised by an end-to-end worktree integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)