### PR TITLE
fix: contain configured prompt files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   compile time.
 
 ### Fixed
+- **Configured prompt files cannot escape their declared roots.** Objective,
+  review, harness-instruction, and topology role paths now reject parent
+  traversal and symlink escapes while preserving optional and explicitly empty
+  file semantics.
 - **Generated tool wrappers reliably re-invoke every CLI distribution.**
   Checkout builds now use the Node interpreter instead of asking `/bin/sh` to
   execute the ESM entry point, while standalone builds re-invoke their binary

--- a/docs/reference/topology.md
+++ b/docs/reference/topology.md
@@ -59,7 +59,7 @@ Each `[[role]]` table defines one role in the loop. Roles are processed in decla
 | `id` | string | Yes | Unique identifier for the role. Used in handoff maps and prompt rendering. |
 | `emits` | array of strings | Yes | Events this role is allowed to emit. Determines the allowed-event set for backpressure. |
 | `prompt` | string | No | Inline prompt text for this role. |
-| `prompt_file` | string | No | Path to a markdown file containing the role's prompt, relative to the project directory. |
+| `prompt_file` | string | No | Path to a markdown file containing the role's prompt, relative to the preset directory. Parent traversal and symlink escapes are rejected. |
 | `backend_kind` | string | No | Override the loop's `backend.kind` for iterations routed to this role. See [Per-role backend overrides](#per-role-backend-overrides). |
 | `backend_provider` | string | No | Override the ACP `backend.provider` preset for this role (`kiro`, `claude-agent-acp`, `generic`, or a custom label). |
 | `backend_command` | string | No | Override `backend.command` for this role's iterations. |

--- a/packages/core/src/contained-file.ts
+++ b/packages/core/src/contained-file.ts
@@ -1,0 +1,50 @@
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { relative, resolve, sep } from "node:path";
+
+/**
+ * Read an optional text file without allowing a config-supplied path or symlink
+ * to escape its declared root. Missing contained files remain optional; unsafe
+ * paths fail closed.
+ */
+export function readOptionalContainedFile(
+  rootDir: string,
+  configuredPath: string,
+  label = "configured file",
+): string {
+  return readContainedFileIfExists(rootDir, configuredPath, label) ?? "";
+}
+
+export function readContainedFileIfExists(
+  rootDir: string,
+  configuredPath: string,
+  label = "configured file",
+): string | undefined {
+  if (!configuredPath) return undefined;
+  const root = canonicalPath(rootDir);
+  const candidate = resolve(root, configuredPath);
+  assertWithin(candidate, root, label);
+
+  if (!existsSync(candidate)) return undefined;
+  const realCandidate = canonicalPath(candidate);
+  assertWithin(realCandidate, root, label);
+  return readFileSync(realCandidate, "utf-8");
+}
+
+function canonicalPath(path: string): string {
+  const absolute = resolve(path);
+  try {
+    return realpathSync.native(absolute);
+  } catch {
+    return absolute;
+  }
+}
+
+function assertWithin(candidate: string, root: string, label: string): void {
+  const rel = relative(root, candidate);
+  if (rel === "" || (!rel.startsWith(`..${sep}`) && rel !== "..")) return;
+  throw new Error(`${label} must stay within the ${rootLabel(label)}`);
+}
+
+function rootLabel(label: string): string {
+  return label === "prompt_file" ? "preset directory" : "project directory";
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@
 
 export * from "./bundled-presets.js";
 export * from "./color.js";
+export * from "./contained-file.js";
 export * from "./duration.js";
 export * from "./events/decode.js";
 export * from "./events/encode.js";

--- a/packages/core/src/topology.ts
+++ b/packages/core/src/topology.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import TOML from "@iarna/toml";
+import { readOptionalContainedFile } from "./contained-file.js";
 import type {
   FanoutKind,
   FanoutStage,
@@ -624,9 +625,7 @@ function rolePrompt(role: Role, projectDir: string): string {
 }
 
 function readPromptFile(projectDir: string, promptFile: string): string {
-  const fullPath = join(projectDir, promptFile);
-  if (!existsSync(fullPath)) return "";
-  return readFileSync(fullPath, "utf-8");
+  return readOptionalContainedFile(projectDir, promptFile, "prompt_file");
 }
 
 function collectMatchingRoles(topology: Topology, event: string): string[] {

--- a/packages/core/test/topology.test.ts
+++ b/packages/core/test/topology.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -618,6 +618,30 @@ describe("prompt_file support", () => {
     );
     const topo = loadTopology(dir);
     expect(topo.roles[0].prompt).toBe("Do something specific.");
+  });
+
+  it("rejects prompt files that escape through parent traversal", () => {
+    const dir = tmpDir("prompt-parent-escape");
+    writeFileSync(join(TMP_BASE, "outside.md"), "host-only instructions");
+    writeFileSync(
+      join(dir, "topology.toml"),
+      '[[role]]\nid = "worker"\nprompt_file = "../outside.md"\nemits = ["done"]\n',
+    );
+
+    expect(() => loadTopology(dir)).toThrow(/prompt_file.*within/i);
+  });
+
+  it("rejects prompt files that escape through a symlink", () => {
+    const dir = tmpDir("prompt-symlink-escape");
+    const outside = join(TMP_BASE, "outside-symlink.md");
+    writeFileSync(outside, "host-only instructions");
+    symlinkSync(outside, join(dir, "linked-prompt.md"));
+    writeFileSync(
+      join(dir, "topology.toml"),
+      '[[role]]\nid = "worker"\nprompt_file = "linked-prompt.md"\nemits = ["done"]\n',
+    );
+
+    expect(() => loadTopology(dir)).toThrow(/prompt_file.*within/i);
   });
 });
 

--- a/packages/harness/src/config-helpers.ts
+++ b/packages/harness/src/config-helpers.ts
@@ -15,6 +15,8 @@ import {
   expandTemplatePlaceholders,
   generateCompactId,
   generateReadableId,
+  readContainedFileIfExists,
+  readOptionalContainedFile,
   splitCsv,
   uniqueGeneratedId,
 } from "@mobrienv/autoloop-core";
@@ -75,8 +77,12 @@ export function resolvePrompt(
   if (inlinePrompt) return inlinePrompt;
   const promptFile = config.get(cfg, "event_loop.prompt_file", "");
   if (promptFile) {
-    const fullPath = join(projectDir, promptFile);
-    if (existsSync(fullPath)) return readFileSync(fullPath, "utf-8");
+    const prompt = readContainedFileIfExists(
+      projectDir,
+      promptFile,
+      "configured file",
+    );
+    if (prompt !== undefined) return prompt;
   }
   if (!existingPlanFile(options)) {
     const promptDir =
@@ -112,10 +118,7 @@ export function readOptionalProjectFile(
   projectDir: string,
   relativePath: string,
 ): string {
-  if (!relativePath) return "";
-  const fullPath = join(projectDir, relativePath);
-  if (!existsSync(fullPath)) return "";
-  return readFileSync(fullPath, "utf-8");
+  return readOptionalContainedFile(projectDir, relativePath, "configured file");
 }
 
 export function resolveReviewEvery(

--- a/packages/harness/test/harness/config-helpers.test.ts
+++ b/packages/harness/test/harness/config-helpers.test.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { put } from "@mobrienv/autoloop-core/config";
@@ -7,6 +13,7 @@ import {
   buildLoopContext,
   injectClaudePermissions,
   processIntOverride,
+  readOptionalProjectFile,
   reloadLoop,
   resolveProcessKind,
 } from "@mobrienv/autoloop-harness/config-helpers";
@@ -141,6 +148,42 @@ describe("injectClaudePermissions", () => {
   });
 });
 
+describe("readOptionalProjectFile", () => {
+  it("reads a file contained by the project", () => {
+    const projectDir = makeProject("event_loop.max_iterations = 1\n", {
+      files: { "roles/builder.md": "contained prompt\n" },
+    });
+
+    expect(readOptionalProjectFile(projectDir, "roles/builder.md")).toBe(
+      "contained prompt\n",
+    );
+  });
+
+  it("rejects parent traversal outside the project", () => {
+    const parent = mkdtempSync(join(tmpdir(), "autoloop-ts-file-parent-"));
+    const projectDir = join(parent, "project");
+    mkdirSync(projectDir);
+    writeFileSync(join(parent, "outside.md"), "host-only instructions\n");
+
+    expect(() => readOptionalProjectFile(projectDir, "../outside.md")).toThrow(
+      /must stay within the project directory/i,
+    );
+  });
+
+  it("rejects symlinks outside the project", () => {
+    const parent = mkdtempSync(join(tmpdir(), "autoloop-ts-file-link-"));
+    const projectDir = join(parent, "project");
+    mkdirSync(projectDir);
+    const outside = join(parent, "outside.md");
+    writeFileSync(outside, "host-only instructions\n");
+    symlinkSync(outside, join(projectDir, "prompt.md"));
+
+    expect(() => readOptionalProjectFile(projectDir, "prompt.md")).toThrow(
+      /must stay within the project directory/i,
+    );
+  });
+});
+
 describe("buildLoopContext", () => {
   it("rejects an unrecognized global backend kind", () => {
     const projectDir = makeProject(
@@ -252,6 +295,24 @@ describe("buildLoopContext", () => {
     });
 
     expect(loop.objective).toBe("Configured file prompt\n");
+  });
+
+  it("keeps an explicitly configured empty prompt_file authoritative", () => {
+    const projectDir = makeProject(
+      [
+        "event_loop.max_iterations = 1",
+        'event_loop.prompt_file = "empty.md"',
+      ].join("\n"),
+      { files: { "empty.md": "" } },
+    );
+    const workDir = mkdtempSync(join(tmpdir(), "autoloop-ts-prompt-work-"));
+    writeFileSync(join(workDir, "PROMPT.md"), "Root prompt\n");
+
+    const loop = buildLoopContext(projectDir, null, "node dist/main.js", {
+      workDir,
+    });
+
+    expect(loop.objective).toBe("");
   });
 
   it("does not replace an existing in-flight plan with work directory PROMPT.md", () => {


### PR DESCRIPTION
## Summary

- reject configured objective, review, harness-instruction, and topology role paths that traverse outside their declared root
- resolve symlinks before reading and reject targets outside the project or preset directory
- preserve missing-file fallbacks and explicitly configured empty prompt semantics

## Scope

This is the narrow path-containment portion split from closed PR #60. It makes no changes to backend process environments, provider startup, `PATH`, credentials, proxies, or toolchain inheritance.

## Verification

- `npm run check` — PASS: 2,231 passed, 4 skipped; coverage gate passed
- `npm run build` — PASS
- `npm run docs:build` — PASS
- focused topology/config-helper suite — 139 passed
- `git diff --cached --check` — PASS
- Husky/lint-staged pre-commit hook — PASS

Supersedes the configured-file portion of #60.
