### PR TITLE
fix(dashboard): prevent POST /runs spawn crash

### DIFF
--- a/packages/dashboard/src/routes/api.ts
+++ b/packages/dashboard/src/routes/api.ts
@@ -46,6 +46,54 @@ export function buildRunsPayload(
   return result;
 }
 
+export function splitSelfCommand(selfCmd: string): string[] {
+  const words: string[] = [];
+  let word = "";
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+  let started = false;
+
+  for (const char of selfCmd) {
+    if (escaped) {
+      word += char;
+      escaped = false;
+      started = true;
+      continue;
+    }
+    if (char === "\\" && quote !== "'") {
+      escaped = true;
+      started = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) quote = null;
+      else word += char;
+      started = true;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      started = true;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (started) {
+        words.push(word);
+        word = "";
+        started = false;
+      }
+      continue;
+    }
+    word += char;
+    started = true;
+  }
+
+  if (escaped || quote) throw new Error("invalid self command quoting");
+  if (started) words.push(word);
+  if (words.length === 0 || !words[0]) throw new Error("self command is empty");
+  return words;
+}
+
 export function apiRoutes(ctx: DashboardContext): Hono {
   const api = new Hono();
 
@@ -219,10 +267,14 @@ export function apiRoutes(ctx: DashboardContext): Hono {
     }
     args.push(prompt);
 
-    const child = spawn(ctx.selfCmd.replace(/'/g, ""), args, {
+    const [command, ...commandArgs] = splitSelfCommand(ctx.selfCmd);
+    const child = spawn(command, [...commandArgs, ...args], {
       cwd: ctx.projectDir,
       detached: true,
       stdio: "ignore",
+    });
+    child.once("error", (error) => {
+      console.error(`Failed to spawn dashboard run: ${error.message}`);
     });
     child.unref();
 

--- a/packages/dashboard/test/api-spawn.test.ts
+++ b/packages/dashboard/test/api-spawn.test.ts
@@ -1,0 +1,93 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawn: spawnMock,
+}));
+
+import type { DashboardContext } from "../src/app.js";
+import { createApp } from "../src/app.js";
+
+function makeCtx(selfCmd: string): DashboardContext {
+  const projectDir = mkdtempSync(join(tmpdir(), "dashboard-api-spawn-test-"));
+  const stateDir = join(projectDir, ".autoloop");
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(join(stateDir, "registry.jsonl"), "", "utf-8");
+  writeFileSync(join(stateDir, "journal.jsonl"), "", "utf-8");
+  return {
+    registryPath: join(stateDir, "registry.jsonl"),
+    journalPath: join(stateDir, "journal.jsonl"),
+    stateDir,
+    bundleRoot: projectDir,
+    projectDir,
+    selfCmd,
+    listPresets: () => [],
+  };
+}
+
+function fakeChild(): ChildProcess {
+  const child = new EventEmitter() as ChildProcess;
+  Object.assign(child, { pid: 12345, unref: vi.fn() });
+  return child;
+}
+
+describe("POST /api/runs process launch", () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+    spawnMock.mockReturnValue(fakeChild());
+  });
+
+  it("keeps the dashboard alive when the child process cannot start", async () => {
+    const child = fakeChild();
+    spawnMock.mockReturnValue(child);
+    const errorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const app = createApp(makeCtx("/missing/autoloop"));
+
+    const response = await app.request("/api/runs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: "build a widget" }),
+    });
+
+    expect(response.status).toBe(202);
+    expect(() => child.emit("error", new Error("spawn failed"))).not.toThrow();
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Failed to spawn dashboard run: spawn failed",
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("passes a quoted node command as executable plus entrypoint argument", async () => {
+    const ctx = makeCtx(
+      "'/opt/Node Runtime/bin/node' '/opt/Auto Loop/bin/autoloop.js'",
+    );
+    const app = createApp(ctx);
+
+    const response = await app.request("/api/runs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: "build a widget" }),
+    });
+
+    expect(response.status).toBe(202);
+    expect(spawnMock).toHaveBeenCalledWith(
+      "/opt/Node Runtime/bin/node",
+      ["/opt/Auto Loop/bin/autoloop.js", "run", "build a widget"],
+      {
+        cwd: ctx.projectDir,
+        detached: true,
+        stdio: "ignore",
+      },
+    );
+  });
+});

--- a/packages/dashboard/test/pages.test.ts
+++ b/packages/dashboard/test/pages.test.ts
@@ -378,6 +378,7 @@ describe("POST /api/runs input validation", () => {
         ...orig,
         spawn: vi.fn(() => ({
           pid: 12345,
+          once: vi.fn(),
           unref: vi.fn(),
         })),
       };


### PR DESCRIPTION
## Summary

- parse the internally generated quoted `selfCmd` into an executable plus preserved argv before calling `spawn()`
- keep `shell: false` semantics rather than evaluating a command string
- consume asynchronous child-process `error` events so an `ENOENT` cannot terminate the dashboard server
- cover both quoted paths containing spaces and child launch failures

## Root cause

The dashboard removed quote characters and passed the resulting full command string as `spawn()`'s executable. For source runs this produced a value such as:

```text
/path/to/node /path/to/packages/cli/src/main.ts
```

Node treated that entire string as a filesystem path, emitted `ENOENT`, and the unhandled child `error` event crashed the process.

## Verification

- `npm run build`
- `npm run check` — 2,227 passed, 4 skipped
- focused dashboard route tests — 42 passed
- compiled live smoke:
  - quoted Node executable and entrypoint paths launched with argv `['run', 'smoke prompt']`
  - real `ENOENT` was logged and a subsequent dashboard request returned HTTP 200

Closes #59
