### PR TITLE
feat(hooks): lifecycle hooks engine with suspend/resume and I/O mutation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -383,9 +383,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -398,9 +395,6 @@
       "integrity": "sha512-uu8MnPwFBc9ayFg5c94aHaqJVLS51oHNVxHwud4nK27GliP5WoME3F7pmm1N/Jyy2ry2E2CLNnsAm5l3zemfYA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -415,9 +409,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -430,9 +421,6 @@
       "integrity": "sha512-ofKxyp/N8+LLSrClt+dJo0laCHDzmBgmN8+Q+zabJ54Jqc1KXee68UsziE7kLCqGbOSY7rsIK9d22T1uQyZkUw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -6493,7 +6481,7 @@
         "@mobrienv/autoloop-issue-sync-core": "*"
       },
       "bin": {
-        "gh-sync": "dist/cli.js"
+        "autoloop-gh-sync": "dist/cli.js"
       },
       "engines": {
         "node": ">=18"
@@ -6517,6 +6505,9 @@
       "name": "@mobrienv/autoloop-issue-sync-core",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@mobrienv/autoloop-core": "*"
+      },
       "engines": {
         "node": ">=18"
       }
@@ -6549,7 +6540,8 @@
         "@mobrienv/autoloop-issue-sync-core": "*"
       },
       "bin": {
-        "linear-sync": "dist/cli.js"
+        "autoloop-linear-open": "bin/autoloop-linear-open",
+        "autoloop-linear-sync": "dist/cli.js"
       },
       "engines": {
         "node": ">=18"

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -1,0 +1,210 @@
+import * as config from "@mobrienv/autoloop-core/config";
+import {
+  HOOK_PHASES,
+  type HookPhase,
+  type HookSpec,
+  isHookPhase,
+  validateHookSpecs,
+} from "@mobrienv/autoloop-core/hooks-schema";
+import {
+  clearResumeRequest,
+  clearSuspendState,
+  readSuspendState,
+} from "@mobrienv/autoloop-harness/suspend-state";
+import { failUnknown } from "../cli/fail.js";
+
+function resolveRuntimeProjectDir(): string {
+  return process.env.AUTOLOOP_PROJECT_DIR || ".";
+}
+
+function resolveRuntimeStateDir(projectDir: string): string {
+  return process.env.AUTOLOOP_STATE_DIR || config.stateDirPath(projectDir);
+}
+
+function resolveSpecs(projectDir: string): HookSpec[] {
+  const presetFile = process.env.AUTOLOOP_PRESET_FILE;
+  return presetFile
+    ? config.loadHookSpecsFromFile(presetFile)
+    : config.loadHookSpecs(projectDir);
+}
+
+function resolveRawToml(projectDir: string): Record<string, unknown> {
+  const presetFile = process.env.AUTOLOOP_PRESET_FILE;
+  return presetFile
+    ? config.loadRawProjectTomlFromFile(presetFile)
+    : config.loadRawProjectToml(projectDir);
+}
+
+export function dispatchHooks(args: string[]): boolean {
+  const sub = args[0] ?? "";
+  const json = args.includes("--json");
+  const rest = args.slice(1).filter((a) => a !== "--json");
+
+  switch (sub) {
+    case "list": {
+      const projectDir = rest[0] ?? resolveRuntimeProjectDir();
+      return runList(projectDir, json);
+    }
+    case "show": {
+      const projectDir = rest[1] ?? resolveRuntimeProjectDir();
+      return runShow(rest[0], projectDir, json);
+    }
+    case "validate": {
+      const projectDir = rest[0] ?? resolveRuntimeProjectDir();
+      return runValidate(projectDir, json);
+    }
+    case "clear-suspend": {
+      const projectDir = rest[0] ?? resolveRuntimeProjectDir();
+      return runClearSuspend(projectDir, json);
+    }
+    default:
+      if (sub === "" || sub === "--help" || sub === "-h") {
+        printHooksUsage();
+        return true;
+      }
+      failUnknown({
+        kind: "hooks subcommand",
+        input: sub,
+        candidates: ["list", "show", "validate", "clear-suspend"],
+        helpCommand: "autoloop hooks --help",
+      });
+      return true;
+  }
+}
+
+function runList(projectDir: string, json: boolean): boolean {
+  const specs = resolveSpecs(projectDir);
+  if (json) {
+    console.log(JSON.stringify({ hooks: specs }, null, 2));
+    return true;
+  }
+  if (specs.length === 0) {
+    console.log("No hooks configured.");
+    return true;
+  }
+  console.log("Configured hooks:");
+  for (const phase of HOOK_PHASES) {
+    const forPhase = specs.filter((s) => s.phase === phase);
+    if (forPhase.length === 0) continue;
+    console.log(`  ${phase}:`);
+    for (const spec of forPhase) {
+      console.log(
+        `    - command=${JSON.stringify(spec.command)} on_error=${spec.onError} mutate=${spec.mutate} source=${spec.source}`,
+      );
+    }
+  }
+  return true;
+}
+
+function runShow(
+  phaseArg: string | undefined,
+  projectDir: string,
+  json: boolean,
+): boolean {
+  if (!phaseArg || phaseArg === "--help") {
+    console.log(`Usage: autoloop hooks show <phase> [project-dir]`);
+    console.log(`Phases: ${HOOK_PHASES.join(", ")}`);
+    return true;
+  }
+  if (!isHookPhase(phaseArg)) {
+    console.log(
+      `error: unknown phase \`${phaseArg}\`; expected one of: ${HOOK_PHASES.join(", ")}`,
+    );
+    process.exitCode = 1;
+    return true;
+  }
+  const phase: HookPhase = phaseArg;
+  const specs = resolveSpecs(projectDir).filter((s) => s.phase === phase);
+  if (json) {
+    console.log(JSON.stringify({ phase, hooks: specs }, null, 2));
+    return true;
+  }
+  if (specs.length === 0) {
+    console.log(`No hooks configured for phase \`${phase}\`.`);
+    return true;
+  }
+  console.log(`Hooks for phase \`${phase}\`:`);
+  for (const spec of specs) {
+    console.log(`  command:  ${spec.command}`);
+    console.log(`  on_error: ${spec.onError}`);
+    console.log(`  mutate:   ${spec.mutate}`);
+    console.log(`  source:   ${spec.source}`);
+    console.log("");
+  }
+  return true;
+}
+
+function runValidate(projectDir: string, json: boolean): boolean {
+  const raw = resolveRawToml(projectDir);
+  const errors = validateHookSpecs(raw);
+  if (json) {
+    console.log(
+      JSON.stringify({ valid: errors.length === 0, errors }, null, 2),
+    );
+  } else if (errors.length === 0) {
+    console.log("Hooks config is valid.");
+  } else {
+    console.log(`Found ${errors.length} hook config error(s):`);
+    for (const err of errors) {
+      console.log(`  - ${err.message}`);
+    }
+  }
+  process.exitCode = errors.length === 0 ? 0 : 1;
+  return true;
+}
+
+function runClearSuspend(projectDir: string, json: boolean): boolean {
+  const stateDir = resolveRuntimeStateDir(projectDir);
+  const state = readSuspendState(stateDir);
+  const clearedSuspend = clearSuspendState(stateDir);
+  const clearedResumeRequest = clearResumeRequest(stateDir);
+
+  if (json) {
+    console.log(
+      JSON.stringify(
+        { clearedSuspend, clearedResumeRequest, previousState: state },
+        null,
+        2,
+      ),
+    );
+    return true;
+  }
+
+  if (!clearedSuspend && !clearedResumeRequest) {
+    console.log("No suspend state or resume-request signal to clear.");
+    return true;
+  }
+  if (clearedSuspend) {
+    console.log(
+      `Cleared suspend state (phase=${state?.phase ?? "unknown"}, reason=${state?.reason ?? "unknown"}).`,
+    );
+  }
+  if (clearedResumeRequest) {
+    console.log("Cleared resume-requested signal.");
+  }
+  return true;
+}
+
+export function printHooksUsage(): void {
+  console.log(
+    "Usage: autoloop hooks <list|show|validate|clear-suspend> [project-dir] [--json]",
+  );
+  console.log("");
+  console.log(
+    "Lifecycle hooks: phase-anchored commands run around iterations, runs, and emits.",
+  );
+  console.log("");
+  console.log("Subcommands:");
+  console.log("  list                    List all configured hooks by phase");
+  console.log("  show <phase>            Show hooks configured for one phase");
+  console.log(`                          (phases: ${HOOK_PHASES.join(", ")})`);
+  console.log(
+    "  validate                Validate [[hook]] entries; non-zero exit on error",
+  );
+  console.log(
+    "  clear-suspend           Clear suspend-state.json and resume-requested",
+  );
+  console.log("");
+  console.log("Flags:");
+  console.log("  --json                  Output machine-readable JSON");
+}

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -14,6 +14,7 @@ import { dispatchControl } from "./commands/control.js";
 import { dispatchDashboard } from "./commands/dashboard.js";
 import { dispatchDoctor } from "./commands/doctor.js";
 import { dispatchGuide } from "./commands/guide.js";
+import { dispatchHooks } from "./commands/hooks.js";
 import { dispatchInit } from "./commands/init.js";
 import { dispatchInspect } from "./commands/inspect.js";
 import { dispatchKanban } from "./commands/kanban.js";
@@ -157,6 +158,9 @@ async function dispatch(args: string[], argv: string[]): Promise<void> {
     case "guide":
       dispatchGuide(args.slice(1));
       return;
+    case "hooks":
+      dispatchHooks(args.slice(1));
+      return;
     case "control":
       dispatchControl(args.slice(1));
       return;
@@ -243,6 +247,7 @@ const CLI_COMMANDS = [
   "worktree",
   "config",
   "guide",
+  "hooks",
   "control",
   "dashboard",
   "kanban",

--- a/packages/cli/src/usage.ts
+++ b/packages/cli/src/usage.ts
@@ -40,6 +40,9 @@ export function printUsage(): void {
   console.log("  autoloop preset promote <source.toml> <name>");
   console.log("  autoloop worktree <list|show|diff|merge|clean> [args]");
   console.log("  autoloop config <show|set|unset|path> [args]");
+  console.log(
+    "  autoloop hooks <list|show|validate|clear-suspend> [project-dir] [--json]",
+  );
   console.log("  autoloop dashboard [--port <port>]");
   console.log("  autoloop kanban [--port <port>]");
   console.log("  autoloop acp [--project-dir <dir>]");

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,6 +39,10 @@
       "types": "./dist/config.d.ts",
       "default": "./dist/config.js"
     },
+    "./hooks-schema": {
+      "types": "./dist/hooks-schema.d.ts",
+      "default": "./dist/hooks-schema.js"
+    },
     "./agent-map": {
       "types": "./dist/agent-map.d.ts",
       "default": "./dist/agent-map.js"

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -20,6 +20,7 @@ import {
   stringifyValues,
 } from "@mobrienv/autoloop-core/config-schema";
 import { bundledPresetsRoot } from "./bundled-presets.js";
+import { type HookSpec, parseHookSpecs } from "./hooks-schema.js";
 
 export type {
   Config,
@@ -250,6 +251,45 @@ export function backendOverrideFromProject(
     override.timeout_ms = section.timeout_ms;
 
   return override;
+}
+
+/**
+ * Structured per-hook specs (legacy flat `[hooks]` keys + `[[hook]]`
+ * array-of-tables) read from raw TOML — the stringified `Config` pipeline
+ * collapses arrays to CSV and cannot represent per-hook records. Mirrors
+ * `backendOverrideFromProject`'s raw-read pattern. Directory-preset form.
+ */
+export function loadHookSpecs(projectDir: string): HookSpec[] {
+  const path = resolveConfigPath(projectDir);
+  if (!existsSync(path)) return [];
+  return parseHookSpecs(parseRawToml(readFileSync(path, "utf-8")));
+}
+
+/** Single-file (`.toml`) preset form of {@link loadHookSpecs}. */
+export function loadHookSpecsFromFile(file: string): HookSpec[] {
+  if (!existsSync(file)) return [];
+  return parseHookSpecs(parseRawToml(readFileSync(file, "utf-8")));
+}
+
+/**
+ * The raw (un-stringified) parsed TOML tree for a directory preset's project
+ * config, or `{}` when absent. Used by `autoloop hooks validate` to surface
+ * `[[hook]]` schema errors that the stringified `Config` pipeline can't see.
+ */
+export function loadRawProjectToml(
+  projectDir: string,
+): Record<string, unknown> {
+  const path = resolveConfigPath(projectDir);
+  if (!existsSync(path)) return {};
+  return parseRawToml(readFileSync(path, "utf-8"));
+}
+
+/** Single-file (`.toml`) preset form of {@link loadRawProjectToml}. */
+export function loadRawProjectTomlFromFile(
+  file: string,
+): Record<string, unknown> {
+  if (!existsSync(file)) return {};
+  return parseRawToml(readFileSync(file, "utf-8"));
 }
 
 export function projectHasConfig(projectDir: string): boolean {

--- a/packages/core/src/hooks-schema.ts
+++ b/packages/core/src/hooks-schema.ts
@@ -1,0 +1,238 @@
+// Lifecycle hooks engine: pure types + parsing for phase-anchored hooks and
+// durable suspend state. Everything here operates on plain data (raw parsed
+// TOML, in-memory records) — no fs, no process spawning. The fs-touching
+// pieces (spawning hook commands, writing suspend-state.json) live in
+// `@mobrienv/autoloop-harness`.
+
+/** Phase-anchored hook points. */
+export type HookPhase =
+  | "pre_run"
+  | "post_run"
+  | "pre_iteration"
+  | "post_iteration"
+  | "pre_emit"
+  | "post_emit";
+
+export const HOOK_PHASES: HookPhase[] = [
+  "pre_run",
+  "post_run",
+  "pre_iteration",
+  "post_iteration",
+  "pre_emit",
+  "post_emit",
+];
+
+/** Per-hook error policy: how a non-zero exit is routed. */
+export type HookOnError = "block" | "warn" | "suspend";
+
+export const HOOK_ON_ERRORS: HookOnError[] = ["block", "warn", "suspend"];
+
+/** What (if anything) a hook's stdout may mutate. */
+export type HookMutate = "none" | "prompt" | "event";
+
+export const HOOK_MUTATES: HookMutate[] = ["none", "prompt", "event"];
+
+export interface HookSpec {
+  phase: HookPhase;
+  command: string;
+  onError: HookOnError;
+  mutate: HookMutate;
+  /** Source of this spec, for `hooks show`/debugging: "legacy" or "hook[<i>]". */
+  source: string;
+}
+
+export interface HookSpecError {
+  index: number;
+  field: string;
+  value: unknown;
+  message: string;
+}
+
+const LEGACY_PHASE_KEYS: Record<string, HookPhase> = {
+  pre_run: "pre_run",
+  pre_iteration: "pre_iteration",
+  post_iteration: "post_iteration",
+  post_run: "post_run",
+};
+
+/**
+ * Parse hook specs from a raw (un-stringified) TOML tree: the legacy flat
+ * `[hooks]` keys plus the richer `[[hook]]` array-of-tables form. Order is
+ * legacy first (in fixed phase order), then `[[hook]]` entries in file order —
+ * both are preserved per-phase by `hooksForPhase`.
+ *
+ * `strict=true` (legacy `[hooks].strict`) upgrades a legacy `pre_run` hook's
+ * error policy to `block`, preserving the pre-existing "strict mode aborts on
+ * pre_run failure" behavior.
+ */
+export function parseHookSpecs(raw: Record<string, unknown>): HookSpec[] {
+  const specs: HookSpec[] = [];
+
+  const legacyHooks = asRecord(raw.hooks);
+  const strict = legacyHooks ? truthy(legacyHooks.strict) : false;
+  if (legacyHooks) {
+    for (const [key, phase] of Object.entries(LEGACY_PHASE_KEYS)) {
+      const command = legacyHooks[key];
+      if (typeof command === "string" && command.trim() !== "") {
+        specs.push({
+          phase,
+          command,
+          onError: strict && phase === "pre_run" ? "block" : "warn",
+          mutate: "none",
+          source: "legacy",
+        });
+      }
+    }
+  }
+
+  const hookTables = raw.hook;
+  if (Array.isArray(hookTables)) {
+    hookTables.forEach((entry, index) => {
+      const table = asRecord(entry);
+      if (!table) return;
+      const phase = table.phase;
+      const command = table.command;
+      if (typeof phase !== "string" || !isHookPhase(phase)) return;
+      if (typeof command !== "string" || command.trim() === "") return;
+      const onErrorRaw = table.on_error;
+      const mutateRaw = table.mutate;
+      specs.push({
+        phase,
+        command,
+        onError: isHookOnError(onErrorRaw) ? onErrorRaw : "warn",
+        mutate: isHookMutate(mutateRaw) ? mutateRaw : "none",
+        source: `hook[${index}]`,
+      });
+    });
+  }
+
+  return specs;
+}
+
+/** Specs for a single phase, in declaration order. */
+export function hooksForPhase(specs: HookSpec[], phase: HookPhase): HookSpec[] {
+  return specs.filter((s) => s.phase === phase);
+}
+
+export function isHookPhase(value: unknown): value is HookPhase {
+  return typeof value === "string" && (HOOK_PHASES as string[]).includes(value);
+}
+
+export function isHookOnError(value: unknown): value is HookOnError {
+  return (
+    typeof value === "string" && (HOOK_ON_ERRORS as string[]).includes(value)
+  );
+}
+
+export function isHookMutate(value: unknown): value is HookMutate {
+  return (
+    typeof value === "string" && (HOOK_MUTATES as string[]).includes(value)
+  );
+}
+
+/**
+ * Validate the raw `[[hook]]` array-of-tables entries, surfacing unknown
+ * phase/on_error/mutate values and missing commands as typed errors (used by
+ * `autoloop hooks validate`). Legacy flat keys are always valid by
+ * construction, so this only inspects `[[hook]]`.
+ */
+export function validateHookSpecs(
+  raw: Record<string, unknown>,
+): HookSpecError[] {
+  const errors: HookSpecError[] = [];
+  const hookTables = raw.hook;
+  if (!Array.isArray(hookTables)) return errors;
+
+  hookTables.forEach((entry, index) => {
+    const table = asRecord(entry);
+    if (!table) {
+      errors.push({
+        index,
+        field: "hook",
+        value: entry,
+        message: `[[hook]] entry ${index} must be a table`,
+      });
+      return;
+    }
+    if (!isHookPhase(table.phase)) {
+      errors.push({
+        index,
+        field: "phase",
+        value: table.phase,
+        message: `[[hook]] entry ${index}: phase must be one of ${HOOK_PHASES.join(", ")} (got ${JSON.stringify(table.phase)})`,
+      });
+    }
+    if (typeof table.command !== "string" || table.command.trim() === "") {
+      errors.push({
+        index,
+        field: "command",
+        value: table.command,
+        message: `[[hook]] entry ${index}: command must be a non-empty string`,
+      });
+    }
+    if (table.on_error !== undefined && !isHookOnError(table.on_error)) {
+      errors.push({
+        index,
+        field: "on_error",
+        value: table.on_error,
+        message: `[[hook]] entry ${index}: on_error must be one of ${HOOK_ON_ERRORS.join(", ")} (got ${JSON.stringify(table.on_error)})`,
+      });
+    }
+    if (table.mutate !== undefined && !isHookMutate(table.mutate)) {
+      errors.push({
+        index,
+        field: "mutate",
+        value: table.mutate,
+        message: `[[hook]] entry ${index}: mutate must be one of ${HOOK_MUTATES.join(", ")} (got ${JSON.stringify(table.mutate)})`,
+      });
+    }
+  });
+
+  return errors;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function truthy(value: unknown): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") return value === "true";
+  return false;
+}
+
+// --- Durable suspend state -------------------------------------------------
+
+export const SUSPEND_STATE_SCHEMA_VERSION = 1;
+
+export interface SuspendState {
+  schemaVersion: number;
+  runId: string;
+  /** Phase the suspending hook ran at. */
+  phase: HookPhase;
+  /** Iteration number in flight when the suspend was requested (0 for pre_run/post_run). */
+  iteration: number;
+  reason: string;
+  hookCommand: string;
+  createdAt: string;
+  /** Iteration to resume at once `resume-requested` is observed. */
+  resumeIteration: number;
+}
+
+export function isSuspendState(value: unknown): value is SuspendState {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.schemaVersion === "number" &&
+    typeof v.runId === "string" &&
+    isHookPhase(v.phase) &&
+    typeof v.iteration === "number" &&
+    typeof v.reason === "string" &&
+    typeof v.hookCommand === "string" &&
+    typeof v.createdAt === "string" &&
+    typeof v.resumeIteration === "number"
+  );
+}

--- a/packages/core/test/hooks-schema.test.ts
+++ b/packages/core/test/hooks-schema.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+import {
+  hooksForPhase,
+  isSuspendState,
+  parseHookSpecs,
+  SUSPEND_STATE_SCHEMA_VERSION,
+  validateHookSpecs,
+} from "../src/hooks-schema.js";
+
+describe("hooks-schema: parseHookSpecs", () => {
+  it("parses legacy flat [hooks] keys as warn/none specs", () => {
+    const raw = {
+      hooks: {
+        pre_run: "echo pre",
+        pre_iteration: "echo pre-iter",
+        post_iteration: "echo post-iter",
+        post_run: "echo post",
+      },
+    };
+    const specs = parseHookSpecs(raw);
+    expect(specs).toHaveLength(4);
+    for (const spec of specs) {
+      expect(spec.onError).toBe("warn");
+      expect(spec.mutate).toBe("none");
+      expect(spec.source).toBe("legacy");
+    }
+    expect(hooksForPhase(specs, "pre_run")[0].command).toBe("echo pre");
+  });
+
+  it("upgrades legacy pre_run to block when strict=true", () => {
+    const raw = { hooks: { pre_run: "exit 1", strict: "true" } };
+    const specs = parseHookSpecs(raw);
+    expect(specs).toHaveLength(1);
+    expect(specs[0].onError).toBe("block");
+  });
+
+  it("strict=true does not affect other legacy phases", () => {
+    const raw = {
+      hooks: { pre_iteration: "echo hi", strict: true },
+    };
+    const specs = parseHookSpecs(raw);
+    expect(specs[0].onError).toBe("warn");
+  });
+
+  it("parses [[hook]] array-of-tables entries with defaults", () => {
+    const raw = {
+      hook: [{ phase: "pre_iteration", command: "echo hi" }],
+    };
+    const specs = parseHookSpecs(raw);
+    expect(specs).toHaveLength(1);
+    expect(specs[0]).toMatchObject({
+      phase: "pre_iteration",
+      command: "echo hi",
+      onError: "warn",
+      mutate: "none",
+      source: "hook[0]",
+    });
+  });
+
+  it("parses explicit on_error and mutate on [[hook]] entries", () => {
+    const raw = {
+      hook: [
+        {
+          phase: "pre_iteration",
+          command: "echo hi",
+          on_error: "suspend",
+          mutate: "prompt",
+        },
+      ],
+    };
+    const specs = parseHookSpecs(raw);
+    expect(specs[0].onError).toBe("suspend");
+    expect(specs[0].mutate).toBe("prompt");
+  });
+
+  it("merges legacy + [[hook]] entries, legacy first, in phase order", () => {
+    const raw = {
+      hooks: { pre_run: "echo legacy-pre" },
+      hook: [{ phase: "pre_run", command: "echo extra-pre" }],
+    };
+    const specs = parseHookSpecs(raw);
+    const preRun = hooksForPhase(specs, "pre_run");
+    expect(preRun.map((s) => s.command)).toEqual([
+      "echo legacy-pre",
+      "echo extra-pre",
+    ]);
+  });
+
+  it("ignores [[hook]] entries with unknown phase or empty command", () => {
+    const raw = {
+      hook: [
+        { phase: "bogus_phase", command: "echo hi" },
+        { phase: "pre_run", command: "" },
+        { phase: "pre_run" },
+      ],
+    };
+    expect(parseHookSpecs(raw)).toHaveLength(0);
+  });
+
+  it("returns no specs for an empty/absent config", () => {
+    expect(parseHookSpecs({})).toHaveLength(0);
+  });
+
+  it("hooksForPhase filters and preserves order", () => {
+    const raw = {
+      hook: [
+        { phase: "pre_iteration", command: "a" },
+        { phase: "post_iteration", command: "b" },
+        { phase: "pre_iteration", command: "c" },
+      ],
+    };
+    const specs = parseHookSpecs(raw);
+    expect(hooksForPhase(specs, "pre_iteration").map((s) => s.command)).toEqual(
+      ["a", "c"],
+    );
+  });
+});
+
+describe("hooks-schema: validateHookSpecs", () => {
+  it("returns no errors for a well-formed [[hook]] table", () => {
+    const raw = {
+      hook: [
+        {
+          phase: "pre_emit",
+          command: "echo hi",
+          on_error: "block",
+          mutate: "event",
+        },
+      ],
+    };
+    expect(validateHookSpecs(raw)).toHaveLength(0);
+  });
+
+  it("flags an unknown phase", () => {
+    const raw = { hook: [{ phase: "bogus", command: "echo hi" }] };
+    const errors = validateHookSpecs(raw);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].field).toBe("phase");
+  });
+
+  it("flags a missing/empty command", () => {
+    const raw = { hook: [{ phase: "pre_run" }] };
+    const errors = validateHookSpecs(raw);
+    expect(errors.some((e) => e.field === "command")).toBe(true);
+  });
+
+  it("flags an unknown on_error policy", () => {
+    const raw = {
+      hook: [{ phase: "pre_run", command: "echo", on_error: "yeet" }],
+    };
+    const errors = validateHookSpecs(raw);
+    expect(errors.some((e) => e.field === "on_error")).toBe(true);
+  });
+
+  it("flags an unknown mutate value", () => {
+    const raw = {
+      hook: [{ phase: "pre_run", command: "echo", mutate: "yeet" }],
+    };
+    const errors = validateHookSpecs(raw);
+    expect(errors.some((e) => e.field === "mutate")).toBe(true);
+  });
+
+  it("is a no-op when there is no [[hook]] table", () => {
+    expect(validateHookSpecs({ hooks: { pre_run: "echo" } })).toHaveLength(0);
+  });
+});
+
+describe("hooks-schema: suspend state", () => {
+  it("SUSPEND_STATE_SCHEMA_VERSION is 1", () => {
+    expect(SUSPEND_STATE_SCHEMA_VERSION).toBe(1);
+  });
+
+  it("isSuspendState validates a well-formed record", () => {
+    const state = {
+      schemaVersion: 1,
+      runId: "run-1",
+      phase: "pre_iteration" as const,
+      iteration: 3,
+      reason: "needs approval",
+      hookCommand: "echo hi",
+      createdAt: new Date().toISOString(),
+      resumeIteration: 3,
+    };
+    expect(isSuspendState(state)).toBe(true);
+  });
+
+  it("isSuspendState rejects malformed/partial records", () => {
+    expect(isSuspendState(null)).toBe(false);
+    expect(isSuspendState({})).toBe(false);
+    expect(
+      isSuspendState({
+        schemaVersion: 1,
+        runId: "r",
+        phase: "not_a_phase",
+        iteration: 1,
+        reason: "x",
+        hookCommand: "y",
+        createdAt: "z",
+        resumeIteration: 1,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -135,6 +135,14 @@
       "types": "./dist/registry-bridge.d.ts",
       "default": "./dist/registry-bridge.js"
     },
+    "./hooks": {
+      "types": "./dist/hooks.d.ts",
+      "default": "./dist/hooks.js"
+    },
+    "./suspend-state": {
+      "types": "./dist/suspend-state.d.ts",
+      "default": "./dist/suspend-state.js"
+    },
     "./control": {
       "types": "./dist/control/index.d.ts",
       "default": "./dist/control/index.js"

--- a/packages/harness/src/config-helpers.ts
+++ b/packages/harness/src/config-helpers.ts
@@ -20,6 +20,7 @@ import {
 } from "@mobrienv/autoloop-core";
 import { loadAgentMap } from "@mobrienv/autoloop-core/agent-map";
 import * as config from "@mobrienv/autoloop-core/config";
+import type { HookSpec } from "@mobrienv/autoloop-core/hooks-schema";
 import {
   presetCategory,
   resolveIsolationMode,
@@ -665,6 +666,12 @@ export function reloadLoop(loop: LoopContext): LoopContext {
         templateVars,
       ),
       strict: config.get(cfg, "hooks.strict", "false") === "true",
+      specs: expandHookSpecCommands(
+        presetFile
+          ? config.loadHookSpecsFromFile(presetFile)
+          : config.loadHookSpecs(pd),
+        templateVars,
+      ),
     },
     memory: {
       budgetChars: config.getInt(cfg, "memory.prompt_budget_chars", 8000),
@@ -881,6 +888,18 @@ export function applyRuntimeModeOverrides(loop: LoopContext): LoopContext {
       ),
     },
   };
+}
+
+/** Apply the same template-placeholder expansion legacy hook fields get to
+ * every structured hook spec's command (e.g. `{{PRESET_DIR}}`, `{{TOOL_PATH}}`). */
+function expandHookSpecCommands(
+  specs: HookSpec[],
+  templateVars: Record<string, string>,
+): HookSpec[] {
+  return specs.map((spec) => ({
+    ...spec,
+    command: expandTemplatePlaceholders(spec.command, templateVars),
+  }));
 }
 
 export function initStore(loop: LoopContext): LoopContext {

--- a/packages/harness/src/emit.ts
+++ b/packages/harness/src/emit.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import {
@@ -7,6 +8,7 @@ import {
   splitCsv,
 } from "@mobrienv/autoloop-core";
 import * as config from "@mobrienv/autoloop-core/config";
+import type { HookPhase, HookSpec } from "@mobrienv/autoloop-core/hooks-schema";
 import {
   appendAgentEvent,
   appendEvent,
@@ -19,6 +21,9 @@ import {
   resolveFile,
 } from "@mobrienv/autoloop-core/tasks";
 import * as topology from "@mobrienv/autoloop-core/topology";
+import { printHookOutput } from "./display.js";
+import { parseMutationDirective } from "./hooks.js";
+import { writeSuspendState } from "./suspend-state.js";
 
 const COORDINATION_TOPICS = new Set([
   "issue.discovered",
@@ -90,7 +95,152 @@ export interface EmitResult {
   error?: string;
 }
 
+interface EmitHookOutcome {
+  blocked: boolean;
+  blockedMessage?: string;
+  mutatedTopic?: string;
+  mutatedPayload?: string;
+}
+
+/**
+ * Run pre_emit/post_emit hooks. `emit()` runs out-of-process (the agent
+ * invokes the `autoloops emit` tool script, which spawns a fresh CLI process
+ * calling `harness.emit()`) so there is no live `LoopContext` to drive
+ * `runPhaseHooks` through — this is a disk/config-driven parallel
+ * implementation reading `HookSpec`s straight from the project's raw TOML.
+ *
+ * `on_error = "suspend"` is honored as `block` here (see design note: the
+ * emit subprocess cannot itself block the harness's iteration loop) but ALSO
+ * writes durable suspend state, so the harness detects it at the next
+ * iteration boundary (`runIteration` start) and halts there instead of
+ * silently continuing.
+ */
+function runEmitPhaseHooks(
+  projectDir: string,
+  journalFile: string,
+  phase: HookPhase,
+  runId: string,
+  iteration: string,
+  topic: string,
+  payload: string,
+): EmitHookOutcome {
+  const specs: HookSpec[] = config
+    .loadHookSpecs(projectDir)
+    .filter((s) => s.phase === phase);
+  const outcome: EmitHookOutcome = { blocked: false };
+
+  for (const spec of specs) {
+    if (!spec.command) continue;
+    const env: Record<string, string | undefined> = {
+      ...process.env,
+      AUTOLOOP_PROJECT_DIR: projectDir,
+      AUTOLOOP_RUN_ID: runId,
+      AUTOLOOP_ITERATION: iteration,
+      AUTOLOOP_EMIT_TOPIC: outcome.mutatedTopic ?? topic,
+      AUTOLOOP_EMIT_PAYLOAD: outcome.mutatedPayload ?? payload,
+    };
+    const result = spawnSync(spec.command, {
+      shell: true,
+      cwd: projectDir,
+      encoding: "utf-8",
+      env,
+    });
+    const combined =
+      (result.stdout ?? "") +
+      (result.stderr ? `\n[stderr]\n${result.stderr}` : "");
+    const status = result.status ?? -1;
+    const failed = status !== 0 || Boolean(result.error);
+
+    appendEvent(
+      journalFile,
+      runId,
+      iteration,
+      "hook.output",
+      `"hook": ${JSON.stringify(phase)}, "exit_code": ${status}, "output": ${JSON.stringify(combined.trim())}`,
+    );
+    printHookOutput(phase, status, combined.trim(), failed);
+
+    if (!failed && spec.mutate === "event") {
+      const directive = parseMutationDirective(
+        combined.split("\n[stderr]\n")[0],
+        "event",
+      );
+      if (directive) {
+        if (directive.topic !== undefined)
+          outcome.mutatedTopic = directive.topic;
+        if (directive.payload !== undefined)
+          outcome.mutatedPayload = directive.payload;
+      }
+    }
+
+    if (!failed) continue;
+
+    const detail =
+      (result.stderr ?? "").trim() || (result.stdout ?? "").trim() || "";
+    const msg = `hook ${phase} failed (exit ${status}): ${detail.split("\n")[0] ?? ""}`;
+
+    if (spec.onError === "warn") continue;
+
+    outcome.blocked = true;
+    outcome.blockedMessage = msg;
+    if (spec.onError === "suspend") {
+      const stateDir =
+        process.env.AUTOLOOP_STATE_DIR || config.stateDirPath(projectDir);
+      writeSuspendState(
+        stateDir,
+        {
+          runId,
+          phase,
+          iteration: Number(iteration) || 0,
+          reason: msg,
+          hookCommand: spec.command,
+          createdAt: new Date().toISOString(),
+          resumeIteration: Number(iteration) || 0,
+        },
+        journalFile,
+      );
+    }
+    return outcome;
+  }
+
+  return outcome;
+}
+
 export function emit(
+  projectDir: string,
+  topic: string,
+  payload: string,
+): EmitResult {
+  const result = emitCore(projectDir, topic, payload);
+  if (!result.ok) return result;
+
+  // post_emit hooks run after a successful accept. They cannot un-journal the
+  // already-accepted event, but a `block` policy still surfaces as a failed
+  // result (visible to the agent/CLI caller) and a `suspend` policy writes
+  // durable suspend state for the harness to catch at the next iteration
+  // boundary.
+  const journalFile = resolveEmitJournalFile(projectDir);
+  const validation = emitValidationContext(projectDir, journalFile);
+  const postEmit = runEmitPhaseHooks(
+    projectDir,
+    journalFile,
+    "post_emit",
+    validation.runId,
+    validation.iteration,
+    result.topic ?? topic,
+    payload,
+  );
+  if (postEmit.blocked) {
+    return {
+      ok: false,
+      topic: result.topic,
+      error: postEmit.blockedMessage ?? "post_emit hook blocked this event",
+    };
+  }
+  return result;
+}
+
+function emitCore(
   projectDir: string,
   topic: string,
   payload: string,
@@ -98,6 +248,28 @@ export function emit(
   const journalFile = resolveEmitJournalFile(projectDir);
   mkdirSync(dirname(journalFile), { recursive: true });
   const validation = emitValidationContext(projectDir, journalFile);
+
+  // pre_emit hooks: run before any gating so a configured mutation can steer
+  // routing/gate decisions too. Runs disk/config-driven (see
+  // `runEmitPhaseHooks`) since this call is out-of-process from the harness.
+  const preEmit = runEmitPhaseHooks(
+    projectDir,
+    journalFile,
+    "pre_emit",
+    validation.runId,
+    validation.iteration,
+    topic,
+    payload,
+  );
+  if (preEmit.mutatedTopic !== undefined) topic = preEmit.mutatedTopic;
+  if (preEmit.mutatedPayload !== undefined) payload = preEmit.mutatedPayload;
+  if (preEmit.blocked) {
+    return {
+      ok: false,
+      topic,
+      error: preEmit.blockedMessage ?? "pre_emit hook blocked this event",
+    };
+  }
 
   // Evidence gate (opt-in): applies to ANY configured event, BEFORE routing /
   // coordination / completion handling, so a declared gate is never silently
@@ -321,6 +493,7 @@ export function routingTopic(topic: string): boolean {
     // letting the agent self-route and skip required intermediate steps.
     "backend.usage",
     "hook.output",
+    "hook.suspend",
     "event.invalid",
     "operator.guidance",
     "operator.guidance.consumed",

--- a/packages/harness/src/hooks.ts
+++ b/packages/harness/src/hooks.ts
@@ -1,6 +1,8 @@
 import { spawnSync } from "node:child_process";
+import type { HookPhase } from "@mobrienv/autoloop-core/hooks-schema";
 import { appendEvent } from "@mobrienv/autoloop-core/journal";
 import { log, printHookOutput } from "./display.js";
+import { writeSuspendState } from "./suspend-state.js";
 import type { LoopContext } from "./types.js";
 
 export interface HookEnv {
@@ -62,17 +64,18 @@ export function captureGitSha(cwd: string): string {
   return "";
 }
 
-export function runHook(
+interface RawHookRun {
+  status: number;
+  combined: string;
+  failed: boolean;
+}
+
+function spawnHook(
   loop: LoopContext,
   name: string,
   cmd: string,
   hookEnv: HookEnv,
-  iteration?: string,
-): void {
-  if (!cmd) return;
-
-  log(loop, "debug", `hook ${name} start cmd=${JSON.stringify(cmd)}`);
-
+): RawHookRun {
   const env: Record<string, string | undefined> = { ...process.env };
   for (const [k, v] of Object.entries(hookEnv)) {
     if (v !== undefined) env[k] = v;
@@ -89,35 +92,266 @@ export function runHook(
     (result.stdout ?? "") +
     (result.stderr ? `\n[stderr]\n${result.stderr}` : "");
 
+  const failed = result.status !== 0 || Boolean(result.error);
+  if (failed && result.error) {
+    log(loop, "debug", `hook ${name} spawn error: ${result.error.message}`);
+  }
+
+  return { status: result.status ?? -1, combined, failed };
+}
+
+/**
+ * Legacy single-hook entry point (`runHook`). Kept for backward compatibility
+ * with any external callers/tests; internally the engine runs hooks through
+ * `runPhaseHooks` which layers policy + mutation on top of this same spawn +
+ * journal behavior.
+ */
+export function runHook(
+  loop: LoopContext,
+  name: string,
+  cmd: string,
+  hookEnv: HookEnv,
+  iteration?: string,
+): void {
+  if (!cmd) return;
+
+  log(loop, "debug", `hook ${name} start cmd=${JSON.stringify(cmd)}`);
+  const { status, combined, failed } = spawnHook(loop, name, cmd, hookEnv);
+
   appendEvent(
     loop.paths.journalFile,
     loop.runtime.runId,
     iteration ?? "",
     "hook.output",
-    `"hook": ${JSON.stringify(name)}, "exit_code": ${result.status ?? -1}, "output": ${JSON.stringify(combined.trim())}`,
+    `"hook": ${JSON.stringify(name)}, "exit_code": ${status}, "output": ${JSON.stringify(combined.trim())}`,
   );
 
-  const failed = result.status !== 0 || result.error;
-
-  // Surface hook output on screen (not just in the journal). Silent successes
-  // print nothing; anything with output or a failure shows a bordered block.
-  printHookOutput(name, result.status ?? -1, combined.trim(), Boolean(failed));
+  printHookOutput(name, status, combined.trim(), failed);
 
   if (failed) {
-    // Surface the first meaningful line — prefer stderr (where errors land), then
-    // stdout. Don't echo the literal "[stderr]" marker as the summary.
-    const detail = (result.stderr ?? "").trim() || (result.stdout ?? "").trim();
-    const firstLine =
-      detail
-        .split("\n")
-        .map((l) => l.trim())
-        .find((l) => l.length > 0) ?? "";
-    const msg = `hook ${name} failed (exit ${result.status ?? -1}): ${result.error?.message ?? firstLine}`;
+    const msg = firstFailureLine(name, status, combined);
     log(loop, "warn", msg);
     if (loop.hooks.strict && name === "pre_run") {
       throw new Error(`Aborting run: ${msg}`);
     }
   } else {
     log(loop, "debug", `hook ${name} ok`);
+  }
+}
+
+function firstFailureLine(
+  name: string,
+  status: number,
+  combined: string,
+): string {
+  const stderrIdx = combined.indexOf("\n[stderr]\n");
+  const detail =
+    (stderrIdx >= 0 ? combined.slice(stderrIdx + 10) : "").trim() ||
+    (stderrIdx >= 0 ? combined.slice(0, stderrIdx) : combined).trim();
+  const firstLine =
+    detail
+      .split("\n")
+      .map((l) => l.trim())
+      .find((l) => l.length > 0) ?? "";
+  return `hook ${name} failed (exit ${status}): ${firstLine}`;
+}
+
+// --- Mutation directive parsing --------------------------------------------
+
+const MUTATE_FENCE_RE = /<<<AUTOLOOP_MUTATE>>>\n?([\s\S]*?)\n?<<<END>>>/;
+
+/**
+ * Parse a mutation directive from hook stdout, given which kind of mutation
+ * this hook is configured for:
+ *
+ * - `mutate="prompt"`: a fenced block (`<<<AUTOLOOP_MUTATE>>> ... <<<END>>>`)
+ *   or a `{"prompt": "..."}` JSON line take precedence; otherwise the *entire*
+ *   trimmed stdout becomes the new prompt (so a hook can be as simple as
+ *   `echo "new prompt text"`).
+ * - `mutate="event"`: requires a JSON object with `topic` and/or `payload`
+ *   (there is no plain-text form — an emitted event is structured, not free
+ *   text).
+ *
+ * Empty/malformed stdout is not an error — it simply yields no mutation
+ * (returns null), since a hook may run for its side effects alone.
+ */
+export function parseMutationDirective(
+  stdout: string,
+  mutate: "prompt" | "event",
+): { prompt?: string; topic?: string; payload?: string } | null {
+  if (!stdout?.trim()) return null;
+  const trimmed = stdout.trim();
+
+  const fenced = MUTATE_FENCE_RE.exec(stdout);
+  if (fenced && mutate === "prompt") {
+    return { prompt: fenced[1] };
+  }
+
+  if (trimmed.startsWith("{")) {
+    try {
+      const obj = JSON.parse(trimmed) as Record<string, unknown>;
+      const out: { prompt?: string; topic?: string; payload?: string } = {};
+      if (typeof obj.prompt === "string") out.prompt = obj.prompt;
+      if (typeof obj.topic === "string") out.topic = obj.topic;
+      if (typeof obj.payload === "string") out.payload = obj.payload;
+      if (Object.keys(out).length > 0) return out;
+    } catch {
+      /* not JSON — fall through to the plain-text prompt case below */
+    }
+  }
+
+  if (mutate === "prompt") return { prompt: trimmed };
+  return null;
+}
+
+export interface PhaseHookResult {
+  /** Mutated prompt, when a `mutate="prompt"` hook produced one (pre_iteration). */
+  mutatedPrompt?: string;
+  /** Mutated event, when a `mutate="event"` hook produced one (pre_emit). */
+  mutatedEvent?: { topic?: string; payload?: string };
+  /** True when a `block` hook failed — caller must abort/fail. */
+  blocked: boolean;
+  /** Detail message for the first blocking failure, if any. */
+  blockedMessage?: string;
+  /** True when a `suspend` hook fired and the run should stop (out-of-process
+   * phases can't block; the caller is responsible for tearing down). */
+  suspended: boolean;
+}
+
+export interface RunPhaseHooksOptions {
+  iteration?: number;
+  gitShaBefore?: string;
+  gitShaAfter?: string;
+  stopReason?: string;
+}
+
+/**
+ * Run every hook configured for `phase`, in declaration order, applying each
+ * hook's error policy and (if configured) parsing a mutation directive from
+ * its stdout. Later hooks in the same phase see the not-yet-applied original
+ * inputs — mutation from multiple hooks in one phase is last-write-wins
+ * (whichever hook mutates last), which keeps the model simple and matches
+ * the common case of a single hook per phase.
+ */
+export async function runPhaseHooks(
+  loop: LoopContext,
+  phase: HookPhase,
+  hookEnv: HookEnv,
+  opts: RunPhaseHooksOptions = {},
+): Promise<PhaseHookResult> {
+  // Defensive default: hand-built test LoopContexts (and any older caller
+  // that predates `hooks.specs`) may omit it entirely.
+  const specs = (loop.hooks.specs ?? []).filter((s) => s.phase === phase);
+  const result: PhaseHookResult = { blocked: false, suspended: false };
+  const iterationStr =
+    opts.iteration !== undefined ? String(opts.iteration) : "";
+
+  for (const spec of specs) {
+    if (!spec.command) continue;
+    log(
+      loop,
+      "debug",
+      `hook ${phase} start cmd=${JSON.stringify(spec.command)} on_error=${spec.onError} mutate=${spec.mutate}`,
+    );
+    const { status, combined, failed } = spawnHook(
+      loop,
+      phase,
+      spec.command,
+      hookEnv,
+    );
+
+    appendEvent(
+      loop.paths.journalFile,
+      loop.runtime.runId,
+      iterationStr,
+      "hook.output",
+      `"hook": ${JSON.stringify(phase)}, "exit_code": ${status}, "output": ${JSON.stringify(combined.trim())}`,
+    );
+    printHookOutput(phase, status, combined.trim(), failed);
+
+    if (!failed && spec.mutate !== "none") {
+      const stdoutOnly = combined.split("\n[stderr]\n")[0];
+      const directive = parseMutationDirective(stdoutOnly, spec.mutate);
+      if (directive) {
+        if (spec.mutate === "prompt" && directive.prompt !== undefined) {
+          result.mutatedPrompt = directive.prompt;
+        } else if (spec.mutate === "event") {
+          result.mutatedEvent = {
+            topic: directive.topic,
+            payload: directive.payload,
+          };
+        }
+      }
+    }
+
+    if (!failed) {
+      log(loop, "debug", `hook ${phase} ok`);
+      continue;
+    }
+
+    const msg = firstFailureLine(phase, status, combined);
+
+    switch (spec.onError) {
+      case "warn":
+        log(loop, "warn", msg);
+        break;
+      case "block":
+        log(loop, "error", `hook ${phase} blocked run: ${msg}`);
+        result.blocked = true;
+        result.blockedMessage = msg;
+        return result;
+      case "suspend": {
+        // Durable suspend: write versioned state and stop this call site
+        // immediately. The run process ends (see stopSuspended in the
+        // call sites); a later `autoloop resume` (a fresh process) reads
+        // suspend-state.json and continues from `resumeIteration`. This
+        // deliberately does NOT block in-process — emit's pre_emit/post_emit
+        // hooks run in a disposable subprocess and could never block the
+        // harness loop anyway, so in-process phases use the same simple,
+        // uniform "stop and let resume pick it back up" contract.
+        log(loop, "warn", `hook ${phase} suspended run: ${msg}`);
+        const resumeIteration = suspendResumeIteration(phase, opts.iteration);
+        writeSuspendState(
+          loop.paths.stateDir,
+          {
+            runId: loop.runtime.runId,
+            phase,
+            iteration: opts.iteration ?? 0,
+            reason: msg,
+            hookCommand: spec.command,
+            createdAt: new Date().toISOString(),
+            resumeIteration,
+          },
+          loop.paths.journalFile,
+        );
+        result.suspended = true;
+        result.blockedMessage = msg;
+        return result;
+      }
+    }
+  }
+
+  return result;
+}
+
+function suspendResumeIteration(
+  phase: HookPhase,
+  iteration: number | undefined,
+): number {
+  const iter = iteration ?? 0;
+  switch (phase) {
+    case "pre_run":
+      return 1;
+    case "pre_iteration":
+      return iter;
+    case "post_iteration":
+    case "post_emit":
+      return iter + 1;
+    case "pre_emit":
+      return iter;
+    case "post_run":
+      return iter + 1;
+    default:
+      return iter;
   }
 }

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -45,7 +45,7 @@ import { piControlAdapter } from "./control/pi-adapter.js";
 import { log, runCostUsd } from "./display.js";
 import { emit as emitCmd } from "./emit.js";
 import { checkCostBudget, checkRuntimeBudget, detectStall } from "./guards.js";
-import { buildHookEnv, runHook } from "./hooks.js";
+import { buildHookEnv, runPhaseHooks } from "./hooks.js";
 import { journalAcceptanceContract } from "./intent.js";
 import { runIteration } from "./iteration.js";
 import { maybeRunMetareview } from "./metareview.js";
@@ -73,7 +73,9 @@ import {
   stopPrematureQuit,
   stopReviewUnknown,
   stopStalled,
+  stopSuspended,
 } from "./stop.js";
+import { readSuspendState, resumeRequested } from "./suspend-state.js";
 import type { LoopContext, RunOptions, RunSummary } from "./types.js";
 
 export type { LoopContext, RunOptions, RunSummary };
@@ -102,11 +104,37 @@ export async function run(
     /* best-effort: readLines already skips corrupt lines, so this is belt-and-suspenders */
   }
   installRuntimeTools(loop);
+
+  // A durable suspend from a prior run still pending (no resume-requested
+  // signal dropped yet) must block a fresh `run` from starting over the same
+  // state dir — the operator needs to resolve it first via `autoloop resume`
+  // or `autoloop hooks clear-suspend`.
+  const pendingSuspend = readSuspendState(loop.paths.stateDir);
+  if (pendingSuspend && !resumeRequested(loop.paths.stateDir)) {
+    throw new Error(
+      `run suspended (phase=${pendingSuspend.phase}, reason=${pendingSuspend.reason}); ` +
+        "resolve with `autoloop resume` or clear it with `autoloop hooks clear-suspend` before starting a new run",
+    );
+  }
+
   appendLoopStart(loop);
   // Bind the acceptance contract (intent) at loop start so the deterministic
   // gate keys its criteria off what was asked.
   journalAcceptanceContract(loop);
-  runHook(loop, "pre_run", loop.hooks.preRun, buildHookEnv(loop));
+  const preRunResult = await runPhaseHooks(loop, "pre_run", buildHookEnv(loop));
+  if (preRunResult.blocked) {
+    throw new Error(
+      `Aborting run: ${preRunResult.blockedMessage ?? "pre_run hook blocked"}`,
+    );
+  }
+  if (preRunResult.suspended) {
+    const summary = stopSuspended(
+      loop,
+      0,
+      preRunResult.blockedMessage ?? "pre_run hook suspended the run",
+    );
+    return summary;
+  }
   registryStart(loop);
   loop.controlAdapter = buildControlAdapter(loop);
   if (loop.controlAdapter) {
@@ -356,12 +384,16 @@ export async function driveLoop(
     }
   }
 
-  runHook(
+  const postRunResult = await runPhaseHooks(
     loop,
     "post_run",
-    loop.hooks.postRun,
     buildHookEnv(loop, { stopReason: summary.stopReason }),
   );
+  if (postRunResult.blocked) {
+    throw new Error(
+      `post_run hook failed: ${postRunResult.blockedMessage ?? "post_run hook blocked"}`,
+    );
+  }
   runFinishNotification({
     projectDir: loop.paths.mainProjectDir,
     journalFile: loop.paths.journalFile,

--- a/packages/harness/src/iteration.ts
+++ b/packages/harness/src/iteration.ts
@@ -46,7 +46,7 @@ import {
   systemTopic,
 } from "./emit.js";
 import { loopStartMs } from "./guards.js";
-import { buildHookEnv, captureGitSha, runHook } from "./hooks.js";
+import { buildHookEnv, captureGitSha, runPhaseHooks } from "./hooks.js";
 import { reinjectIntentFailure, runIntentCriteria } from "./intent.js";
 import {
   appendBackendFinish,
@@ -77,7 +77,9 @@ import {
   stopBackendFailed,
   stopBackendTimeout,
   stopMaxRuntime,
+  stopSuspended,
 } from "./stop.js";
+import { readSuspendState, resumeRequested } from "./suspend-state.js";
 import { reinjectTamperFailure, runTamperScreen } from "./tamper.js";
 import type { LoopContext, RunSummary } from "./types.js";
 import {
@@ -91,6 +93,21 @@ export async function runIteration(
   iteration: number,
   iterate: (loop: LoopContext, iteration: number) => Promise<RunSummary>,
 ): Promise<RunSummary> {
+  // Out-of-process pre_emit/post_emit `suspend` hooks (run in the `emit`
+  // subprocess — see emit.ts:runEmitPhaseHooks) can't block the harness loop
+  // directly; they write durable suspend state instead. Detect it here, at
+  // the next iteration boundary, and halt the loop rather than silently
+  // continuing past a pending suspend.
+  const pendingEmitSuspend = readSuspendState(loop.paths.stateDir);
+  if (
+    pendingEmitSuspend &&
+    (pendingEmitSuspend.phase === "pre_emit" ||
+      pendingEmitSuspend.phase === "post_emit") &&
+    !resumeRequested(loop.paths.stateDir)
+  ) {
+    return stopSuspended(loop, iteration, pendingEmitSuspend.reason);
+  }
+
   let iter = buildIterationContext(loop, iteration);
 
   // Clamp the iteration timeout to the remaining loop wall-clock budget so a
@@ -134,13 +151,30 @@ export async function runIteration(
 
   const startEpoch = Math.floor(Date.now() / 1000);
   const gitShaBefore = captureGitSha(loop.paths.workDir);
-  runHook(
+  const preIterResult = await runPhaseHooks(
     loop,
     "pre_iteration",
-    loop.hooks.preIteration,
     buildHookEnv(loop, { iteration, gitShaBefore }),
-    String(iteration),
+    { iteration, gitShaBefore },
   );
+  if (preIterResult.blocked) {
+    throw new Error(
+      `Aborting run: ${preIterResult.blockedMessage ?? "pre_iteration hook blocked"}`,
+    );
+  }
+  if (preIterResult.suspended) {
+    return stopSuspended(
+      loop,
+      iteration,
+      preIterResult.blockedMessage ?? "pre_iteration hook suspended the run",
+    );
+  }
+  // Mutation seam: applied after buildIterationContext but before the backend
+  // command is built, so a mutated prompt survives the loop-budget timeout
+  // clamp's `iter = {...iter, backend:{...}}` reassignment above.
+  if (preIterResult.mutatedPrompt !== undefined) {
+    iter = { ...iter, prompt: preIterResult.mutatedPrompt };
+  }
 
   // Fresh ACP session per iteration — ensures each role (researcher, critic,
   // etc.) starts with a clean context window for truly independent review.
@@ -213,13 +247,24 @@ export async function runIteration(
   appendBackendFinish(loop, iter, output, exitCode, timedOut);
   appendIterationFinish(loop, iter, output, exitCode, timedOut, elapsedS);
   const gitShaAfter = captureGitSha(loop.paths.workDir);
-  runHook(
+  const postIterResult = await runPhaseHooks(
     loop,
     "post_iteration",
-    loop.hooks.postIteration,
     buildHookEnv(loop, { iteration, gitShaBefore, gitShaAfter }),
-    String(iteration),
+    { iteration, gitShaBefore, gitShaAfter },
   );
+  if (postIterResult.blocked) {
+    throw new Error(
+      `Aborting run: ${postIterResult.blockedMessage ?? "post_iteration hook blocked"}`,
+    );
+  }
+  if (postIterResult.suspended) {
+    return stopSuspended(
+      loop,
+      iteration,
+      postIterResult.blockedMessage ?? "post_iteration hook suspended the run",
+    );
+  }
   registryProgress(loop, iteration);
   // Capture the preset-declared progress scalar each iteration (drift signal).
   runProgressMetric(loop, iteration);

--- a/packages/harness/src/resume.ts
+++ b/packages/harness/src/resume.ts
@@ -20,6 +20,11 @@ import { publishCapabilities } from "./control/dispatch.js";
 import { log } from "./display.js";
 import { buildControlAdapter, driveLoop } from "./index.js";
 import { registryStart } from "./registry-bridge.js";
+import {
+  clearResumeRequest,
+  clearSuspendState,
+  readSuspendState,
+} from "./suspend-state.js";
 import type { LoopContext, RunOptions, RunSummary } from "./types.js";
 
 export interface ResumeOptions {
@@ -148,12 +153,19 @@ export function buildResumeContext(
   const logLevel =
     options.logLevel || config.get(cfg, "core.log_level", "info");
 
-  const resumeIteration = determineResumeIteration(
-    journalFile,
-    record.run_id,
-    record.stop_reason,
-    record.iteration,
-  );
+  // A durable suspend (written by a `suspend`-policy hook) carries its own
+  // recorded resume point — prefer it over the stop-reason heuristic, since
+  // it reflects exactly where the hook engine intended to resume rather than
+  // a best-effort guess from the journal.
+  const suspendState = readSuspendState(stateDir);
+  const resumeIteration = suspendState
+    ? suspendState.resumeIteration
+    : determineResumeIteration(
+        journalFile,
+        record.run_id,
+        record.stop_reason,
+        record.iteration,
+      );
 
   // Budget is additive from the resume point. Default add-iterations to the
   // run's original max_iterations (so a max_iterations stop, by default, grants
@@ -289,6 +301,12 @@ export async function resume(
   if (loop.controlAdapter) {
     publishCapabilities(loop.paths.stateDir, loop.controlAdapter);
   }
+
+  // Clear durable suspend markers now that we're re-entering the loop at the
+  // recorded resume point — a stale suspend-state.json would otherwise make
+  // the next `run()` (or this resume, if invoked again) refuse to start.
+  clearSuspendState(loop.paths.stateDir);
+  clearResumeRequest(loop.paths.stateDir);
 
   log(
     loop,

--- a/packages/harness/src/stop.ts
+++ b/packages/harness/src/stop.ts
@@ -349,6 +349,45 @@ export function stopPrematureQuit(
   return { iterations: completed, stopReason: "premature_quit" };
 }
 
+/**
+ * Stop for a `suspend`-policy hook that fired and could not (or was not
+ * configured to) block in-process. Durable suspend state has already been
+ * written by the hooks engine (`writeSuspendState`); this only journals the
+ * typed stop reason and registry status so `autoloop resume` can pick it up.
+ */
+export function stopSuspended(
+  loop: LoopContext,
+  iteration: number,
+  reason: string,
+): RunSummary {
+  log(
+    loop,
+    "warn",
+    `loop stop reason=suspended iteration=${iteration} detail=${reason}`,
+  );
+  loop.onEvent?.({
+    type: "progress",
+    runId: loop.runtime.runId,
+    iteration,
+    recentEvent: "loop.stop",
+    allowedRoles: [],
+    outcome: "stop:suspended",
+  });
+  appendEvent(
+    loop.paths.journalFile,
+    loop.runtime.runId,
+    String(iteration),
+    "loop.stop",
+    jsonField("reason", "suspended") +
+      ", " +
+      jsonField("iteration", String(iteration)) +
+      ", " +
+      jsonField("detail", reason),
+  );
+  registryStop(loop, iteration, "suspended");
+  return { iterations: iteration, stopReason: "suspended" };
+}
+
 export function completeLoop(
   loop: LoopContext,
   iteration: number,

--- a/packages/harness/src/suspend-state.ts
+++ b/packages/harness/src/suspend-state.ts
@@ -1,0 +1,146 @@
+// Durable suspend/resume signalling for the lifecycle hooks engine.
+//
+// `on_error = "suspend"` writes a versioned `.autoloop/suspend-state.json`
+// and (for in-process phases) blocks the harness until an operator drops
+// `.autoloop/resume-requested` (or `autoloop hooks clear-suspend` / `resume`
+// clears it). This lets a hook halt the loop for out-of-band remediation
+// (e.g. a human approval gate) without losing the run's position.
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { jsonField } from "@mobrienv/autoloop-core";
+import {
+  isSuspendState,
+  SUSPEND_STATE_SCHEMA_VERSION,
+  type SuspendState,
+} from "@mobrienv/autoloop-core/hooks-schema";
+import { appendEvent } from "@mobrienv/autoloop-core/journal";
+
+export type { SuspendState };
+export { SUSPEND_STATE_SCHEMA_VERSION };
+
+export function suspendStatePath(stateDir: string): string {
+  return join(stateDir, "suspend-state.json");
+}
+
+export function resumeRequestPath(stateDir: string): string {
+  return join(stateDir, "resume-requested");
+}
+
+/**
+ * Write the suspend state atomically (tmp file + rename) so a reader never
+ * observes a torn write, and journal `hook.suspend` for observability.
+ */
+export function writeSuspendState(
+  stateDir: string,
+  state: Omit<SuspendState, "schemaVersion">,
+  journalFile?: string,
+): SuspendState {
+  mkdirSync(stateDir, { recursive: true });
+  const full: SuspendState = {
+    schemaVersion: SUSPEND_STATE_SCHEMA_VERSION,
+    ...state,
+  };
+  const path = suspendStatePath(stateDir);
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, `${JSON.stringify(full, null, 2)}\n`, "utf-8");
+  renameSync(tmp, path);
+
+  if (journalFile) {
+    appendEvent(
+      journalFile,
+      state.runId,
+      state.iteration ? String(state.iteration) : "",
+      "hook.suspend",
+      jsonField("phase", state.phase) +
+        ", " +
+        jsonField("reason", state.reason) +
+        ", " +
+        jsonField("hook_command", state.hookCommand) +
+        ", " +
+        jsonField("resume_iteration", String(state.resumeIteration)),
+    );
+  }
+
+  return full;
+}
+
+/** Read the durable suspend state, or null when absent/unreadable/invalid. */
+export function readSuspendState(stateDir: string): SuspendState | null {
+  const path = suspendStatePath(stateDir);
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8"));
+    return isSuspendState(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Remove the suspend-state file. No-op if absent. */
+export function clearSuspendState(stateDir: string): boolean {
+  const path = suspendStatePath(stateDir);
+  if (!existsSync(path)) return false;
+  rmSync(path, { force: true });
+  return true;
+}
+
+/** Drop the resume-requested signal file (operator says "go"). */
+export function requestResume(stateDir: string): void {
+  mkdirSync(dirname(resumeRequestPath(stateDir)), { recursive: true });
+  writeFileSync(resumeRequestPath(stateDir), `${new Date().toISOString()}\n`);
+}
+
+export function resumeRequested(stateDir: string): boolean {
+  return existsSync(resumeRequestPath(stateDir));
+}
+
+/** Remove the resume-requested signal file. No-op if absent. */
+export function clearResumeRequest(stateDir: string): boolean {
+  const path = resumeRequestPath(stateDir);
+  if (!existsSync(path)) return false;
+  rmSync(path, { force: true });
+  return true;
+}
+
+export interface WaitForResumeOptions {
+  pollMs?: number;
+  /** Abort signal, honoured the same way `ask.ts:awaitHumanResponse` does. */
+  signal?: AbortSignal;
+  /** Optional wall-clock cap in ms; 0/undefined = wait indefinitely. */
+  timeoutMs?: number;
+}
+
+/**
+ * Block until `resume-requested` appears, the run is aborted, or (if set)
+ * `timeoutMs` elapses. Returns `true` when resumed, `false` on abort/timeout.
+ * Mirrors `ask.ts:awaitHumanResponse`'s signal-aware poll loop.
+ */
+export async function waitForResume(
+  stateDir: string,
+  opts: WaitForResumeOptions = {},
+): Promise<boolean> {
+  const pollMs = opts.pollMs && opts.pollMs > 0 ? opts.pollMs : 1000;
+  const deadline =
+    opts.timeoutMs && opts.timeoutMs > 0 ? Date.now() + opts.timeoutMs : null;
+
+  for (;;) {
+    if (opts.signal?.aborted) return false;
+    if (resumeRequested(stateDir)) return true;
+    if (deadline !== null && Date.now() >= deadline) return false;
+    const wait =
+      deadline !== null ? Math.min(pollMs, deadline - Date.now()) : pollMs;
+    await sleep(Math.max(0, wait));
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/harness/src/types.ts
+++ b/packages/harness/src/types.ts
@@ -2,6 +2,7 @@ import type { AcpSession } from "@mobrienv/autoloop-backends/acp-client";
 import type { ClaudeSdkSession } from "@mobrienv/autoloop-backends/claude-sdk-client";
 import type { PiSession } from "@mobrienv/autoloop-backends/pi-rpc-client";
 import type { AgentMap } from "@mobrienv/autoloop-core/agent-map";
+import type { HookSpec } from "@mobrienv/autoloop-core/hooks-schema";
 import type * as topo from "@mobrienv/autoloop-core/topology";
 import type { LiveControlAdapter } from "./control/adapter.js";
 import type { LoopEventEmitter } from "./events.js";
@@ -167,6 +168,13 @@ export interface LoopContext {
     postIteration: string;
     postRun: string;
     strict: boolean;
+    /**
+     * Structured per-hook specs (legacy flat keys + `[[hook]]` entries),
+     * merged and template-expanded. This is the engine's source of truth;
+     * the flat fields above remain for backward compatibility with existing
+     * callers/tests but `specs` is what `runPhaseHooks` iterates.
+     */
+    specs: HookSpec[];
   };
   memory: { budgetChars: number };
   tasks: { budgetChars: number };

--- a/packages/harness/test/suspend-state.test.ts
+++ b/packages/harness/test/suspend-state.test.ts
@@ -1,0 +1,150 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SUSPEND_STATE_SCHEMA_VERSION } from "@mobrienv/autoloop-core/hooks-schema";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearResumeRequest,
+  clearSuspendState,
+  readSuspendState,
+  requestResume,
+  resumeRequested,
+  suspendStatePath,
+  waitForResume,
+  writeSuspendState,
+} from "../src/suspend-state.js";
+
+let stateDir: string;
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), "autoloop-suspend-state-"));
+});
+
+afterEach(() => {
+  rmSync(stateDir, { recursive: true, force: true });
+});
+
+describe("suspend-state: write/read/clear round-trip", () => {
+  it("writes a versioned suspend-state.json and reads it back", () => {
+    const written = writeSuspendState(stateDir, {
+      runId: "run-1",
+      phase: "pre_iteration",
+      iteration: 4,
+      reason: "needs human approval",
+      hookCommand: "./approve.sh",
+      createdAt: new Date().toISOString(),
+      resumeIteration: 4,
+    });
+
+    expect(written.schemaVersion).toBe(SUSPEND_STATE_SCHEMA_VERSION);
+    expect(existsSync(suspendStatePath(stateDir))).toBe(true);
+
+    const read = readSuspendState(stateDir);
+    expect(read).not.toBeNull();
+    expect(read?.schemaVersion).toBe(1);
+    expect(read?.runId).toBe("run-1");
+    expect(read?.resumeIteration).toBe(4);
+  });
+
+  it("returns null when no suspend state exists", () => {
+    expect(readSuspendState(stateDir)).toBeNull();
+  });
+
+  it("returns null for a corrupt suspend-state.json", () => {
+    writeSuspendState(stateDir, {
+      runId: "run-1",
+      phase: "pre_run",
+      iteration: 0,
+      reason: "x",
+      hookCommand: "y",
+      createdAt: new Date().toISOString(),
+      resumeIteration: 1,
+    });
+    // Corrupt it in place.
+    const path = suspendStatePath(stateDir);
+    const original = readFileSync(path, "utf-8");
+    expect(original.length).toBeGreaterThan(0);
+    writeFileSync(path, "{not json");
+    expect(readSuspendState(stateDir)).toBeNull();
+  });
+
+  it("clearSuspendState removes the file and reports whether it existed", () => {
+    expect(clearSuspendState(stateDir)).toBe(false);
+    writeSuspendState(stateDir, {
+      runId: "run-1",
+      phase: "post_run",
+      iteration: 2,
+      reason: "x",
+      hookCommand: "y",
+      createdAt: new Date().toISOString(),
+      resumeIteration: 3,
+    });
+    expect(clearSuspendState(stateDir)).toBe(true);
+    expect(readSuspendState(stateDir)).toBeNull();
+  });
+
+  it("journals hook.suspend when a journalFile is passed", () => {
+    const journalFile = join(stateDir, "journal.jsonl");
+    writeSuspendState(
+      stateDir,
+      {
+        runId: "run-1",
+        phase: "pre_iteration",
+        iteration: 1,
+        reason: "needs approval",
+        hookCommand: "./approve.sh",
+        createdAt: new Date().toISOString(),
+        resumeIteration: 1,
+      },
+      journalFile,
+    );
+    const journal = readFileSync(journalFile, "utf-8");
+    expect(journal).toContain('"topic": "hook.suspend"');
+    expect(journal).toContain("needs approval");
+  });
+});
+
+describe("suspend-state: resume signal", () => {
+  it("resumeRequested is false until requestResume is called", () => {
+    expect(resumeRequested(stateDir)).toBe(false);
+    requestResume(stateDir);
+    expect(resumeRequested(stateDir)).toBe(true);
+  });
+
+  it("clearResumeRequest removes the signal and reports whether it existed", () => {
+    expect(clearResumeRequest(stateDir)).toBe(false);
+    requestResume(stateDir);
+    expect(clearResumeRequest(stateDir)).toBe(true);
+    expect(resumeRequested(stateDir)).toBe(false);
+  });
+
+  it("waitForResume resolves true once resume-requested appears", async () => {
+    const promise = waitForResume(stateDir, { pollMs: 20 });
+    setTimeout(() => requestResume(stateDir), 30);
+    expect(await promise).toBe(true);
+  });
+
+  it("waitForResume resolves false when the signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const resumed = await waitForResume(stateDir, {
+      pollMs: 10,
+      signal: controller.signal,
+    });
+    expect(resumed).toBe(false);
+  });
+
+  it("waitForResume resolves false on timeout", async () => {
+    const resumed = await waitForResume(stateDir, {
+      pollMs: 10,
+      timeoutMs: 30,
+    });
+    expect(resumed).toBe(false);
+  });
+});

--- a/test/integration/hooks-cli.test.ts
+++ b/test/integration/hooks-cli.test.ts
@@ -1,0 +1,149 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+import { ensureBuild, makeTempProject, runCli } from "../helpers/runtime.js";
+
+beforeAll(() => {
+  ensureBuild();
+});
+
+function appendConfig(project: string, toml: string): void {
+  const configPath = join(project, "autoloops.toml");
+  const existing = readFileSync(configPath, "utf-8");
+  writeFileSync(configPath, `${existing}\n${toml}\n`, "utf-8");
+}
+
+describe("integration: autoloop hooks CLI", () => {
+  it("hooks list shows configured hooks grouped by phase", () => {
+    const project = makeTempProject("hooks-cli-list");
+    appendConfig(
+      project,
+      [
+        "[hooks]",
+        'pre_run = "echo legacy"',
+        "",
+        "[[hook]]",
+        'phase = "pre_iteration"',
+        'command = "echo structured"',
+        'on_error = "block"',
+        'mutate = "prompt"',
+      ].join("\n"),
+    );
+
+    const res = runCli(["hooks", "list", project], {});
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("pre_run:");
+    expect(res.stdout).toContain("echo legacy");
+    expect(res.stdout).toContain("pre_iteration:");
+    expect(res.stdout).toContain("echo structured");
+    expect(res.stdout).toContain("on_error=block");
+    expect(res.stdout).toContain("mutate=prompt");
+  });
+
+  it("hooks list --json emits machine-readable hook specs", () => {
+    const project = makeTempProject("hooks-cli-list-json");
+    appendConfig(
+      project,
+      ["[[hook]]", 'phase = "post_run"', 'command = "echo done"'].join("\n"),
+    );
+
+    const res = runCli(["hooks", "list", project, "--json"], {});
+    expect(res.status).toBe(0);
+    const parsed = JSON.parse(res.stdout);
+    expect(parsed.hooks).toHaveLength(1);
+    expect(parsed.hooks[0]).toMatchObject({
+      phase: "post_run",
+      command: "echo done",
+      onError: "warn",
+      mutate: "none",
+    });
+  });
+
+  it("hooks show <phase> displays only that phase's hooks", () => {
+    const project = makeTempProject("hooks-cli-show");
+    appendConfig(
+      project,
+      [
+        "[[hook]]",
+        'phase = "pre_emit"',
+        'command = "echo pre-emit-hook"',
+        'mutate = "event"',
+        "",
+        "[[hook]]",
+        'phase = "post_emit"',
+        'command = "echo post-emit-hook"',
+      ].join("\n"),
+    );
+
+    const res = runCli(["hooks", "show", "pre_emit", project], {});
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("pre-emit-hook");
+    expect(res.stdout).not.toContain("post-emit-hook");
+  });
+
+  it("hooks show with an unknown phase fails clearly", () => {
+    const project = makeTempProject("hooks-cli-show-bad");
+    const res = runCli(["hooks", "show", "not_a_phase", project], {});
+    expect(res.status).not.toBe(0);
+    expect(res.stdout).toContain("unknown phase");
+  });
+
+  it("hooks validate succeeds on a well-formed config", () => {
+    const project = makeTempProject("hooks-cli-validate-ok");
+    appendConfig(
+      project,
+      ["[[hook]]", 'phase = "pre_run"', 'command = "echo ok"'].join("\n"),
+    );
+
+    const res = runCli(["hooks", "validate", project], {});
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("valid");
+  });
+
+  it("hooks validate exits non-zero and reports errors for a bad policy/phase", () => {
+    const project = makeTempProject("hooks-cli-validate-bad");
+    appendConfig(
+      project,
+      [
+        "[[hook]]",
+        'phase = "not_a_real_phase"',
+        'command = "echo hi"',
+        'on_error = "not_a_real_policy"',
+      ].join("\n"),
+    );
+
+    const res = runCli(["hooks", "validate", project], {});
+    expect(res.status).not.toBe(0);
+    expect(res.stdout).toContain("phase must be one of");
+    expect(res.stdout).toContain("on_error must be one of");
+  });
+
+  it("hooks validate --json reports structured errors", () => {
+    const project = makeTempProject("hooks-cli-validate-json");
+    appendConfig(
+      project,
+      ["[[hook]]", 'phase = "pre_run"'].join("\n"), // missing command
+    );
+
+    const res = runCli(["hooks", "validate", project, "--json"], {});
+    expect(res.status).not.toBe(0);
+    const parsed = JSON.parse(res.stdout);
+    expect(parsed.valid).toBe(false);
+    expect(parsed.errors.length).toBeGreaterThan(0);
+    expect(parsed.errors[0].field).toBe("command");
+  });
+
+  it("hooks clear-suspend reports nothing to clear when no suspend state exists", () => {
+    const project = makeTempProject("hooks-cli-clear-noop");
+    const res = runCli(["hooks", "clear-suspend", project], {});
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("No suspend state");
+  });
+
+  it("hooks --help / bare hooks prints usage", () => {
+    const res = runCli(["hooks"], {});
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("autoloop hooks");
+    expect(res.stdout).toContain("clear-suspend");
+  });
+});

--- a/test/integration/hooks-lifecycle.test.ts
+++ b/test/integration/hooks-lifecycle.test.ts
@@ -1,0 +1,180 @@
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+  ensureBuild,
+  FIXTURES_DIR,
+  makeTempProject,
+  runCli,
+} from "../helpers/runtime.js";
+
+beforeAll(() => {
+  ensureBuild();
+});
+
+function appendConfig(project: string, toml: string): void {
+  const configPath = join(project, "autoloops.toml");
+  const existing = readFileSync(configPath, "utf-8");
+  writeFileSync(configPath, `${existing}\n${toml}\n`, "utf-8");
+}
+
+function journal(project: string): string {
+  return readFileSync(join(project, ".autoloop/journal.jsonl"), "utf-8");
+}
+
+/**
+ * `active-prompt.md` lives under the run-scoped state dir
+ * (`.autoloop/runs/<run-id>/active-prompt.md`, isolation mode default), not
+ * directly under `.autoloop/` — locate it by scanning the runs directory
+ * rather than hardcoding a run id.
+ */
+function activePrompt(project: string): string {
+  const runsDir = join(project, ".autoloop", "runs");
+  const runIds = readdirSync(runsDir);
+  for (const runId of runIds) {
+    const path = join(runsDir, runId, "active-prompt.md");
+    try {
+      return readFileSync(path, "utf-8");
+    } catch {
+      /* try the next run dir */
+    }
+  }
+  throw new Error(`no active-prompt.md found under ${runsDir}`);
+}
+
+describe("integration: [[hook]] structured lifecycle engine", () => {
+  it("[[hook]] pre_iteration/post_iteration fire in the right order alongside legacy hooks", () => {
+    const project = makeTempProject("hooks-order");
+    appendConfig(
+      project,
+      [
+        "[[hook]]",
+        'phase = "pre_iteration"',
+        'command = "echo structured-pre"',
+        "",
+        "[[hook]]",
+        'phase = "post_iteration"',
+        'command = "echo structured-post"',
+      ].join("\n"),
+    );
+
+    const res = runCli(["run", project, "test hook order"], {
+      MOCK_FIXTURE_PATH: join(FIXTURES_DIR, "complete-success.json"),
+    });
+
+    expect(res.status).toBe(0);
+    const j = journal(project);
+    const preIdx = j.indexOf('"output": "structured-pre"');
+    const postIdx = j.indexOf('"output": "structured-post"');
+    const iterFinishIdx = j.indexOf('"topic": "iteration.finish"');
+    expect(preIdx).toBeGreaterThan(-1);
+    expect(postIdx).toBeGreaterThan(-1);
+    // pre_iteration fires before the iteration's backend work finishes, and
+    // post_iteration fires after.
+    expect(preIdx).toBeLessThan(iterFinishIdx);
+    expect(iterFinishIdx).toBeLessThan(postIdx);
+  });
+
+  it("on_error=block aborts the run when a pre_iteration hook fails", () => {
+    const project = makeTempProject("hooks-block");
+    appendConfig(
+      project,
+      [
+        "[[hook]]",
+        'phase = "pre_iteration"',
+        'command = "exit 1"',
+        'on_error = "block"',
+      ].join("\n"),
+    );
+
+    const res = runCli(["run", project, "test hook block"], {
+      MOCK_FIXTURE_PATH: join(FIXTURES_DIR, "complete-success.json"),
+    });
+
+    expect(res.status).not.toBe(0);
+  });
+
+  it("on_error=warn (default) lets the run continue past a failing hook", () => {
+    const project = makeTempProject("hooks-warn");
+    appendConfig(
+      project,
+      [
+        "[[hook]]",
+        'phase = "pre_iteration"',
+        'command = "exit 1"',
+        'on_error = "warn"',
+      ].join("\n"),
+    );
+
+    const res = runCli(["run", project, "test hook warn"], {
+      MOCK_FIXTURE_PATH: join(FIXTURES_DIR, "complete-success.json"),
+    });
+
+    expect(res.status).toBe(0);
+  });
+
+  it("mutate=prompt: a pre_iteration hook's stdout replaces the iteration prompt", () => {
+    const project = makeTempProject("hooks-mutate-prompt");
+    appendConfig(
+      project,
+      [
+        "[[hook]]",
+        'phase = "pre_iteration"',
+        'command = "echo MUTATED_PROMPT_MARKER"',
+        'mutate = "prompt"',
+      ].join("\n"),
+    );
+
+    const res = runCli(["run", project, "original prompt text"], {
+      MOCK_FIXTURE_PATH: join(FIXTURES_DIR, "complete-success.json"),
+    });
+
+    expect(res.status).toBe(0);
+    const promptFile = activePrompt(project);
+    expect(promptFile).toContain("MUTATED_PROMPT_MARKER");
+    expect(promptFile).not.toContain("original prompt text");
+  });
+
+  it("mutate=none (default) leaves the prompt untouched even if the hook prints something", () => {
+    const project = makeTempProject("hooks-no-mutate");
+    appendConfig(
+      project,
+      [
+        "[[hook]]",
+        'phase = "pre_iteration"',
+        'command = "echo SHOULD_NOT_APPEAR_IN_PROMPT"',
+      ].join("\n"),
+    );
+
+    const res = runCli(["run", project, "keep this prompt"], {
+      MOCK_FIXTURE_PATH: join(FIXTURES_DIR, "complete-success.json"),
+    });
+
+    expect(res.status).toBe(0);
+    const promptFile = activePrompt(project);
+    expect(promptFile).toContain("keep this prompt");
+    expect(promptFile).not.toContain("SHOULD_NOT_APPEAR_IN_PROMPT");
+  });
+
+  it("mutate=event: a pre_emit hook's directive changes the emitted topic", () => {
+    const project = makeTempProject("hooks-mutate-event");
+    appendConfig(
+      project,
+      [
+        "[[hook]]",
+        'phase = "pre_emit"',
+        `command = ${JSON.stringify(
+          'echo {\\"topic\\":\\"issue.discovered\\"}',
+        )}`,
+        'mutate = "event"',
+      ].join("\n"),
+    );
+
+    const res = runCli(["emit", "some.other.topic", "hello"], {}, project);
+
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("emitted issue.discovered");
+    const j = journal(project);
+    expect(j).toContain('"topic": "issue.discovered"');
+  });
+});

--- a/test/integration/hooks-suspend-resume.test.ts
+++ b/test/integration/hooks-suspend-resume.test.ts
@@ -1,0 +1,146 @@
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+  ensureBuild,
+  FIXTURES_DIR,
+  makeTempProject,
+  runCli,
+} from "../helpers/runtime.js";
+
+beforeAll(() => {
+  ensureBuild();
+});
+
+function appendConfig(project: string, toml: string): void {
+  const configPath = join(project, "autoloops.toml");
+  const existing = readFileSync(configPath, "utf-8");
+  writeFileSync(configPath, `${existing}\n${toml}\n`, "utf-8");
+}
+
+function runsDirOf(project: string): string {
+  return join(project, ".autoloop", "runs");
+}
+
+/** The single run-scoped id created by a fresh `run` (default isolation). */
+function soleRunId(project: string): string {
+  const [runId] = readdirSync(runsDirOf(project));
+  return runId;
+}
+
+function stateDirOf(project: string, runId: string): string {
+  return join(runsDirOf(project), runId);
+}
+
+describe("integration: hooks suspend/resume durability", () => {
+  it("a suspend-policy pre_run hook writes versioned suspend-state.json and stops the run", () => {
+    const project = makeTempProject("hooks-suspend-prerun");
+    appendConfig(
+      project,
+      [
+        "[[hook]]",
+        'phase = "pre_run"',
+        'command = "exit 1"',
+        'on_error = "suspend"',
+      ].join("\n"),
+    );
+
+    const res = runCli(["run", project, "test suspend"], {
+      MOCK_FIXTURE_PATH: join(FIXTURES_DIR, "complete-success.json"),
+    });
+
+    // A suspend is a controlled stop (like max_iterations) — the harness
+    // returns a terminal RunSummary rather than throwing, so the CLI process
+    // exits 0. Durability is via suspend-state.json, not the exit code.
+    expect(res.status).toBe(0);
+
+    const runId = soleRunId(project);
+    const stateDir = stateDirOf(project, runId);
+    const suspendPath = join(stateDir, "suspend-state.json");
+    expect(existsSync(suspendPath)).toBe(true);
+
+    const state = JSON.parse(readFileSync(suspendPath, "utf-8"));
+    expect(state.schemaVersion).toBe(1);
+    expect(state.phase).toBe("pre_run");
+    expect(state.resumeIteration).toBe(1);
+    expect(state.runId).toBe(runId);
+
+    const journal = readFileSync(
+      join(project, ".autoloop/journal.jsonl"),
+      "utf-8",
+    );
+    expect(journal).toContain('"topic": "hook.suspend"');
+    expect(journal).toContain('"reason": "suspended"');
+  });
+
+  it("hooks clear-suspend removes suspend-state.json and the resume-requested signal", () => {
+    const project = makeTempProject("hooks-clear-suspend");
+    appendConfig(
+      project,
+      [
+        "[[hook]]",
+        'phase = "pre_run"',
+        'command = "exit 1"',
+        'on_error = "suspend"',
+      ].join("\n"),
+    );
+
+    const runRes = runCli(["run", project, "test suspend"], {
+      MOCK_FIXTURE_PATH: join(FIXTURES_DIR, "complete-success.json"),
+    });
+    expect(runRes.status).toBe(0);
+
+    const stateDir = stateDirOf(project, soleRunId(project));
+    expect(existsSync(join(stateDir, "suspend-state.json"))).toBe(true);
+
+    const res = runCli(["hooks", "clear-suspend"], {
+      AUTOLOOP_STATE_DIR: stateDir,
+    });
+
+    expect(res.status).toBe(0);
+    expect(existsSync(join(stateDir, "suspend-state.json"))).toBe(false);
+    expect(existsSync(join(stateDir, "resume-requested"))).toBe(false);
+  });
+
+  it("`autoloop resume` loads suspend state and retries at the recorded resume point", () => {
+    const project = makeTempProject("hooks-resume-cycle");
+    // Fails (and suspends) on its first invocation only — a sentinel file
+    // makes the retry after resume succeed, so we can observe the loop
+    // actually completing on the resumed attempt.
+    const sentinel = join(project, "hook-ran-once");
+    appendConfig(
+      project,
+      [
+        "[[hook]]",
+        'phase = "pre_iteration"',
+        `command = "test -f ${sentinel} || (touch ${sentinel} && exit 1)"`,
+        'on_error = "suspend"',
+      ].join("\n"),
+    );
+
+    const first = runCli(["run", project, "test suspend then resume"], {
+      MOCK_FIXTURE_PATH: join(FIXTURES_DIR, "complete-success.json"),
+    });
+    expect(first.status).toBe(0);
+
+    const runId = soleRunId(project);
+    const stateDir = stateDirOf(project, runId);
+    const suspendPath = join(stateDir, "suspend-state.json");
+    expect(existsSync(suspendPath)).toBe(true);
+    const suspendState = JSON.parse(readFileSync(suspendPath, "utf-8"));
+    expect(suspendState.phase).toBe("pre_iteration");
+    expect(suspendState.resumeIteration).toBe(1);
+
+    const resumeRes = runCli(
+      ["resume", runId],
+      { MOCK_FIXTURE_PATH: join(FIXTURES_DIR, "complete-success.json") },
+      project,
+    );
+
+    expect(resumeRes.status).toBe(0);
+    expect(resumeRes.stdout).toContain(`resumed ${runId} from iteration 1`);
+
+    // Resume clears durable suspend markers once it re-enters the loop.
+    expect(existsSync(suspendPath)).toBe(false);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     alias: {
       "@mobrienv/autoloop-core/config-schema": `${CORE}/config-schema.ts`,
       "@mobrienv/autoloop-core/config": `${CORE}/config.ts`,
+      "@mobrienv/autoloop-core/hooks-schema": `${CORE}/hooks-schema.ts`,
       "@mobrienv/autoloop-core/agent-map": `${CORE}/agent-map.ts`,
       "@mobrienv/autoloop-core/profiles": `${CORE}/profiles.ts`,
       "@mobrienv/autoloop-core/tasks-render": `${CORE}/tasks-render.ts`,
@@ -58,6 +59,8 @@ export default defineConfig({
       "@mobrienv/autoloop-harness/backend": `${HARNESS}/backend/index.ts`,
       "@mobrienv/autoloop-harness/wave/parse-objectives": `${HARNESS}/wave/parse-objectives.ts`,
       "@mobrienv/autoloop-harness/registry-bridge": `${HARNESS}/registry-bridge.ts`,
+      "@mobrienv/autoloop-harness/suspend-state": `${HARNESS}/suspend-state.ts`,
+      "@mobrienv/autoloop-harness/hooks": `${HARNESS}/hooks.ts`,
       "@mobrienv/autoloop-harness/pi-adapter": `${HARNESS}/pi-adapter.ts`,
       "@mobrienv/autoloop-harness/control/render": `${HARNESS}/control/render.ts`,
       "@mobrienv/autoloop-harness/control/types": `${HARNESS}/control/types.ts`,


### PR DESCRIPTION
## Summary

Implements a lifecycle hooks engine for autoloop, matching ralph v3 orchestration parity:

- Phase-anchored hook points (`pre_run`, `post_run`, `pre_iteration`, `post_iteration`, `pre_emit`, `post_emit`), configurable via a structured `[[hook]]` array-of-tables (`command`, `on_error`, `mutate`) alongside the existing flat `[hooks]` keys, which keep working unchanged.
- Per-hook error policies: `block` aborts the run, `warn` journals and continues (existing default behavior), `suspend` writes durable state and stops the run.
- Hook output mutation: a `pre_iteration` hook can rewrite the next prompt; a `pre_emit` hook can rewrite the topic/payload of an event before it's journaled.
- Durable suspend/resume: versioned `.autoloop/suspend-state.json` (`SUSPEND_STATE_SCHEMA_VERSION=1`) plus a `.autoloop/resume-requested` signal file. `autoloop resume` prefers the suspend state's recorded resume point; a fresh `run` refuses to start over an unresolved suspend in the same state dir.
- Because `emit` runs out-of-process (a fresh CLI invocation from the agent's tool script), `pre_emit`/`post_emit` hooks are driven from disk config rather than the live `LoopContext`; a `suspend` there writes state the harness detects at the next iteration boundary.
- New CLI commands: `autoloop hooks list|show|validate|clear-suspend`.
- New modules: `packages/core/src/hooks-schema.ts` (types/parser/validator) and `packages/harness/src/suspend-state.ts` (read/write/clear + resume polling).

Closes #38.

## Test plan
- [x] `packages/core/test/hooks-schema.test.ts` — parser merge (legacy + `[[hook]]`), validation errors, suspend-state type guard
- [x] `packages/harness/test/suspend-state.test.ts` — write/read/clear round-trip, versioned schema, resume signal, poll/timeout/abort
- [x] `test/integration/hooks-lifecycle.test.ts` — phase ordering, `on_error=block` aborts, `on_error=warn` continues, `mutate=prompt`/`mutate=event`
- [x] `test/integration/hooks-suspend-resume.test.ts` — suspend writes versioned state + journal, `hooks clear-suspend`, full suspend → `autoloop resume` → completion cycle
- [x] `test/integration/hooks-cli.test.ts` — `list`/`show`/`validate` (incl. non-zero exit)/`clear-suspend`, `--json` mode
- [x] Backward-compat: existing `test/integration/hooks.test.ts` (legacy flat `[hooks]` keys, strict mode) passes unchanged
- [x] Full suite: `npx vitest run` — 2024/2029 passing; the only failures (`install-hooks.test.ts`, needs a real `.git` dir the worktree lacks) are pre-existing/environmental, confirmed via a clean-baseline stash test

🤖 Generated with [Claude Code](https://claude.com/claude-code)