### PR TITLE
fix(chains): count metareview EXIT/TAKEOVER verdicts as step success

### DIFF
--- a/packages/cli/src/chains/run.ts
+++ b/packages/cli/src/chains/run.ts
@@ -286,7 +286,13 @@ function chainStepSuccess(stopReason: string): boolean {
   return (
     stopReason === "max_iterations" ||
     stopReason === "completion_event" ||
-    stopReason === "completion_promise"
+    stopReason === "completion_promise" ||
+    // The metareview's EXIT and TAKEOVER verdicts terminate the loop via
+    // completeLoop() (see harness index.ts) — they are successful completions
+    // ("output already sufficient" / "solved directly"), not failures. Without
+    // these, a step the meta-reviewer approves stopping wrongly fails the chain.
+    stopReason === "verdict_exit" ||
+    stopReason === "verdict_takeover"
   );
 }
 


### PR DESCRIPTION
## Problem

When running a chain (`autoloop chain run`), any step the **metareview** approved
stopping was recorded as a **failure** and halted the whole chain. In practice this
fired constantly on already-green steps (e.g. an `autotest` step over a passing suite),
because the metareview prompt *defaults to EXIT*.

## Root cause

The harness terminates a loop on the metareview's `EXIT` / `TAKEOVER` verdicts via
`completeLoop()` — i.e. they are **successful completions**, not failures:

```ts
// packages/harness/src/index.ts
if (verdict.verdict === "EXIT")     return completeLoop(reviewed, iteration, "verdict_exit");
if (verdict.verdict === "TAKEOVER") return completeLoop(reviewed, iteration, "verdict_takeover");
```

But the chain runner's `chainStepSuccess()` only accepted
`max_iterations | completion_event | completion_promise`, so `verdict_exit` /
`verdict_takeover` were classified as step failures, stopping the chain.

## Fix

Add `verdict_exit` and `verdict_takeover` to the chain-step success set in
`packages/cli/src/chains/run.ts`.

## Testing

- `npm run build` — clean.
- `vitest run packages/cli` — **282 passed / 36 files**, no regressions.