### PR TITLE
fix(plugin): add marketplace manifest so the repo is installable

### DIFF
--- a/.agents/skills/autoloop-acp/SKILL.md
+++ b/.agents/skills/autoloop-acp/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoloop-acp
 description: Drive autoloop over the Agent Client Protocol (ACP) — connect an external editor, harness, or agent to `autoloop acp` over stdio, send prompts/slash commands that map to autoloop verbs, and stream loop runs as tool calls. Use when wiring up or operating an ACP connection to autoloop from another system.
-argument-hint: [connect|run|<slash-command>] [args...]
+argument-hint: "[connect|run|<slash-command>] [args...]"
 ---
 
 # Autoloop over ACP

--- a/.agents/skills/autoloop/SKILL.md
+++ b/.agents/skills/autoloop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoloop
 description: Run and operate autoloops — start runs, monitor progress, inject guidance, manage worktrees, inspect artifacts, and clean up. Use when the user asks to run an autoloop, check loop status, merge/clean worktrees, or operate on runs.
-argument-hint: [run|status|guide|merge|clean|inspect] [args...]
+argument-hint: "[run|status|guide|merge|clean|inspect] [args...]"
 ---
 
 # Autoloop Operations

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,5 @@
+{
+  "name": "autoloop",
+  "owner": { "name": "mikeyobrien" },
+  "plugins": [{ "name": "autoloop", "source": "./plugins/autoloop" }]
+}

--- a/.claude/skills/autoloop
+++ b/.claude/skills/autoloop
@@ -1,0 +1,1 @@
+../../.agents/skills/autoloop

--- a/.claude/skills/autoloop-acp
+++ b/.claude/skills/autoloop-acp
@@ -1,0 +1,1 @@
+../../.agents/skills/autoloop-acp

--- a/docs/getting-started/claude-code-onboarding.md
+++ b/docs/getting-started/claude-code-onboarding.md
@@ -1,0 +1,153 @@
+# Claude Code Onboarding
+
+Claude Code is Anthropic's agentic coding tool that runs in your terminal. You give
+it a task in plain language and it reads your code, plans an approach, edits files,
+runs commands, and reports back — pausing to ask before it does anything risky. This
+guide takes you from zero to a productive first session.
+
+> Claude Code evolves quickly. Where this guide would otherwise hardcode versions,
+> prices, or model names, it points you at the official docs instead so you always
+> get current information: <https://docs.claude.com/en/docs/claude-code>.
+
+## Prerequisites
+
+- A terminal you're comfortable working in.
+- [Node.js](https://nodejs.org) (a current LTS release) and `npm`.
+- `git` installed, and ideally a git repository to work in — Claude Code is most
+  useful inside a project under version control.
+- A Claude account (Pro/Max) or an Anthropic API account for authentication.
+
+Claude Code runs on macOS, Linux, and Windows (via WSL). Check the official docs for
+the current list of supported platforms and exact version requirements.
+
+## Install
+
+Install the CLI globally with npm:
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+Verify the install:
+
+```bash
+claude --version
+```
+
+If the command isn't found, make sure your npm global `bin` directory is on your
+`PATH`.
+
+## Authenticate / first launch
+
+From inside a project directory, start Claude Code:
+
+```bash
+cd your-project
+claude
+```
+
+The first time you launch, Claude Code walks you through authentication. You can sign
+in with your Claude account, or authenticate with an Anthropic API key — follow the
+on-screen prompts. Once authenticated, you land at an interactive prompt where you can
+start typing requests.
+
+## Your first session
+
+Working with Claude Code is a conversation loop:
+
+1. **Prompt** — describe what you want in plain language, for example
+   *"Add input validation to the signup form and write a test for it."*
+2. **Plan** — Claude inspects the relevant files and figures out an approach. For
+   larger tasks it may outline the steps first.
+3. **Act** — Claude edits files and runs commands to carry out the work.
+4. **Review** — Claude summarizes what it changed. You read the diff, run the code,
+   and either accept it or ask for adjustments.
+
+You stay in control the whole time: keep the requests small, review each change, and
+iterate. Treat it like pairing with a fast teammate, not a vending machine.
+
+## Essential slash commands
+
+Inside a session, commands that start with `/` control Claude Code itself rather than
+sending a prompt. A few you'll use constantly:
+
+- `/help` — list available commands and get usage help.
+- `/clear` — clear the current conversation context and start fresh. Use this between
+  unrelated tasks so old context doesn't leak in.
+- `/init` — scan the project and generate a starter `CLAUDE.md` (see below).
+- `/model` — view or switch the model Claude Code is using.
+
+Type `/` at the prompt to see the full, current list — the available commands grow
+over time, so `/help` is the source of truth.
+
+## Permissions & safety
+
+Claude Code asks for your approval before doing things that are hard to undo —
+editing files, running shell commands, or making network requests. When it proposes an
+action you can allow it once, allow that kind of action for the rest of the session,
+or decline.
+
+There are different permission modes that trade convenience for caution (from
+prompting on every action to running more autonomously). Start conservative while you
+learn what Claude does, and loosen permissions only once you trust the workflow. See
+the official docs for the current modes and how to configure them.
+
+## CLAUDE.md — project memory
+
+`CLAUDE.md` is a file Claude Code reads automatically and treats as standing
+instructions for the project. Put durable context there: how to build and test,
+coding conventions, directories to avoid, project-specific gotchas. Anything you'd
+otherwise re-explain in every session belongs in `CLAUDE.md`.
+
+Generate a first draft with the `/init` command, then edit it by hand. Keep it
+concise and high-signal — it's loaded into context every session, so treat it like a
+README for your collaborator rather than an exhaustive manual.
+
+## Extending Claude Code
+
+Two ways to give Claude Code more capabilities, both worth knowing about early but
+not required to get started:
+
+- **MCP servers** — the Model Context Protocol lets Claude Code connect to external
+  tools and data sources (issue trackers, databases, browsers, internal APIs).
+  Configure servers and Claude can call their tools mid-task.
+- **Skills & subagents** — reusable, packaged workflows and specialized agents you can
+  invoke for specific kinds of work, keeping the main conversation focused.
+
+Both are configurable per project. Reach for them once the basics feel natural; see
+the official docs for setup details.
+
+## Tips for good results
+
+- **Be specific.** "Fix the bug" is weak; "the signup form accepts empty emails — add
+  validation and a test that an empty email is rejected" gives Claude a verifiable
+  goal.
+- **Work in small steps.** Smaller tasks are easier to review and correct than one
+  giant request.
+- **Keep a clean context.** Use `/clear` when you switch tasks so stale context
+  doesn't bias the work.
+- **Let it verify.** Ask Claude to run tests or the app and confirm the change works,
+  rather than trusting that it does.
+- **Capture conventions in `CLAUDE.md`** so you stop repeating yourself.
+- **Review the diff.** You are the final check — read what changed before you commit.
+
+## Troubleshooting
+
+- **`claude: command not found`** — the npm global bin directory isn't on your
+  `PATH`. Run `npm config get prefix` and add its `bin` subdirectory to `PATH`.
+- **Authentication problems** — re-run the login flow; check `/help` for the auth
+  command, and confirm your account or API key is active.
+- **Claude lost track of the task** — the context may be cluttered. Use `/clear` and
+  restate the goal concisely.
+- **It keeps asking for permission** — that's by design. If a workflow is safe and
+  repetitive, adjust the permission mode (see the docs) rather than disabling all
+  safeguards.
+- **Unexpected or wrong edits** — review the diff and ask Claude to revise; with git
+  you can always discard changes and try a smaller prompt.
+
+## Where to go next
+
+- Official documentation: <https://docs.claude.com/en/docs/claude-code>
+- Run `/help` inside any session for the current command list.
+- Once you're comfortable driving Claude Code by hand, explore **autoloop** in this
+  repository for orchestrating multi-iteration agent runs on top of it.

--- a/plugins/autoloop/.claude-plugin/plugin.json
+++ b/plugins/autoloop/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "name": "autoloop",
   "version": "0.8.0",
   "description": "Run and operate autoloops — start runs, monitor progress, inject guidance, manage worktrees, inspect artifacts, and clean up.",
-  "homepage": "https://github.com/mikeyobrien/autoloop-ts",
-  "repository": "https://github.com/mikeyobrien/autoloop-ts",
+  "homepage": "https://github.com/mikeyobrien/autoloop",
+  "repository": "https://github.com/mikeyobrien/autoloop",
   "license": "MIT",
   "keywords": ["autoloop", "ai-agents", "autonomous", "coding"]
 }

--- a/plugins/autoloop/skills/autoloop-acp/SKILL.md
+++ b/plugins/autoloop/skills/autoloop-acp/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoloop-acp
 description: Drive autoloop over the Agent Client Protocol (ACP) — connect an external editor, harness, or agent to `autoloop acp` over stdio, send prompts/slash commands that map to autoloop verbs, and stream loop runs as tool calls. Use when wiring up or operating an ACP connection to autoloop from another system.
-argument-hint: [connect|run|<slash-command>] [args...]
+argument-hint: "[connect|run|<slash-command>] [args...]"
 ---
 
 # Autoloop over ACP

--- a/plugins/autoloop/skills/autoloop/SKILL.md
+++ b/plugins/autoloop/skills/autoloop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoloop
 description: Run and operate autoloops — start runs, monitor progress, inject guidance, manage worktrees, inspect artifacts, and clean up. Use when the user asks to run an autoloop, check loop status, merge/clean worktrees, or operate on runs.
-argument-hint: [run|status|guide|merge|clean|inspect] [args...]
+argument-hint: "[run|status|guide|merge|clean|inspect] [args...]"
 ---
 
 # Autoloop Operations


### PR DESCRIPTION
## Problem

Two install paths into this repo were broken:

1. **`claude plugin marketplace add mikeyobrien/autoloop`** failed — the repo shipped only `plugins/autoloop/.claude-plugin/plugin.json` (the single-plugin manifest), but the CLI's `marketplace add` reads a **root** `.claude-plugin/marketplace.json` catalog, which didn't exist.
2. **`npx skills add mikeyobrien/autoloop`** reported "No skills found" — the `argument-hint` frontmatter value started with `[`, so YAML parsed it as a malformed flow sequence, frontmatter parsing threw, and both skills were silently dropped.

Separately, `plugin.json` pointed `homepage`/`repository` at the non-existent `github.com/mikeyobrien/autoloop-ts`.

## Changes

- Add root `.claude-plugin/marketplace.json` pointing at `./plugins/autoloop`.
- Fix `plugin.json` `homepage`/`repository` → `github.com/mikeyobrien/autoloop`.
- Quote `argument-hint` in all SKILL.md copies (`.agents/skills` + `plugins/autoloop/skills`) so `npx skills` can parse the frontmatter.
- Move the distributable skill source `.claude/skills` → `.agents/skills` so `npx skills` installs into each agent's own dir rather than the source doubling as the repo's own consumed skills.
- Symlink `.claude/skills/{autoloop,autoloop-acp}` → `.agents/skills/...` (see tradeoff below).

## Tradeoff: skill source location

Moving skills out of `.claude/skills/` would stop Claude Code from **auto-loading them as project skills** for anyone working *in* this repo — they'd become distribution-only via `npx skills`.

To keep both behaviors, `.claude/skills/{autoloop,autoloop-acp}` are now **relative symlinks** into `.agents/skills/`:
- `.agents/skills/` stays the canonical, agent-neutral distribution source for `npx skills`.
- Claude Code follows symlinked skills, so they still auto-load as project skills here.
- The `skills` CLI dedupes by name, so discovery still reports each skill once (verified).

## Verification

Plugin install (from a local clone):
```
claude plugin marketplace add <path>    # ✔ Successfully added marketplace: autoloop
claude plugin install autoloop@autoloop # ✔ installed & enabled, v0.8.0
```

Skills install:
```
npx skills add <repo> -l                # ✔ Found 2 skills (autoloop, autoloop-acp)
npx skills add <repo> -s '*' -a '*'     # ✔ Installed 2 skills into .claude/skills/
```

> Note: verified against the working tree / a local clone. The GitHub-hosted `marketplace add` and `npx skills add mikeyobrien/autoloop` will reflect these once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWrXTsmdKSTFKcLxzJDtwd