### PR TITLE
feat: add opt-in backend environment policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [Unreleased]
 
 ### Added
+- **Backend environment hardening is available as an opt-in policy.** Existing
+  presets continue to inherit their process environment unchanged. Setting
+  `backend.environment_policy = "hardened"` (or the review-specific override)
+  removes process-injection and Git-authority variables, repository-owned or
+  relative `PATH` entries, and rejects credential-bearing proxy URLs.
 - **Standalone binaries provide a Node-free installation channel.** GitHub
   releases now attach Bun-compiled executables for macOS and Linux on arm64
   and x64, plus a `SHA256SUMS` file. `scripts/build-standalone.sh` builds all

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -90,6 +90,7 @@ Prompt resolution order: CLI prompt override > `event_loop.prompt` > `event_loop
 | `backend.profile` | string | `""` | Provider-side agent profile. For `provider = "hermes"`, launches as `hermes --profile <name> acp` to select which Hermes Agent profile runs the iteration. Empty means the Hermes default profile. Has no effect on other providers. |
 | `backend.disallowed_tools` | list (CSV) | `""` | **`claude-sdk` only.** Comma-separated tool names to remove from the agent entirely (e.g. `"WebFetch,WebSearch"`). A hard block that applies even under `bypassPermissions` (unlike deny rules). Empty by default, so other presets are unaffected. Used to force a preset onto a dedicated capture tool by removing the built-ins. |
 | `backend.usage_from` | string | `""` | **`command` only.** Opt-in cost-telemetry convention. Set to `"file"` to have the harness read a JSON usage object the wrapped command writes to `$AUTOLOOP_USAGE_FILE` before exiting. Empty (default) skips extraction entirely — no behavior change for existing presets. See [The `command` backend: cost telemetry and live control](#the-command-backend-cost-telemetry-and-live-control) below. |
+| `backend.environment_policy` | `"inherit"` or `"hardened"` | `"inherit"` | Process environment policy for command, ACP, Pi RPC, and Claude SDK children. `inherit` preserves the current environment exactly for backward compatibility. `hardened` removes process-injection and Git-authority variables, relative and project-owned `PATH` entries, and rejects credential-bearing proxy URLs. Enable only after confirming the provider and project toolchain do not depend on those values. |
 
 Kind auto-detection: if `kind` is empty, the harness checks whether `command` is or ends with `pi` (→ `"pi"`); then whether it is or ends with `claude` with no custom `args` (→ `"claude-sdk"`); otherwise `"command"`. Pin `kind = "command"` to force the legacy `claude -p` shell path. Use `kind = "acp"` for ACP providers, or the CLI aliases `-b claude-sdk`, `-b kiro`, `-b hermes[:profile]`, `-b claude-agent-acp`, or `-b acp:<provider>:<command>`. Unknown non-empty kinds fail during configuration resolution, including values supplied by `--set backend.kind=...` and per-role `backend_kind` overrides.
 
@@ -129,6 +130,7 @@ The review pass is a separate backend invocation that runs periodically for cons
 | `review.agent` | string | *backend.agent* | ACP session mode/agent for reviews. |
 | `review.model` | string | *backend.model* | Model ID for the review backend. |
 | `review.profile` | string | *backend.profile* | Hermes profile for the review backend (provider = `"hermes"`). |
+| `review.environment_policy` | `"inherit"` or `"hardened"` | *backend.environment_policy* | Optional review-specific environment policy. This allows a constrained reviewer without changing the primary implementation backend, or an inherited reviewer when the primary backend is hardened. |
 | `review.prompt` | string | `""` | Inline review prompt. If set, takes precedence over `prompt_file`. |
 | `review.prompt_file` | string | `"metareview.md"` | Path to the review prompt file, relative to the project directory. |
 

--- a/packages/backends/package.json
+++ b/packages/backends/package.json
@@ -31,6 +31,10 @@
       "types": "./dist/run-command.d.ts",
       "default": "./dist/run-command.js"
     },
+    "./environment": {
+      "types": "./dist/environment.d.ts",
+      "default": "./dist/environment.js"
+    },
     "./types": {
       "types": "./dist/types.d.ts",
       "default": "./dist/types.js"

--- a/packages/backends/src/acp-client.ts
+++ b/packages/backends/src/acp-client.ts
@@ -6,6 +6,10 @@ import {
   commandFloorDecision,
   extractCommandFromToolInput,
 } from "./command-risk.js";
+import {
+  type BackendEnvironmentPolicy,
+  resolveBackendEnvironment,
+} from "./environment.js";
 
 export interface AcpClientOptions {
   provider?: string;
@@ -18,6 +22,8 @@ export interface AcpClientOptions {
   verbose?: boolean;
   /** Deadline for the ACP handshake (default 30s). */
   handshakeTimeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
+  environmentPolicy?: BackendEnvironmentPolicy;
 }
 
 const DEFAULT_HANDSHAKE_TIMEOUT_MS = 30_000;
@@ -78,7 +84,10 @@ export async function initAcpSession(
   const child = spawn(opts.command, opts.args, {
     stdio: ["pipe", "pipe", "pipe"],
     cwd: opts.cwd,
-    env: process.env,
+    env: resolveBackendEnvironment(opts.env ?? process.env, {
+      projectDir: opts.cwd,
+      policy: opts.environmentPolicy,
+    }),
     detached: true, // create own process group so process.kill(-pid) in terminateAcpSession kills the full tree
   });
 

--- a/packages/backends/src/claude-sdk-client.ts
+++ b/packages/backends/src/claude-sdk-client.ts
@@ -13,6 +13,10 @@ import {
   commandFloorDecision,
   extractCommandFromToolInput,
 } from "./command-risk.js";
+import {
+  type BackendEnvironmentPolicy,
+  resolveBackendEnvironment,
+} from "./environment.js";
 
 export interface ClaudeSdkClientOptions {
   /** Path to the Claude Code executable when it isn't the bare `claude` on PATH. */
@@ -28,6 +32,7 @@ export interface ClaudeSdkClientOptions {
   /** How long a timed-out turn may drain after interrupt() before the session is abandoned (default 2s). */
   interruptGraceMs?: number;
   env?: Record<string, string | undefined>;
+  environmentPolicy?: BackendEnvironmentPolicy;
 }
 
 const DEFAULT_HANDSHAKE_TIMEOUT_MS = 30_000;
@@ -160,7 +165,10 @@ export async function initClaudeSdkSession(
   const options: Options = {
     cwd: opts.cwd,
     abortController,
-    env: opts.env ?? process.env,
+    env: resolveBackendEnvironment(opts.env ?? process.env, {
+      projectDir: opts.cwd,
+      policy: opts.environmentPolicy,
+    }),
     // Parity with the legacy `claude -p` shell backend: the Claude Code
     // system prompt and project settings (CLAUDE.md) stay loaded.
     systemPrompt: { type: "preset", preset: "claude_code" },

--- a/packages/backends/src/environment.ts
+++ b/packages/backends/src/environment.ts
@@ -1,0 +1,167 @@
+import { realpathSync } from "node:fs";
+import { delimiter, isAbsolute, relative, resolve, sep } from "node:path";
+
+export type BackendEnvironmentPolicy = "inherit" | "hardened";
+
+export interface BackendEnvironmentOptions {
+  /** Repository or isolated worktree whose executables must not shadow trusted tools. */
+  projectDir: string;
+}
+
+export interface ResolveBackendEnvironmentOptions
+  extends BackendEnvironmentOptions {
+  /** `inherit` preserves the process environment exactly; hardening is explicit. */
+  policy?: BackendEnvironmentPolicy;
+}
+
+/**
+ * Resolve the environment for a backend process without changing compatibility
+ * defaults. Existing callers inherit the exact object they supplied; only an
+ * explicit `hardened` policy invokes the sanitizer.
+ */
+export function resolveBackendEnvironment(
+  source: NodeJS.ProcessEnv,
+  options: ResolveBackendEnvironmentOptions,
+): NodeJS.ProcessEnv {
+  return options.policy === "hardened"
+    ? sanitizeBackendEnvironment(source, options)
+    : source;
+}
+
+const BLOCKED_EXACT = new Set([
+  "BASH_ENV",
+  "ENV",
+  "GCONV_PATH",
+  "JAVA_TOOL_OPTIONS",
+  "JDK_JAVA_OPTIONS",
+  "NODE_OPTIONS",
+  "NODE_PATH",
+  "PERL5LIB",
+  "PERL5OPT",
+  "PYTHONHOME",
+  "PYTHONPATH",
+  "RUBYLIB",
+  "RUBYOPT",
+  "SSLKEYLOGFILE",
+  "_JAVA_OPTIONS",
+  "GIT_ASKPASS",
+  "GIT_COMMON_DIR",
+  "GIT_CONFIG",
+  "GIT_CONFIG_COUNT",
+  "GIT_CONFIG_GLOBAL",
+  "GIT_CONFIG_NOSYSTEM",
+  "GIT_CONFIG_PARAMETERS",
+  "GIT_CONFIG_SYSTEM",
+  "GIT_DIR",
+  "GIT_EDITOR",
+  "GIT_EXEC_PATH",
+  "GIT_EXTERNAL_DIFF",
+  "GIT_INDEX_FILE",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_PAGER",
+  "GIT_PROXY_COMMAND",
+  "GIT_SEQUENCE_EDITOR",
+  "GIT_SSH",
+  "GIT_SSH_COMMAND",
+  "GIT_TEMPLATE_DIR",
+  "GIT_WORK_TREE",
+  "SSH_ASKPASS",
+]);
+
+const BLOCKED_PREFIXES = [
+  "BASH_FUNC_",
+  "DYLD_",
+  "LD_",
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  "GIT_CONFIG_KEY_",
+  "GIT_CONFIG_VALUE_",
+];
+
+const PROXY_KEYS = new Set(["ALL_PROXY", "HTTP_PROXY", "HTTPS_PROXY"]);
+
+/**
+ * Build the environment inherited by a model/backend process.
+ *
+ * General SDE agents still need ordinary project and toolchain variables, so
+ * this is deliberately a denylist rather than the review-only helper's tiny
+ * allowlist. The removed values are execution hooks or Git authority overrides
+ * that let an ambient checkout/session replace code run by the harness.
+ */
+export function sanitizeBackendEnvironment(
+  source: NodeJS.ProcessEnv,
+  options: BackendEnvironmentOptions,
+): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (value === undefined || blockedKey(key)) continue;
+    if (PROXY_KEYS.has(key.toUpperCase())) validateProxy(key, value);
+    env[key] = value;
+  }
+
+  if (env.PATH !== undefined) {
+    env.PATH = sanitizePath(env.PATH, options.projectDir);
+  }
+  return env;
+}
+
+function blockedKey(key: string): boolean {
+  const normalized = key.toUpperCase();
+  return (
+    BLOCKED_EXACT.has(normalized) ||
+    BLOCKED_PREFIXES.some((prefix) => normalized.startsWith(prefix))
+  );
+}
+
+function sanitizePath(value: string, projectDir: string): string {
+  const project = canonical(projectDir);
+  return value
+    .split(delimiter)
+    .filter((entry) => {
+      if (!entry || !isAbsolute(entry)) return false;
+      return !isWithin(canonical(entry), project);
+    })
+    .join(delimiter);
+}
+
+function canonical(path: string): string {
+  const absolute = resolve(path);
+  try {
+    return realpathSync.native(absolute);
+  } catch {
+    return absolute;
+  }
+}
+
+function isWithin(candidate: string, root: string): boolean {
+  const rel = relative(root, candidate);
+  return rel === "" || (!rel.startsWith(`..${sep}`) && rel !== "..");
+}
+
+function validateProxy(key: string, value: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(value.includes("://") ? value : `http://${value}`);
+  } catch {
+    throw new Error(`unsafe malformed proxy URL in ${key}`);
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error(`unsafe credential-bearing proxy URL in ${key}`);
+  }
+  if (
+    ![
+      "http:",
+      "https:",
+      "socks:",
+      "socks4:",
+      "socks4a:",
+      "socks5:",
+      "socks5h:",
+    ].includes(parsed.protocol) ||
+    !parsed.hostname ||
+    (parsed.pathname !== "" && parsed.pathname !== "/") ||
+    parsed.search !== "" ||
+    parsed.hash !== ""
+  ) {
+    throw new Error(`unsafe malformed proxy URL in ${key}`);
+  }
+}

--- a/packages/backends/src/index.ts
+++ b/packages/backends/src/index.ts
@@ -35,6 +35,15 @@ export {
   isCommandBearingTool,
   readSafetyAllowlist,
 } from "./command-risk.js";
+export type {
+  BackendEnvironmentOptions,
+  BackendEnvironmentPolicy,
+  ResolveBackendEnvironmentOptions,
+} from "./environment.js";
+export {
+  resolveBackendEnvironment,
+  sanitizeBackendEnvironment,
+} from "./environment.js";
 export type { BackendErrorClass } from "./error-class.js";
 export { classifyBackendError, isRetryableErrorClass } from "./error-class.js";
 export type {
@@ -199,8 +208,13 @@ export function runBackendCommand(
   providerKind: string,
   command: string,
   timeoutMs: number,
+  projectDir?: string,
+  environmentPolicy?: import("./environment.js").BackendEnvironmentPolicy,
 ): BackendRunResult {
-  return runShellCommand(providerKind, command, timeoutMs);
+  return runShellCommand(providerKind, command, timeoutMs, {
+    projectDir,
+    environmentPolicy,
+  });
 }
 
 /**
@@ -214,9 +228,15 @@ export function runBackendCommandAsync(
   command: string,
   timeoutMs: number,
   onSpawn?: (pid: number) => void,
+  projectDir?: string,
+  environmentPolicy?: import("./environment.js").BackendEnvironmentPolicy,
 ): Promise<BackendRunResult> {
-  return spawnShellCommand(providerKind, command, timeoutMs, (pid) =>
-    onSpawn?.(pid),
+  return spawnShellCommand(
+    providerKind,
+    command,
+    timeoutMs,
+    (pid) => onSpawn?.(pid),
+    { projectDir, environmentPolicy },
   );
 }
 

--- a/packages/backends/src/pi-rpc-client.ts
+++ b/packages/backends/src/pi-rpc-client.ts
@@ -1,5 +1,9 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { writeFileSync } from "node:fs";
+import {
+  type BackendEnvironmentPolicy,
+  resolveBackendEnvironment,
+} from "./environment.js";
 
 export interface PiClientOptions {
   command: string;
@@ -11,6 +15,8 @@ export interface PiClientOptions {
   handshakeTimeoutMs?: number;
   /** How long a timed-out turn may drain after `abort` before the session is reused (default 2s). */
   abortGraceMs?: number;
+  env?: NodeJS.ProcessEnv;
+  environmentPolicy?: BackendEnvironmentPolicy;
 }
 
 const DEFAULT_HANDSHAKE_TIMEOUT_MS = 30_000;
@@ -99,7 +105,10 @@ export async function initPiSession(opts: PiClientOptions): Promise<PiSession> {
   const child = spawn(opts.command, args, {
     stdio: ["pipe", "pipe", "pipe"],
     cwd: opts.cwd,
-    env: process.env,
+    env: resolveBackendEnvironment(opts.env ?? process.env, {
+      projectDir: opts.cwd,
+      policy: opts.environmentPolicy,
+    }),
     detached: true, // own process group so terminatePiSession can kill the full tree
   });
 

--- a/packages/backends/src/run-command.ts
+++ b/packages/backends/src/run-command.ts
@@ -1,6 +1,17 @@
 import { type ChildProcess, execSync, spawn } from "node:child_process";
 import { shellQuote, shellWords } from "@mobrienv/autoloop-core";
+import {
+  type BackendEnvironmentPolicy,
+  resolveBackendEnvironment,
+} from "./environment.js";
 import type { BackendRunResult } from "./types.js";
+
+export interface ShellCommandOptions {
+  projectDir?: string;
+  env?: NodeJS.ProcessEnv;
+  cwd?: string;
+  environmentPolicy?: BackendEnvironmentPolicy;
+}
 
 export function buildCommandInvocation(
   spec: { command: string; args: string[]; promptMode: string },
@@ -24,7 +35,13 @@ export function runShellCommand(
   providerKind: string,
   command: string,
   timeoutMs: number,
+  options: ShellCommandOptions = {},
 ): BackendRunResult {
+  const sourceEnv = options.env ?? process.env;
+  const env = resolveBackendEnvironment(sourceEnv, {
+    projectDir: options.projectDir ?? options.cwd ?? process.cwd(),
+    policy: options.environmentPolicy,
+  });
   try {
     const output = execSync(command, {
       encoding: "utf-8",
@@ -32,6 +49,8 @@ export function runShellCommand(
       stdio: ["pipe", "pipe", "inherit"],
       shell: "/bin/sh",
       maxBuffer: 100 * 1024 * 1024,
+      cwd: options.cwd,
+      env,
     });
     return {
       output: output ?? "",
@@ -89,7 +108,12 @@ export function spawnShellCommand(
   command: string,
   timeoutMs: number,
   onSpawn?: (pid: number, child: ChildProcess) => void,
+  options: ShellCommandOptions = {},
 ): Promise<BackendRunResult> {
+  const env = resolveBackendEnvironment(options.env ?? process.env, {
+    projectDir: options.projectDir ?? options.cwd ?? process.cwd(),
+    policy: options.environmentPolicy,
+  });
   return new Promise((resolve) => {
     // `detached: true` makes the child a process-group leader, so a timeout
     // kill can target the whole group (`-pid`) rather than only the `/bin/sh`
@@ -102,6 +126,8 @@ export function spawnShellCommand(
     const child = spawn("/bin/sh", ["-c", command], {
       stdio: ["pipe", "pipe", "inherit"],
       detached: true,
+      cwd: options.cwd,
+      env,
     });
     if (child.pid) onSpawn?.(child.pid, child);
 

--- a/packages/backends/src/types.ts
+++ b/packages/backends/src/types.ts
@@ -1,3 +1,5 @@
+import type { BackendEnvironmentPolicy } from "./environment.js";
+
 export interface BackendSpec {
   kind: string;
   provider?: string;
@@ -17,6 +19,8 @@ export interface BackendSpec {
   usageFrom?: string;
   /** Provider-side agent profile (Hermes: launches as `--profile <p> acp`). */
   profile?: string;
+  /** Process environment inheritance policy. Defaults to `inherit`. */
+  environmentPolicy?: BackendEnvironmentPolicy;
 }
 
 export interface BackendRunResult {

--- a/packages/backends/test/acp-session.test.ts
+++ b/packages/backends/test/acp-session.test.ts
@@ -142,6 +142,44 @@ describe("initAcpSession", () => {
     }
   });
 
+  it("sanitizes the environment passed to the ACP process", async () => {
+    const spawnFn = spawn as unknown as ReturnType<typeof vi.fn>;
+    await initAcpSession({
+      command: "kiro-cli",
+      args: ["--acp"],
+      cwd: "/tmp/project",
+      trustAllTools: true,
+      environmentPolicy: "hardened",
+      env: {
+        PATH: "/usr/bin:/tmp/project/bin",
+        NORMAL_PROJECT_FLAG: "enabled",
+        NODE_OPTIONS: "--require ./owned.js",
+      },
+    });
+
+    const options = spawnFn.mock.calls.at(-1)?.[2];
+    expect(options.env.NORMAL_PROJECT_FLAG).toBe("enabled");
+    expect(options.env.NODE_OPTIONS).toBeUndefined();
+    expect(options.env.PATH).toBe("/usr/bin");
+  });
+
+  it("inherits the ACP process environment when policy is omitted", async () => {
+    const spawnFn = spawn as unknown as ReturnType<typeof vi.fn>;
+    const env = {
+      PATH: "/usr/bin:/tmp/project/bin",
+      NODE_OPTIONS: "--require ./project-hook.js",
+    };
+    await initAcpSession({
+      command: "kiro-cli",
+      args: ["--acp"],
+      cwd: "/tmp/project",
+      trustAllTools: true,
+      env,
+    });
+
+    expect(spawnFn.mock.calls.at(-1)?.[2].env).toBe(env);
+  });
+
   it("resolves provider metadata from options and command", async () => {
     const session = await initAcpSession({
       provider: "claude-agent-acp",

--- a/packages/backends/test/claude-sdk-session.test.ts
+++ b/packages/backends/test/claude-sdk-session.test.ts
@@ -206,6 +206,33 @@ describe("initClaudeSdkSession", () => {
     expect(lastQuery.options.abortController).toBeInstanceOf(AbortController);
   });
 
+  it("sanitizes the environment passed to the SDK", async () => {
+    await startSession({
+      cwd: "/tmp/project",
+      environmentPolicy: "hardened",
+      env: {
+        PATH: "/usr/bin:/tmp/project/bin",
+        NORMAL_PROJECT_FLAG: "enabled",
+        GIT_CONFIG_COUNT: "1",
+      },
+    });
+
+    const env = lastQuery.options.env as Record<string, string>;
+    expect(env.NORMAL_PROJECT_FLAG).toBe("enabled");
+    expect(env.GIT_CONFIG_COUNT).toBeUndefined();
+    expect(env.PATH).toBe("/usr/bin");
+  });
+
+  it("inherits the SDK environment when policy is omitted", async () => {
+    const env = {
+      PATH: "/usr/bin:/tmp/project/bin",
+      NODE_OPTIONS: "--require ./project-hook.js",
+    };
+    await startSession({ cwd: "/tmp/project", env });
+
+    expect(lastQuery.options.env).toBe(env);
+  });
+
   it("keeps default permissions when tools are not trusted", async () => {
     await startSession({ trustAllTools: false });
     expect(lastQuery.options.permissionMode).toBeUndefined();

--- a/packages/backends/test/environment.test.ts
+++ b/packages/backends/test/environment.test.ts
@@ -1,0 +1,131 @@
+import { delimiter, join } from "node:path";
+import {
+  resolveBackendEnvironment,
+  sanitizeBackendEnvironment,
+} from "@mobrienv/autoloop-backends/environment";
+import { describe, expect, it } from "vitest";
+
+describe("sanitizeBackendEnvironment", () => {
+  it("removes process injection and Git override variables", () => {
+    const env = sanitizeBackendEnvironment(
+      {
+        PATH: "/usr/bin:/bin",
+        HOME: "/home/agent",
+        NORMAL_PROJECT_FLAG: "enabled",
+        NODE_OPTIONS: "--require ./owned.js",
+        node_path: "./case-insensitive-owned-node-path",
+        PYTHONPATH: "./owned-python",
+        LD_PRELOAD: "/tmp/owned.so",
+        LD_AUDIT: "/tmp/owned-audit.so",
+        LD_DEBUG: "all",
+        DYLD_INSERT_LIBRARIES: "/tmp/owned.dylib",
+        "BASH_FUNC_owned%%": "() { echo injected; }",
+        GIT_CONFIG_COUNT: "1",
+        GIT_CONFIG_PARAMETERS: "'alias.pwn=!echo injected'",
+        GIT_CONFIG_KEY_0: "core.sshCommand",
+        GIT_CONFIG_VALUE_0: "./owned-ssh",
+        GIT_EXTERNAL_DIFF: "./owned-diff",
+        GIT_SSH: "./owned-ssh-legacy",
+        GIT_PAGER: "./owned-pager",
+        GIT_EDITOR: "./owned-editor",
+        GIT_SEQUENCE_EDITOR: "./owned-sequence-editor",
+        GIT_SSH_COMMAND: "./owned-ssh",
+      },
+      { projectDir: "/workspace/project" },
+    );
+
+    expect(env.NORMAL_PROJECT_FLAG).toBe("enabled");
+    expect(env.HOME).toBe("/home/agent");
+    expect(env.NODE_OPTIONS).toBeUndefined();
+    expect(env.node_path).toBeUndefined();
+    expect(env.PYTHONPATH).toBeUndefined();
+    expect(env.LD_PRELOAD).toBeUndefined();
+    expect(env.LD_AUDIT).toBeUndefined();
+    expect(env.LD_DEBUG).toBeUndefined();
+    expect(env.DYLD_INSERT_LIBRARIES).toBeUndefined();
+    expect(env["BASH_FUNC_owned%%"]).toBeUndefined();
+    expect(env.GIT_CONFIG_COUNT).toBeUndefined();
+    expect(env.GIT_CONFIG_PARAMETERS).toBeUndefined();
+    expect(env.GIT_CONFIG_KEY_0).toBeUndefined();
+    expect(env.GIT_CONFIG_VALUE_0).toBeUndefined();
+    expect(env.GIT_EXTERNAL_DIFF).toBeUndefined();
+    expect(env.GIT_SSH).toBeUndefined();
+    expect(env.GIT_PAGER).toBeUndefined();
+    expect(env.GIT_EDITOR).toBeUndefined();
+    expect(env.GIT_SEQUENCE_EDITOR).toBeUndefined();
+    expect(env.GIT_SSH_COMMAND).toBeUndefined();
+  });
+
+  it("removes relative and repository-owned PATH entries", () => {
+    const projectDir = "/workspace/project";
+    const env = sanitizeBackendEnvironment(
+      {
+        PATH: [
+          ".",
+          "bin",
+          join(projectDir, "node_modules", ".bin"),
+          "/usr/local/bin",
+          "/usr/bin",
+        ].join(delimiter),
+      },
+      { projectDir },
+    );
+
+    expect(env.PATH?.split(delimiter)).toEqual(["/usr/local/bin", "/usr/bin"]);
+  });
+
+  it("rejects credential-bearing proxy URLs instead of forwarding them", () => {
+    expect(() =>
+      sanitizeBackendEnvironment(
+        {
+          PATH: "/usr/bin",
+          HTTPS_PROXY: "https://user:secret@proxy.example:8443",
+        },
+        { projectDir: "/workspace/project" },
+      ),
+    ).toThrow(/credential-bearing proxy/i);
+  });
+
+  it("preserves credential-free proxy URLs", () => {
+    const env = sanitizeBackendEnvironment(
+      {
+        PATH: "/usr/bin",
+        HTTPS_PROXY: "https://proxy.example:8443",
+        NO_PROXY: "localhost,127.0.0.1",
+      },
+      { projectDir: "/workspace/project" },
+    );
+
+    expect(env.HTTPS_PROXY).toBe("https://proxy.example:8443");
+    expect(env.NO_PROXY).toBe("localhost,127.0.0.1");
+  });
+});
+
+describe("resolveBackendEnvironment", () => {
+  it("inherits the exact source environment by default", () => {
+    const source = {
+      PATH: "/workspace/project/node_modules/.bin:/usr/bin",
+      NODE_OPTIONS: "--require ./project-hook.js",
+      GIT_SSH_COMMAND: "ssh -i ./project-key",
+      HTTPS_PROXY: "https://user:secret@proxy.example:8443",
+    };
+
+    expect(
+      resolveBackendEnvironment(source, {
+        projectDir: "/workspace/project",
+      }),
+    ).toBe(source);
+  });
+
+  it("sanitizes only when hardened is explicit", () => {
+    const env = resolveBackendEnvironment(
+      {
+        PATH: "/workspace/project/node_modules/.bin:/usr/bin",
+        NODE_OPTIONS: "--require ./project-hook.js",
+      },
+      { projectDir: "/workspace/project", policy: "hardened" },
+    );
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.NODE_OPTIONS).toBeUndefined();
+  });
+});

--- a/packages/backends/test/pi-rpc-session.test.ts
+++ b/packages/backends/test/pi-rpc-session.test.ts
@@ -130,6 +130,35 @@ describe("initPiSession", () => {
     expect(lastChild.sent[0]).toMatchObject({ type: "get_state" });
   });
 
+  it("sanitizes the environment passed to the Pi process", async () => {
+    const spawnFn = spawn as unknown as ReturnType<typeof vi.fn>;
+    await startSession({
+      cwd: "/tmp/project",
+      environmentPolicy: "hardened",
+      env: {
+        PATH: "/usr/bin:/tmp/project/bin",
+        NORMAL_PROJECT_FLAG: "enabled",
+        PYTHONPATH: "./owned-python",
+      },
+    });
+
+    const options = spawnFn.mock.calls.at(-1)?.[2];
+    expect(options.env.NORMAL_PROJECT_FLAG).toBe("enabled");
+    expect(options.env.PYTHONPATH).toBeUndefined();
+    expect(options.env.PATH).toBe("/usr/bin");
+  });
+
+  it("inherits the Pi process environment when policy is omitted", async () => {
+    const spawnFn = spawn as unknown as ReturnType<typeof vi.fn>;
+    const env = {
+      PATH: "/usr/bin:/tmp/project/bin",
+      PYTHONPATH: "./project-python",
+    };
+    await startSession({ cwd: "/tmp/project", env });
+
+    expect(spawnFn.mock.calls.at(-1)?.[2].env).toBe(env);
+  });
+
   it("rejects when the process dies before the handshake completes", async () => {
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
     (globalThis as any).__piAutoRespond = false;

--- a/packages/backends/test/run-command.test.ts
+++ b/packages/backends/test/run-command.test.ts
@@ -71,6 +71,40 @@ describe("buildCommandInvocation", () => {
 });
 
 describe("spawnShellCommand", () => {
+  it("inherits caller environment by default", async () => {
+    const result = await spawnShellCommand(
+      "command",
+      `printf '%s' "$NODE_OPTIONS"`,
+      5000,
+      undefined,
+      {
+        projectDir: "/tmp/project",
+        env: { PATH: process.env.PATH, NODE_OPTIONS: "project-hook" },
+      },
+    );
+    expect(result.output).toBe("project-hook");
+  });
+
+  it("sanitizes caller environment only under hardened policy", async () => {
+    const result = await spawnShellCommand(
+      "command",
+      `printf '%s:%s' "\${NODE_OPTIONS-unset}" "\${LD_AUDIT-unset}"; bash -c 'if declare -F owned >/dev/null; then printf ":injected"; else printf ":unset"; fi'`,
+      5000,
+      undefined,
+      {
+        projectDir: "/tmp/project",
+        environmentPolicy: "hardened",
+        env: {
+          PATH: process.env.PATH,
+          NODE_OPTIONS: "project-hook",
+          LD_AUDIT: "/definitely-not-present-autoloop-audit.so",
+          "BASH_FUNC_owned%%": "() { echo injected; }",
+        },
+      },
+    );
+    expect(result.output).toBe("unset:unset:unset");
+  });
+
   it("resolves normally on a fast-exiting command", async () => {
     const result = await spawnShellCommand("command", "echo hello", 5000);
     expect(result.exitCode).toBe(0);

--- a/packages/cli/src/chains/load.ts
+++ b/packages/cli/src/chains/load.ts
@@ -26,6 +26,7 @@ const ALLOWED_BACKEND_OVERRIDE_KEYS = new Set([
   "agent",
   "model",
   "profile",
+  "environment_policy",
 ]);
 
 export function load(projectDir: string): ChainsConfig {

--- a/packages/core/src/config-schema.ts
+++ b/packages/core/src/config-schema.ts
@@ -60,6 +60,8 @@ export function defaults(): Config {
       // all optional) after each iteration. Empty = no extraction attempted
       // (default; existing presets are unaffected).
       usage_from: "",
+      // Child environments are inherited unchanged unless explicitly hardened.
+      environment_policy: "inherit",
     },
     parallel: {
       enabled: "false",

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -43,6 +43,21 @@ describe("load", () => {
     expect(get(cfg, "backend.usage_from", "unset")).toBe("");
   });
 
+  it("defaults backend.environment_policy to inherit", () => {
+    const cfg = load("/nonexistent/path/autoloops.toml");
+    expect(get(cfg, "backend.environment_policy", "unset")).toBe("inherit");
+  });
+
+  it("parses an explicit hardened backend environment policy", () => {
+    const dir = tmpDir("environment-policy");
+    writeFileSync(
+      join(dir, "config.toml"),
+      '[backend]\nenvironment_policy = "hardened"\n',
+    );
+    const cfg = load(join(dir, "config.toml"));
+    expect(get(cfg, "backend.environment_policy", "")).toBe("hardened");
+  });
+
   it("parses backend.usage_from from a preset without breaking other keys", () => {
     const dir = tmpDir("usage-from");
     writeFileSync(

--- a/packages/harness/src/backend/types.ts
+++ b/packages/harness/src/backend/types.ts
@@ -1,3 +1,4 @@
+import type { BackendEnvironmentPolicy } from "@mobrienv/autoloop-backends";
 import type { LoopContext } from "../types.js";
 
 export interface ResolvedIterationBackend {
@@ -13,6 +14,7 @@ export interface ResolvedIterationBackend {
   profile: string;
   disallowedTools: string[];
   usageFrom: string;
+  environmentPolicy: BackendEnvironmentPolicy;
 }
 
 export function resolvedFromLoopBackend(
@@ -31,5 +33,6 @@ export function resolvedFromLoopBackend(
     profile: loop.backend.profile ?? "",
     disallowedTools: [...(loop.backend.disallowedTools ?? [])],
     usageFrom: loop.backend.usageFrom ?? "",
+    environmentPolicy: loop.backend.environmentPolicy ?? "inherit",
   };
 }

--- a/packages/harness/src/config-helpers.ts
+++ b/packages/harness/src/config-helpers.ts
@@ -871,6 +871,13 @@ function readBackendConfig(
     "usage_from",
     config.get(cfg, "backend.usage_from", ""),
   );
+  const environmentPolicy = normalizeEnvironmentPolicy(
+    processStringOverride(
+      bo,
+      "environment_policy",
+      config.get(cfg, "backend.environment_policy", "inherit"),
+    ),
+  );
   return {
     kind,
     provider,
@@ -884,6 +891,7 @@ function readBackendConfig(
     profile,
     disallowedTools,
     usageFrom,
+    environmentPolicy,
   };
 }
 
@@ -923,6 +931,13 @@ function readReviewConfig(
     agent: config.get(cfg, "review.agent", backend.agent),
     model: config.get(cfg, "review.model", backend.model),
     profile: config.get(cfg, "review.profile", backend.profile ?? ""),
+    environmentPolicy: normalizeEnvironmentPolicy(
+      config.get(
+        cfg,
+        "review.environment_policy",
+        backend.environmentPolicy ?? "inherit",
+      ),
+    ),
     onError: normalizeReviewOnError(config.get(cfg, "review.on_error", "hold")),
     minConfidence: config.getFloat(cfg, "review.min_confidence", 0.5),
   };
@@ -935,6 +950,14 @@ function readReviewConfig(
 function normalizeReviewOnError(raw: string): ReviewOnError {
   const v = raw.trim().toLowerCase();
   return v === "exit" || v === "continue" ? v : "hold";
+}
+
+function normalizeEnvironmentPolicy(raw: string): "inherit" | "hardened" {
+  const value = raw.trim().toLowerCase();
+  if (value === "inherit" || value === "hardened") return value;
+  throw new Error(
+    `invalid environment policy ${JSON.stringify(raw)}; expected "inherit" or "hardened"`,
+  );
 }
 
 function readParallelConfig(cfg: config.Config): LoopContext["parallel"] {

--- a/packages/harness/src/iteration.ts
+++ b/packages/harness/src/iteration.ts
@@ -194,6 +194,7 @@ export async function runIteration(
       agentName: iter.backend.agent || undefined,
       modelId: iter.backend.model || undefined,
       verbose: loop.runtime.logLevel === "debug",
+      environmentPolicy: iter.backend.environmentPolicy,
     };
     loop.acpSession.current = await initAcpSession(acpOpts);
     log(
@@ -231,6 +232,7 @@ export async function runIteration(
       trustAllTools: iter.backend.trustAllTools,
       disallowedTools: iter.backend.disallowedTools,
       verbose: loop.runtime.logLevel === "debug",
+      environmentPolicy: iter.backend.environmentPolicy,
     });
     log(
       loop,
@@ -403,6 +405,8 @@ async function runBackendIteration(
     (pid) => {
       loop.commandSession.current = { pid };
     },
+    loop.paths.workDir,
+    iter.backend.environmentPolicy,
   );
   loop.commandSession.current = undefined;
   if (iter.backend.kind === "command") {
@@ -566,6 +570,7 @@ async function ensurePiSession(
     cwd: loop.paths.workDir,
     modelId: iter.backend.model || undefined,
     verbose: loop.runtime.logLevel === "debug",
+    environmentPolicy: iter.backend.environmentPolicy,
   });
   log(
     loop,

--- a/packages/harness/src/metareview.ts
+++ b/packages/harness/src/metareview.ts
@@ -150,6 +150,8 @@ export async function runMetareviewReview(
               buildReviewCommand(loop, iteration, reviewPrompt),
               loop.review.timeoutMs,
               loop.review.kind,
+              loop.paths.workDir,
+              loop.review.environmentPolicy,
             );
 
   appendEvent(
@@ -270,6 +272,7 @@ async function runPiReview(
     cwd: loop.paths.workDir,
     modelId: loop.review.model || undefined,
     verbose: loop.runtime.logLevel === "debug",
+    environmentPolicy: loop.review.environmentPolicy,
   });
   try {
     return await runPiIteration(
@@ -305,6 +308,7 @@ async function runClaudeSdkReview(
     cwd: loop.paths.workDir,
     trustAllTools: loop.review.trustAllTools,
     verbose: loop.runtime.logLevel === "debug",
+    environmentPolicy: loop.review.environmentPolicy,
   });
   try {
     return await runClaudeSdkIteration(
@@ -339,6 +343,7 @@ async function runAcpReview(
     agentName: loop.review.agent || undefined,
     modelId: loop.review.model || undefined,
     verbose: loop.runtime.logLevel === "debug",
+    environmentPolicy: loop.review.environmentPolicy,
   });
   try {
     return await runAcpIteration(session, reviewPrompt, loop.review.timeoutMs);

--- a/packages/harness/src/parallel.ts
+++ b/packages/harness/src/parallel.ts
@@ -1,5 +1,6 @@
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
+import type { BackendEnvironmentPolicy } from "@mobrienv/autoloop-backends";
 import {
   buildBackendShellCommand,
   normalizeBackendLabel,
@@ -165,8 +166,16 @@ export function runProcess(
   command: string,
   timeoutMs: number,
   providerKind = "command",
+  projectDir?: string,
+  environmentPolicy?: BackendEnvironmentPolicy,
 ): ProcessResult {
-  const result = runBackendCommand(providerKind, command, timeoutMs);
+  const result = runBackendCommand(
+    providerKind,
+    command,
+    timeoutMs,
+    projectDir,
+    environmentPolicy,
+  );
   return {
     output: result.output,
     exitCode: result.exitCode,
@@ -186,9 +195,16 @@ export function runProcessAsync(
   timeoutMs: number,
   providerKind = "command",
   onSpawn?: (pid: number) => void,
+  projectDir?: string,
+  environmentPolicy?: BackendEnvironmentPolicy,
 ): Promise<ProcessResult> {
-  return runBackendCommandAsync(providerKind, command, timeoutMs, (pid) =>
-    onSpawn?.(pid),
+  return runBackendCommandAsync(
+    providerKind,
+    command,
+    timeoutMs,
+    (pid) => onSpawn?.(pid),
+    projectDir,
+    environmentPolicy,
   ).then((result) => ({
     output: result.output,
     exitCode: result.exitCode,

--- a/packages/harness/src/parallel.ts
+++ b/packages/harness/src/parallel.ts
@@ -39,6 +39,8 @@ export interface BranchLaunch {
   backendArgs: string[];
   backendPromptMode: string;
   backendTimeoutMs: number;
+  /** Exact parent environment policy applied again by the child backend. */
+  backendEnvironmentPolicy: BackendEnvironmentPolicy;
   /** Parent-side wall-clock deadline used to clamp this child iteration. */
   branchTimeoutMs: number;
   logLevel: string;
@@ -63,6 +65,9 @@ export function loadParallelBranchLaunch(branchDir: string): BranchLaunch {
     backendPromptMode: extractField(line, "backend_prompt_mode"),
     backendTimeoutMs:
       Number.parseInt(extractField(line, "backend_timeout_ms"), 10) || 0,
+    backendEnvironmentPolicy: branchEnvironmentPolicy(
+      extractField(line, "backend_environment_policy"),
+    ),
     branchTimeoutMs:
       Number.parseInt(extractField(line, "branch_timeout_ms"), 10) || 0,
     logLevel: extractField(line, "log_level"),
@@ -113,7 +118,15 @@ export function parallelBranchBackendOverride(
   if (launch.backendPromptMode) override.prompt_mode = launch.backendPromptMode;
   if (launch.backendTimeoutMs > 0)
     override.timeout_ms = launch.backendTimeoutMs;
+  if (launch.backendEnvironmentPolicy === "hardened")
+    override.environment_policy = "hardened";
   return override;
+}
+
+function branchEnvironmentPolicy(value: string): BackendEnvironmentPolicy {
+  if (!value) return "inherit";
+  if (value === "inherit" || value === "hardened") return value;
+  throw new Error(`unknown branch backend environment policy: ${value}`);
 }
 
 export function writeParallelBranchSummary(

--- a/packages/harness/src/types.ts
+++ b/packages/harness/src/types.ts
@@ -1,3 +1,4 @@
+import type { BackendEnvironmentPolicy } from "@mobrienv/autoloop-backends";
 import type { AcpSession } from "@mobrienv/autoloop-backends/acp-client";
 import type { ClaudeSdkSession } from "@mobrienv/autoloop-backends/claude-sdk-client";
 import type { PiSession } from "@mobrienv/autoloop-backends/pi-rpc-client";
@@ -170,6 +171,7 @@ export interface LoopContext {
      * `$AUTOLOOP_USAGE_FILE`. Empty disables extraction (default).
      */
     usageFrom: string;
+    environmentPolicy?: BackendEnvironmentPolicy;
   };
   review: {
     enabled: boolean;
@@ -186,6 +188,7 @@ export interface LoopContext {
     agent: string;
     model: string;
     profile?: string;
+    environmentPolicy?: BackendEnvironmentPolicy;
     /**
      * Fail-closed routing for an UNKNOWN verdict (malformed/empty/timed-out
      * review, or confidence below `minConfidence`). Default `hold`: stop the

--- a/packages/harness/src/wave/launch-branches.ts
+++ b/packages/harness/src/wave/launch-branches.ts
@@ -282,6 +282,11 @@ export function writeBranchLaunch(spec: BranchSpec, loop: LoopContext): void {
     ", " +
     jsonField("backend_timeout_ms", String(loop.backend.timeoutMs)) +
     ", " +
+    jsonField(
+      "backend_environment_policy",
+      loop.backend.environmentPolicy ?? "inherit",
+    ) +
+    ", " +
     jsonField("branch_timeout_ms", String(loop.parallel.branchTimeoutMs)) +
     ", " +
     jsonField("log_level", loop.runtime.logLevel) +

--- a/packages/harness/src/wave/launch-branches.ts
+++ b/packages/harness/src/wave/launch-branches.ts
@@ -113,7 +113,13 @@ function launchBranch(loop: LoopContext, spec: BranchSpec): BranchSpec {
     `rm -f ${shellQuote(spec.stdoutFile)} ${shellQuote(spec.stderrFile)} ${shellQuote(spec.statusFile)} ${shellQuote(spec.pidFile)} ; ` +
     `nohup sh ${shellQuote(spec.supervisorFile)} >/dev/null 2>&1 & printf '%s' "$!" > ${shellQuote(spec.pidFile)}`;
 
-  runProcess(cmd, 10000);
+  runProcess(
+    cmd,
+    10000,
+    "command",
+    loop.paths.workDir,
+    loop.backend.environmentPolicy,
+  );
   const launched = { ...spec, launchMs };
   const pid = readIfExists(spec.pidFile).trim();
   if (!pid) recordLaunchFailure(launched);

--- a/packages/harness/test/harness/config-helpers.test.ts
+++ b/packages/harness/test/harness/config-helpers.test.ts
@@ -318,6 +318,43 @@ describe("buildLoopContext", () => {
     expect(loop.policy.fileModAudit).toBe(false);
   });
 
+  it("inherits backend environments by default", () => {
+    const projectDir = makeProject("event_loop.max_iterations = 1\n");
+    const loop = buildLoopContext(projectDir, null, "node dist/main.js", {
+      workDir: projectDir,
+    });
+
+    expect(loop.backend.environmentPolicy).toBe("inherit");
+    expect(loop.review.environmentPolicy).toBe("inherit");
+  });
+
+  it("supports explicit backend hardening with an independent review override", () => {
+    const projectDir = makeProject(
+      [
+        "event_loop.max_iterations = 1",
+        'backend.environment_policy = "hardened"',
+        'review.environment_policy = "inherit"',
+      ].join("\n"),
+    );
+    const loop = buildLoopContext(projectDir, null, "node dist/main.js", {
+      workDir: projectDir,
+    });
+
+    expect(loop.backend.environmentPolicy).toBe("hardened");
+    expect(loop.review.environmentPolicy).toBe("inherit");
+  });
+
+  it("rejects unknown backend environment policies", () => {
+    const projectDir = makeProject(
+      'event_loop.max_iterations = 1\nbackend.environment_policy = "strict-ish"\n',
+    );
+    expect(() =>
+      buildLoopContext(projectDir, null, "node dist/main.js", {
+        workDir: projectDir,
+      }),
+    ).toThrow(/invalid environment policy/i);
+  });
+
   it("reads event_loop.completion_must_be_last and event_loop.audit_file_mods from TOML", () => {
     const projectDir = makeProject(
       [

--- a/packages/harness/test/harness/iteration.test.ts
+++ b/packages/harness/test/harness/iteration.test.ts
@@ -398,6 +398,7 @@ describe("runIteration pi RPC execution", () => {
       cwd: loop.paths.workDir,
       modelId: "gpt-5",
       verbose: false,
+      environmentPolicy: "inherit",
     });
     expect(piMocks.runPiIteration).toHaveBeenCalledWith(
       fakeSession,

--- a/packages/harness/test/harness/parallel.test.ts
+++ b/packages/harness/test/harness/parallel.test.ts
@@ -60,6 +60,7 @@ describe("parallelBranchBackendOverride", () => {
     backendArgs: [],
     backendPromptMode: "",
     backendTimeoutMs: 0,
+    backendEnvironmentPolicy: "inherit",
     branchTimeoutMs: 0,
     logLevel: "info",
     presetFile: "",
@@ -110,6 +111,7 @@ describe("parallelBranchBackendOverride", () => {
       backendCommand: "claude",
       backendArgs: ["--fast"],
       backendPromptMode: "pipe",
+      backendEnvironmentPolicy: "hardened",
     };
     expect(parallelBranchBackendOverride(launch)).toEqual({
       kind: "command",
@@ -117,6 +119,7 @@ describe("parallelBranchBackendOverride", () => {
       command: "claude",
       args: ["--fast"],
       prompt_mode: "pipe",
+      environment_policy: "hardened",
     });
   });
 });
@@ -148,6 +151,7 @@ describe("parallel branch launch context", () => {
         args: [],
         promptMode: "arg",
         timeoutMs: 1_500_000,
+        environmentPolicy: "hardened",
       },
       runtime: { logLevel: "info" },
       launch: { presetFile },
@@ -159,15 +163,35 @@ describe("parallel branch launch context", () => {
 
     expect(launch.presetFile).toBe(presetFile);
     expect(launch.backendTimeoutMs).toBe(1_500_000);
+    expect(launch.backendEnvironmentPolicy).toBe("hardened");
     expect(launch.branchTimeoutMs).toBe(1_500_000);
     expect(parallelBranchRunOptions(launch, branchDir)).toMatchObject({
       workDir: branchDir,
       presetFile,
       noWorktree: true,
       trigger: "branch",
-      backendOverride: { timeout_ms: 1_500_000 },
+      backendOverride: {
+        timeout_ms: 1_500_000,
+        environment_policy: "hardened",
+      },
       configOverride: { parallel: { branch_timeout_ms: "1500000" } },
     });
+  });
+
+  it("defaults legacy branch payloads to inherit and rejects unknown policies", () => {
+    const root = mkdtempSync(join(tmpdir(), "autoloop-branch-policy-"));
+    writeFileSync(join(root, "launch.json"), '{"branch_id": "legacy"}\n');
+    expect(loadParallelBranchLaunch(root).backendEnvironmentPolicy).toBe(
+      "inherit",
+    );
+
+    writeFileSync(
+      join(root, "launch.json"),
+      '{"branch_id": "invalid", "backend_environment_policy": "strict-ish"}\n',
+    );
+    expect(() => loadParallelBranchLaunch(root)).toThrow(
+      /unknown branch backend environment policy/i,
+    );
   });
 });
 

--- a/packages/harness/test/harness/prompt-backend.test.ts
+++ b/packages/harness/test/harness/prompt-backend.test.ts
@@ -151,6 +151,7 @@ describe("buildIterationContext backend resolution (slice 2)", () => {
       profile: "",
       disallowedTools: [],
       usageFrom: "",
+      environmentPolicy: "inherit",
     });
     expect(iter.backendModel).toBe("");
     expect(iter.backendAgent).toBe(iter.roleAgent);
@@ -198,6 +199,7 @@ describe("resolvedFromLoopBackend", () => {
       profile: "",
       disallowedTools: [],
       usageFrom: "",
+      environmentPolicy: "inherit",
     });
     expect(resolved.args).not.toBe(loop.backend.args);
   });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
       "@mobrienv/autoloop-backends/claude-sdk-client": `${BACKENDS}/claude-sdk-client.ts`,
       "@mobrienv/autoloop-backends/pi-rpc-client": `${BACKENDS}/pi-rpc-client.ts`,
       "@mobrienv/autoloop-backends/run-command": `${BACKENDS}/run-command.ts`,
+      "@mobrienv/autoloop-backends/environment": `${BACKENDS}/environment.ts`,
       "@mobrienv/autoloop-backends/types": `${BACKENDS}/types.ts`,
       "@mobrienv/autoloop-backends": `${BACKENDS}/index.ts`,
       "@mobrienv/autoloop-harness/backend/acp-client": `${HARNESS}/backend/acp-client.ts`,


### PR DESCRIPTION
## Summary

- add `backend.environment_policy` and `review.environment_policy` with two explicit values: `inherit` and `hardened`
- preserve existing environment inheritance as the default and return the original environment object unchanged unless hardening is explicitly enabled
- apply opted-in hardening consistently to command, ACP, Pi RPC, Claude SDK, metareview, and wave-launch execution paths
- remove runtime-injection variables, Git authority overrides, project-owned `PATH` entries, and credential-bearing proxy URLs only under the hardened policy
- preserve ordinary project variables, provider credentials, trusted system `PATH` entries, and credential-free proxies
- reject unknown policy values instead of silently weakening a requested policy

## Compatibility boundary

This PR does **not** enable hardening in any bundled preset. Existing configurations continue to use `inherit`, which preserves the source environment unchanged. Operators must explicitly set:

```toml
[backend]
environment_policy = "hardened"
```

Review backends may opt in independently with `review.environment_policy`.

## Verification

- `npm run check` — 2,244 passed, 4 skipped; TypeScript and coverage passed
- `npm run build` — passed
- clean-cache `npm run docs:build` — passed
- focused backend/config/harness policy tests — passed
- installed `@mobrienv/autoloop-backends` tarball smoke — package export, default object-identity inheritance, and hardened removal behavior passed
- bundled-preset scan — no preset enables `environment_policy`
- `git diff --cached --check` — passed

## Evidence limitation

No authenticated real-provider compatibility smoke was run. ACP, Pi RPC, and Claude SDK adapter tests use mocked process/SDK seams, while command tests execute local `/bin/sh`. Accordingly, this PR exposes an opt-in capability only; it does not claim that the hardened policy is compatible with every provider, version manager, proxy, or local toolchain.

## Supersedes

This is the compatibility-safe environment-policy replacement for the environment portion of #60. Configured-file containment is split into #61.
