### PR TITLE
fix: harden Ultra generated workflows

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -164,7 +164,7 @@ export async function dispatchRun(
     process.on("SIGTERM", onSig);
 
     try {
-      await harness.run(
+      const runResult = await harness.run(
         options.projectDir,
         normalizePrompt(options.prompt),
         selfCmd,
@@ -177,6 +177,8 @@ export async function dispatchRun(
           ...chainableOptions(options),
         },
       );
+      propagateRunStopStatus(runResult);
+      if (runResult?.stopReason === "error") return true;
     } finally {
       process.removeListener("SIGINT", onSig);
       process.removeListener("SIGTERM", onSig);
@@ -232,7 +234,11 @@ async function runGeneratedPreset(
     return;
   }
   process.stderr.write(`\narchitect: running generated preset ${file}\n\n`);
-  await harness.run(
+  const effectiveConfig = config.loadProjectFromFile(file, {
+    workDir: options.workDir || undefined,
+    cliOverride: options.configOverride,
+  });
+  const runResult = await harness.run(
     dirname(file),
     normalizePrompt(options.architectObjective ?? null),
     selfCmd,
@@ -240,10 +246,66 @@ async function runGeneratedPreset(
       presetFile: file,
       workDir: options.workDir,
       backendOverride: options.backendOverride,
+      configOverride: generatedPresetConfigOverride(
+        options.configOverride,
+        options.ultra === true,
+        effectiveConfig,
+      ),
       logLevel: options.logLevel,
       onEvent,
     },
   );
+  propagateRunStopStatus(runResult);
+}
+
+function propagateRunStopStatus(
+  result: { stopReason?: string } | null | undefined,
+): void {
+  if (result?.stopReason === "error") process.exitCode = 1;
+}
+
+/**
+ * Ultra fan-out branches routinely need several minutes for repository-scale
+ * analysis. Keep standard architect behavior unchanged, preserve any operator
+ * override (including the legacy namespace), and otherwise grant 25 minutes.
+ */
+export function generatedPresetConfigOverride(
+  overrides: Record<string, unknown>,
+  ultra: boolean,
+  effectiveConfig: Record<string, unknown> = {},
+): Record<string, unknown> {
+  if (!ultra) return overrides;
+  const minimumMs = 1_500_000;
+  let result = overrides;
+  const explicitStageTimeout =
+    config.get(overrides, "stage_runtime.branch_timeout_ms", "") ||
+    config.get(overrides, "stage.branch_timeout_ms", "");
+  const effectiveStageTimeout = config.getInt(
+    effectiveConfig,
+    "stage_runtime.branch_timeout_ms",
+    config.getInt(effectiveConfig, "stage.branch_timeout_ms", 0),
+  );
+  if (!explicitStageTimeout && effectiveStageTimeout < minimumMs) {
+    result = config.put(
+      result,
+      "stage_runtime.branch_timeout_ms",
+      String(minimumMs),
+    );
+  }
+  const explicitBackendTimeout = config.get(
+    overrides,
+    "backend.timeout_ms",
+    "",
+  );
+  const effectiveBackendTimeout = config.getInt(
+    effectiveConfig,
+    "backend.timeout_ms",
+    0,
+  );
+  if (!explicitBackendTimeout && effectiveBackendTimeout < minimumMs) {
+    result = config.put(result, "backend.timeout_ms", String(minimumMs));
+  }
+  return result;
 }
 
 export function parseRunArgs(args: string[], bundleRoot: string): RunOptions {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -177,8 +177,7 @@ export async function dispatchRun(
           ...chainableOptions(options),
         },
       );
-      propagateRunStopStatus(runResult);
-      if (runResult?.stopReason === "error") return true;
+      if (propagateRunStopStatus(runResult)) return true;
     } finally {
       process.removeListener("SIGINT", onSig);
       process.removeListener("SIGTERM", onSig);
@@ -258,10 +257,26 @@ async function runGeneratedPreset(
   propagateRunStopStatus(runResult);
 }
 
+const FAILURE_STOP_REASONS = new Set([
+  "backend_failed",
+  "backend_timeout",
+  "auth_failed",
+  "quota_exhausted",
+  "rate_limited",
+  "transient_error",
+  "review_unknown",
+  "parallel_wave_timeout",
+  "parallel_wave_failed",
+  "parallel_wave_invalid",
+  "error",
+]);
+
 function propagateRunStopStatus(
   result: { stopReason?: string } | null | undefined,
-): void {
-  if (result?.stopReason === "error") process.exitCode = 1;
+): boolean {
+  const failed = FAILURE_STOP_REASONS.has(result?.stopReason ?? "");
+  if (failed) process.exitCode = 1;
+  return failed;
 }
 
 /**

--- a/packages/cli/test/architect-brief.test.ts
+++ b/packages/cli/test/architect-brief.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { architectBrief } from "../src/commands/run.js";
+import {
+  architectBrief,
+  generatedPresetConfigOverride,
+} from "../src/commands/run.js";
 
 describe("architectBrief", () => {
   it("includes the objective, standard intensity, the output path, and no-ceiling note", () => {
@@ -19,5 +22,41 @@ describe("architectBrief", () => {
     expect(brief).toContain("intensity=ultra");
     expect(brief).toContain("$5.00");
     expect(brief).toContain("hard ceiling");
+  });
+});
+
+describe("generatedPresetConfigOverride", () => {
+  it("gives Ultra stage branches enough wall-clock time by default", () => {
+    expect(generatedPresetConfigOverride({}, true)).toEqual({
+      stage_runtime: { branch_timeout_ms: "1500000" },
+      backend: { timeout_ms: "1500000" },
+    });
+  });
+
+  it("does not alter standard runs or override new and legacy explicit timeouts", () => {
+    expect(generatedPresetConfigOverride({}, false)).toEqual({});
+    const explicit = { stage_runtime: { branch_timeout_ms: "2100000" } };
+    expect(generatedPresetConfigOverride(explicit, true)).toEqual({
+      ...explicit,
+      backend: { timeout_ms: "1500000" },
+    });
+    const legacy = { stage: { branch_timeout_ms: "900000" } };
+    expect(generatedPresetConfigOverride(legacy, true)).toEqual({
+      ...legacy,
+      backend: { timeout_ms: "1500000" },
+    });
+    const explicitBackend = { backend: { timeout_ms: "900000" } };
+    expect(generatedPresetConfigOverride(explicitBackend, true)).toEqual({
+      ...explicitBackend,
+      stage_runtime: { branch_timeout_ms: "1500000" },
+    });
+  });
+
+  it("does not lower longer timeouts already present in the generated preset", () => {
+    const effective = {
+      stage_runtime: { branch_timeout_ms: "2100000" },
+      backend: { timeout_ms: "2100000" },
+    };
+    expect(generatedPresetConfigOverride({}, true, effective)).toEqual({});
   });
 });

--- a/packages/cli/test/commands/run-backend-override.test.ts
+++ b/packages/cli/test/commands/run-backend-override.test.ts
@@ -78,20 +78,60 @@ describe("applyGlobalBackendOverride", () => {
     });
   });
 
-  it("propagates a failed loop result to process exit status", async () => {
+  it.each([
+    "backend_failed",
+    "backend_timeout",
+    "auth_failed",
+    "quota_exhausted",
+    "rate_limited",
+    "transient_error",
+    "review_unknown",
+    "parallel_wave_timeout",
+    "parallel_wave_failed",
+    "parallel_wave_invalid",
+    "error",
+  ])("propagates %s to process exit status", async (stopReason) => {
     const targetDir = tmpDir("target-failed-loop");
     writeFileSync(
       join(targetDir, "autoloops.toml"),
       "[event_loop]\nmax_iterations = 1\n",
     );
     runSpy.mockResolvedValue({
-      stopReason: "error",
+      stopReason,
       iterations: 1,
     });
 
     await dispatchRun([targetDir, "review"], [], targetDir, "autoloop");
 
     expect(process.exitCode).toBe(1);
+  });
+
+  it.each([
+    "completed",
+    "completion_event",
+    "completion_promise",
+    "max_iterations",
+    "stalled",
+    "cost_budget",
+    "max_runtime",
+    "premature_quit",
+    "interrupted",
+    "suspended",
+    "verdict_exit",
+    "verdict_takeover",
+    "verdict_unknown",
+    "completion_held",
+  ])("leaves controlled stop %s at exit zero", async (stopReason) => {
+    const targetDir = tmpDir("target-controlled-stop");
+    writeFileSync(
+      join(targetDir, "autoloops.toml"),
+      "[event_loop]\nmax_iterations = 1\n",
+    );
+    runSpy.mockResolvedValue({ stopReason, iterations: 1 });
+
+    await dispatchRun([targetDir, "review"], [], targetDir, "autoloop");
+
+    expect(process.exitCode).toBeUndefined();
   });
 
   it("maps -b claude-agent-acp to the npm ACP adapter", async () => {

--- a/packages/cli/test/commands/run-backend-override.test.ts
+++ b/packages/cli/test/commands/run-backend-override.test.ts
@@ -38,6 +38,11 @@ function tmpDir(name: string): string {
 beforeEach(() => {
   mkdirSync(TMP_BASE, { recursive: true });
   vi.clearAllMocks();
+  process.exitCode = undefined;
+  runSpy.mockResolvedValue({
+    stopReason: "completed",
+    iterations: 1,
+  });
 });
 
 afterEach(() => {
@@ -71,6 +76,22 @@ describe("applyGlobalBackendOverride", () => {
       args: ["acp"],
       prompt_mode: "acp",
     });
+  });
+
+  it("propagates a failed loop result to process exit status", async () => {
+    const targetDir = tmpDir("target-failed-loop");
+    writeFileSync(
+      join(targetDir, "autoloops.toml"),
+      "[event_loop]\nmax_iterations = 1\n",
+    );
+    runSpy.mockResolvedValue({
+      stopReason: "error",
+      iterations: 1,
+    });
+
+    await dispatchRun([targetDir, "review"], [], targetDir, "autoloop");
+
+    expect(process.exitCode).toBe(1);
   });
 
   it("maps -b claude-agent-acp to the npm ACP adapter", async () => {

--- a/packages/harness/src/config-helpers.ts
+++ b/packages/harness/src/config-helpers.ts
@@ -959,13 +959,21 @@ function normalizeAggregateMode(
 }
 
 function readStageConfig(cfg: config.Config): LoopContext["stage"] {
+  // `stage` is also the TOML array-of-tables name for fan-out topology. A
+  // single-file preset therefore cannot legally contain both `[[stage]]` and a
+  // `[stage]` runtime table. Prefer the collision-free namespace while keeping
+  // the legacy keys as fallbacks for directory presets.
   return {
     concurrency: config.getInt(
       cfg,
-      "stage.concurrency",
-      concurrency.defaultConcurrency(),
+      "stage_runtime.concurrency",
+      config.getInt(cfg, "stage.concurrency", concurrency.defaultConcurrency()),
     ),
-    branchTimeoutMs: config.getInt(cfg, "stage.branch_timeout_ms", 180000),
+    branchTimeoutMs: config.getInt(
+      cfg,
+      "stage_runtime.branch_timeout_ms",
+      config.getInt(cfg, "stage.branch_timeout_ms", 180000),
+    ),
   };
 }
 

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -54,7 +54,7 @@ import {
   appendLoopStart,
   branchStopReason,
   loadParallelBranchLaunch,
-  parallelBranchBackendOverride,
+  parallelBranchRunOptions,
   renderBranchResult,
   seedBranchContext,
   writeParallelBranchSummary,
@@ -468,14 +468,12 @@ export async function runParallelBranchCli(
   const launch = loadParallelBranchLaunch(branchDir);
   const branchPrompt = launch.prompt;
   const routingEvent = launch.routingEvent || "loop.start";
-  const backendOverride = parallelBranchBackendOverride(launch);
-  const logLevelVal = launch.logLevel || null;
-  let branchLoop = buildLoopContext(projectDir, branchPrompt, selfCommand, {
-    workDir: branchDir,
-    backendOverride,
-    logLevel: logLevelVal,
-    trigger: "branch",
-  });
+  let branchLoop = buildLoopContext(
+    projectDir,
+    branchPrompt,
+    selfCommand,
+    parallelBranchRunOptions(launch, branchDir),
+  );
   branchLoop.onEvent = onEvent;
   branchLoop = initStore(branchLoop);
   branchLoop.runtime.branchMode = true;

--- a/packages/harness/src/metareview.ts
+++ b/packages/harness/src/metareview.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   classifyBackendError,
@@ -93,10 +93,43 @@ export async function maybeRunMetareview(
   iteration: number,
 ): Promise<LoopContext> {
   if (shouldRunMetareview(loop, iteration)) {
+    const presetFile = loop.launch.presetFile || "";
+    const presetBefore =
+      presetFile && existsSync(presetFile)
+        ? readFileSync(presetFile, "utf8")
+        : null;
     const verdict = await runMetareviewReview(loop, iteration);
-    const reloaded = reloadLoop(loop);
-    reloaded.lastVerdict = verdict;
-    return reloaded;
+    try {
+      const reloaded = reloadLoop(loop);
+      reloaded.lastVerdict = verdict;
+      return reloaded;
+    } catch (error: unknown) {
+      const presetChanged =
+        presetBefore !== null &&
+        (!existsSync(presetFile) ||
+          readFileSync(presetFile, "utf8") !== presetBefore);
+      if (!presetChanged) throw error;
+
+      writeFileSync(presetFile, presetBefore);
+      const reason =
+        error instanceof Error
+          ? error.message
+          : String(error ?? "unknown error");
+      appendEvent(
+        loop.paths.journalFile,
+        loop.runtime.runId,
+        String(iteration),
+        "review.preset.rollback",
+        jsonField("preset_file", presetFile) +
+          ", " +
+          jsonField("reason", reason),
+      );
+      const restored = reloadLoop(loop);
+      restored.lastVerdict = unknownVerdict(
+        `Metareview produced an invalid preset; edit rolled back: ${reason}`,
+      );
+      return restored;
+    }
   }
   return loop;
 }

--- a/packages/harness/src/parallel.ts
+++ b/packages/harness/src/parallel.ts
@@ -22,7 +22,7 @@ import {
   readIfExists,
 } from "@mobrienv/autoloop-core/journal";
 import type { IterationContext } from "./prompt.js";
-import type { LoopContext } from "./types.js";
+import type { LoopContext, RunOptions } from "./types.js";
 
 export interface BranchLaunch {
   branchId: string;
@@ -37,7 +37,12 @@ export interface BranchLaunch {
   backendCommand: string;
   backendArgs: string[];
   backendPromptMode: string;
+  backendTimeoutMs: number;
+  /** Parent-side wall-clock deadline used to clamp this child iteration. */
+  branchTimeoutMs: number;
   logLevel: string;
+  /** Exact topology/config file used by the parent, including generated presets. */
+  presetFile: string;
 }
 
 export function loadParallelBranchLaunch(branchDir: string): BranchLaunch {
@@ -55,7 +60,38 @@ export function loadParallelBranchLaunch(branchDir: string): BranchLaunch {
     backendCommand: extractField(line, "backend_command"),
     backendArgs: csvFieldList(line, "backend_args"),
     backendPromptMode: extractField(line, "backend_prompt_mode"),
+    backendTimeoutMs:
+      Number.parseInt(extractField(line, "backend_timeout_ms"), 10) || 0,
+    branchTimeoutMs:
+      Number.parseInt(extractField(line, "branch_timeout_ms"), 10) || 0,
     logLevel: extractField(line, "log_level"),
+    presetFile: extractField(line, "preset_file"),
+  };
+}
+
+/** Build child options without silently falling back to the project's default preset. */
+export function parallelBranchRunOptions(
+  launch: BranchLaunch,
+  branchDir: string,
+): RunOptions {
+  return {
+    workDir: branchDir,
+    presetFile: launch.presetFile || undefined,
+    backendOverride: parallelBranchBackendOverride(launch),
+    configOverride:
+      launch.branchTimeoutMs > 0
+        ? {
+            parallel: {
+              branch_timeout_ms: String(launch.branchTimeoutMs),
+            },
+          }
+        : undefined,
+    logLevel: launch.logLevel || null,
+    trigger: "branch",
+    // A branch intentionally shares its parent's checkout. Its state remains
+    // isolated under branchDir, so nested worktree selection is both noisy and
+    // incorrect here.
+    noWorktree: true,
   };
 }
 
@@ -74,6 +110,8 @@ export function parallelBranchBackendOverride(
   if (launch.backendCommand) override.command = launch.backendCommand;
   if (launch.backendArgs.length > 0) override.args = launch.backendArgs;
   if (launch.backendPromptMode) override.prompt_mode = launch.backendPromptMode;
+  if (launch.backendTimeoutMs > 0)
+    override.timeout_ms = launch.backendTimeoutMs;
   return override;
 }
 

--- a/packages/harness/src/stage.ts
+++ b/packages/harness/src/stage.ts
@@ -6,9 +6,10 @@
 // path once the stage has finished.
 
 import { jsonField } from "@mobrienv/autoloop-core";
-import type {
-  BranchResult as FanoutBranchResult,
-  FanoutStage,
+import {
+  type BranchResult as FanoutBranchResult,
+  type FanoutStage,
+  reduceStage,
 } from "@mobrienv/autoloop-core/fanout";
 import {
   appendEvent,
@@ -18,11 +19,11 @@ import {
   readRunLines,
 } from "@mobrienv/autoloop-core/journal";
 import { runCostUsd } from "./display.js";
-import type { BranchRunner, BranchSpec } from "./fanout-runner.js";
-import { expandStageBranches, runFanoutStage } from "./fanout-runner.js";
+import type { BranchSpec } from "./fanout-runner.js";
+import { expandStageBranches } from "./fanout-runner.js";
 import type { IterationContext } from "./prompt.js";
 import type { LoopContext, RunSummary } from "./types.js";
-import { buildStageBranchRunner } from "./wave/stage-branch-runner.js";
+import { runStageBranchBatch } from "./wave/stage-branch-runner.js";
 
 type IterateFn = (loop: LoopContext, iteration: number) => Promise<RunSummary>;
 
@@ -136,22 +137,27 @@ export async function finishStageIteration(
   const toAdmit = specs.filter((s) => !resumed.has(s.branchId));
   const admitted = admitByBudget(loop, iter, toAdmit);
 
-  const baseRunner = buildStageBranchRunner(loop, iter, stage.id);
-  const runner: BranchRunner = async (spec) => {
+  const concurrency = Math.max(1, loop.stage?.concurrency || 1);
+  const fresh = await runStageBranchBatch(
+    loop,
+    iter,
+    stage.id,
+    toAdmit.filter((spec) => admitted.has(spec.branchId)),
+    concurrency,
+  );
+  const freshById = new Map(fresh.map((result) => [result.branchId, result]));
+  const results: FanoutBranchResult[] = specs.map((spec) => {
     const cached = resumed.get(spec.branchId);
     if (cached) return cached;
-    if (!admitted.has(spec.branchId)) {
-      return {
-        branchId: spec.branchId,
-        ok: false,
-        error: "budget: not admitted this wave",
-      };
-    }
-    return baseRunner(spec);
-  };
-
-  const concurrency = Math.max(1, loop.stage?.concurrency || 1);
-  const outcome = await runFanoutStage(stage, runner, concurrency);
+    const live = freshById.get(spec.branchId);
+    if (live) return live;
+    return {
+      branchId: spec.branchId,
+      ok: false,
+      error: "budget: not admitted this wave",
+    };
+  });
+  const outcome = reduceStage(stage, results);
 
   appendEvent(
     loop.paths.journalFile,

--- a/packages/harness/src/wave/launch-branches.ts
+++ b/packages/harness/src/wave/launch-branches.ts
@@ -274,7 +274,13 @@ export function writeBranchLaunch(spec: BranchSpec, loop: LoopContext): void {
     ", " +
     jsonField("backend_prompt_mode", loop.backend.promptMode) +
     ", " +
-    jsonField("log_level", loop.runtime.logLevel);
+    jsonField("backend_timeout_ms", String(loop.backend.timeoutMs)) +
+    ", " +
+    jsonField("branch_timeout_ms", String(loop.parallel.branchTimeoutMs)) +
+    ", " +
+    jsonField("log_level", loop.runtime.logLevel) +
+    ", " +
+    jsonField("preset_file", loop.launch.presetFile || "");
   writeFileSync(spec.launchFile, `{${fields}}\n`);
 }
 

--- a/packages/harness/src/wave/stage-branch-runner.ts
+++ b/packages/harness/src/wave/stage-branch-runner.ts
@@ -54,84 +54,130 @@ export function buildStageBranchRunner(
   iter: IterationContext,
   stageId: string,
 ): BranchRunner {
-  const stageDir = stageBranchesDir(loop, stageId);
-  mkdirSync(stageDir, { recursive: true });
+  return async (spec: StageSpec): Promise<FanoutBranchResult> =>
+    (await runStageBranchBatch(loop, iter, stageId, [spec], 1))[0];
+}
 
-  return async (spec: StageSpec): Promise<FanoutBranchResult> => {
-    const branchDir = join(stageDir, spec.branchId);
-    mkdirSync(branchDir, { recursive: true });
-
-    const role = loop.topology.roles.find((r) => r.id === spec.role);
-    const prompt = renderStageBranchPrompt(loop, spec, role);
-
-    const waveSpec: WaveBranchSpec = {
-      branchId: spec.branchId,
-      waveId: stageId,
-      objective: spec.objective,
-      emittedTopic: stageId,
-      routingEvent: spec.role,
-      allowedRoles: role ? [role.id] : [],
-      allowedEvents: role?.emits ?? [],
-      prompt,
-      branchDir,
-      launchFile: join(branchDir, "launch.json"),
-      summaryFile: join(branchDir, "summary.json"),
-      stdoutFile: join(branchDir, "stdout.log"),
-      stderrFile: join(branchDir, "stderr.log"),
-      statusFile: join(branchDir, "status.txt"),
-      pidFile: join(branchDir, "pid.txt"),
-      supervisorFile: join(branchDir, "supervisor.sh"),
-      launchMs: 0,
-    };
-
-    writeBranchLaunch(waveSpec, loop);
-    appendStageBranchStart(loop, iter, stageId, spec);
-    const [launched] = launchParallelBranches(loop, [waveSpec]);
-    const { results } = joinParallelBranches(
-      loop,
+/**
+ * Launch each concurrency window as a group before entering the synchronous
+ * poller. Calling the old one-branch runner through `mapLimit` serialized in
+ * practice because its poll loop blocked the event loop before sibling tasks
+ * could spawn.
+ */
+export async function runStageBranchBatch(
+  loop: LoopContext,
+  iter: IterationContext,
+  stageId: string,
+  specs: StageSpec[],
+  concurrency: number,
+): Promise<FanoutBranchResult[]> {
+  const results: FanoutBranchResult[] = [];
+  const width = Math.max(1, concurrency);
+  const executionLoop: LoopContext = {
+    ...loop,
+    parallel: {
+      ...loop.parallel,
+      branchTimeoutMs:
+        loop.stage?.branchTimeoutMs ?? loop.parallel.branchTimeoutMs,
+    },
+  };
+  for (let offset = 0; offset < specs.length; offset += width) {
+    const chunk = specs.slice(offset, offset + width);
+    const waveSpecs = chunk.map((spec) => makeWaveSpec(loop, stageId, spec));
+    for (let index = 0; index < chunk.length; index += 1) {
+      writeBranchLaunch(waveSpecs[index], executionLoop);
+      appendStageBranchStart(loop, iter, stageId, chunk[index]);
+    }
+    const launched = launchParallelBranches(executionLoop, waveSpecs);
+    const joined = joinParallelBranches(
+      executionLoop,
       iter,
       stageId,
-      [launched],
+      launched,
       { mode: "wait_for_all", timeoutMs: 0 },
       Date.now(),
     );
-    const result = results[0];
-    if (!result) {
-      const branchResult: FanoutBranchResult = {
+    for (const spec of chunk) {
+      const result = joined.results.find(
+        (candidate) => candidate.branchId === spec.branchId,
+      );
+      const branchResult = mapStageBranchResult(spec, result);
+      appendStageBranchFinish(
+        loop,
+        iter,
+        stageId,
+        branchResult,
+        result?.elapsedMs ?? 0,
+      );
+      results.push(branchResult);
+    }
+  }
+  return results;
+}
+
+function makeWaveSpec(
+  loop: LoopContext,
+  stageId: string,
+  spec: StageSpec,
+): WaveBranchSpec {
+  const stageDir = stageBranchesDir(loop, stageId);
+  const branchDir = join(stageDir, spec.branchId);
+  mkdirSync(branchDir, { recursive: true });
+  const role = loop.topology.roles.find(
+    (candidate) => candidate.id === spec.role,
+  );
+  return {
+    branchId: spec.branchId,
+    waveId: stageId,
+    objective: spec.objective,
+    emittedTopic: stageId,
+    routingEvent: spec.role,
+    allowedRoles: role ? [role.id] : [],
+    allowedEvents: role?.emits ?? [],
+    prompt: renderStageBranchPrompt(loop, spec, role),
+    branchDir,
+    launchFile: join(branchDir, "launch.json"),
+    summaryFile: join(branchDir, "summary.json"),
+    stdoutFile: join(branchDir, "stdout.log"),
+    stderrFile: join(branchDir, "stderr.log"),
+    statusFile: join(branchDir, "status.txt"),
+    pidFile: join(branchDir, "pid.txt"),
+    supervisorFile: join(branchDir, "supervisor.sh"),
+    launchMs: 0,
+  };
+}
+
+function mapStageBranchResult(
+  spec: StageSpec,
+  result:
+    | {
+        stopReason: string;
+        output: string;
+        elapsedMs: number;
+      }
+    | undefined,
+): FanoutBranchResult {
+  if (!result) {
+    return {
+      branchId: spec.branchId,
+      ok: false,
+      error: "branch produced no result",
+    };
+  }
+  const succeeded =
+    result.stopReason === "max_iterations" ||
+    result.stopReason === "completion_event" ||
+    result.stopReason === "completion_promise";
+  const data = parseJsonObjectPayload(result.output);
+  return succeeded && data
+    ? { branchId: spec.branchId, ok: true, data }
+    : {
         branchId: spec.branchId,
         ok: false,
-        error: "branch produced no result",
+        error: succeeded
+          ? "branch did not respond with a parseable JSON object"
+          : `branch ${result.stopReason}`,
       };
-      appendStageBranchFinish(loop, iter, stageId, branchResult, 0);
-      return branchResult;
-    }
-
-    const succeeded =
-      result.stopReason === "max_iterations" ||
-      result.stopReason === "completion_event" ||
-      result.stopReason === "completion_promise";
-    const data = parseJsonObjectPayload(result.output);
-
-    const branchResult: FanoutBranchResult =
-      succeeded && data
-        ? { branchId: spec.branchId, ok: true, data }
-        : {
-            branchId: spec.branchId,
-            ok: false,
-            error: succeeded
-              ? "branch did not respond with a parseable JSON object"
-              : `branch ${result.stopReason}`,
-          };
-
-    appendStageBranchFinish(
-      loop,
-      iter,
-      stageId,
-      branchResult,
-      result.elapsedMs,
-    );
-    return branchResult;
-  };
 }
 
 function renderStageBranchPrompt(

--- a/packages/harness/test/harness/config-helpers.test.ts
+++ b/packages/harness/test/harness/config-helpers.test.ts
@@ -142,6 +142,46 @@ describe("injectClaudePermissions", () => {
 });
 
 describe("buildLoopContext", () => {
+  it("loads stage runtime controls beside single-file fan-out stages", () => {
+    const projectDir = makeProject("event_loop.max_iterations = 1\n");
+    const presetFile = join(projectDir, "generated-preset.toml");
+    writeFileSync(
+      presetFile,
+      [
+        'name = "generated-review"',
+        'completion_event = "review.complete"',
+        "",
+        "[event_loop]",
+        "max_iterations = 2",
+        "",
+        "[stage_runtime]",
+        "concurrency = 8",
+        "branch_timeout_ms = 1500000",
+        "",
+        "[[role]]",
+        'id = "lens"',
+        'emits = ["lens.done"]',
+        "",
+        "[[stage]]",
+        'id = "lenses"',
+        'roles = ["lens"]',
+        'reducer = "concat"',
+        'next = "review.complete"',
+      ].join("\n"),
+    );
+
+    const loop = buildLoopContext(projectDir, "review", "autoloop", {
+      workDir: projectDir,
+      presetFile,
+    });
+
+    expect(loop.stage).toEqual({
+      concurrency: 8,
+      branchTimeoutMs: 1_500_000,
+    });
+    expect(loop.topology.stages.map((stage) => stage.id)).toEqual(["lenses"]);
+  });
+
   it("rejects an unrecognized global backend kind", () => {
     const projectDir = makeProject(
       ["event_loop.max_iterations = 1", 'backend.kind = "clade-sdk"'].join(

--- a/packages/harness/test/harness/metareview.test.ts
+++ b/packages/harness/test/harness/metareview.test.ts
@@ -1,9 +1,11 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AcpSession } from "@mobrienv/autoloop-backends/acp-client";
 import type { PiSession } from "@mobrienv/autoloop-backends/pi-rpc-client";
+import { buildLoopContext } from "@mobrienv/autoloop-harness/config-helpers";
 import {
+  maybeRunMetareview,
   parseVerdict,
   runMetareviewReview,
   shouldRunMetareview,
@@ -525,5 +527,68 @@ describe("runMetareviewReview", () => {
     const verdict = await runMetareviewReview(loop, 2);
 
     expect(verdict.verdict).toBe("UNKNOWN");
+  });
+});
+
+describe("maybeRunMetareview preset safety", () => {
+  it("rolls back an invalid generated-preset edit before reloading", async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "autoloop-review-rollback-"));
+    const presetFile = join(projectDir, "generated-preset.toml");
+    const original = [
+      'name = "generated"',
+      'completion_event = "task.complete"',
+      "[event_loop]",
+      "max_iterations = 3",
+      "[backend]",
+      'kind = "pi"',
+      'command = "pi"',
+      "timeout_ms = 1000",
+      "[review]",
+      "enabled = true",
+      "every = 1",
+      "adversarial_first = true",
+      'kind = "pi"',
+      'command = "pi"',
+      "timeout_ms = 1000",
+      "[[role]]",
+      'id = "worker"',
+      'emits = ["task.complete"]',
+      "[handoff]",
+      '"loop.start" = ["worker"]',
+    ].join("\n");
+    writeFileSync(presetFile, original);
+    const loop = buildLoopContext(projectDir, "test", "autoloop", {
+      workDir: projectDir,
+      presetFile,
+      noWorktree: true,
+    });
+    mkdirSync(loop.paths.stateDir, { recursive: true });
+    writeFileSync(loop.paths.journalFile, "", { flag: "a" });
+
+    backendMocks.initPiSession.mockResolvedValue({
+      process: { pid: 11 },
+    } as unknown as PiSession);
+    backendMocks.terminatePiSession.mockResolvedValue(undefined);
+    backendMocks.runPiIteration.mockImplementation(async () => {
+      writeFileSync(
+        presetFile,
+        `${original}\n[stage]\nbranch_timeout_ms = 1500000\n[[stage]]\nid = "bad"\n`,
+      );
+      return {
+        output:
+          '```json\n{"verdict":"CONTINUE","confidence":0.9,"reasoning":"retry"}\n```',
+        exitCode: 0,
+        timedOut: false,
+      };
+    });
+
+    const reloaded = await maybeRunMetareview(loop, 2);
+
+    expect(readFileSync(presetFile, "utf8")).toBe(original);
+    expect(reloaded.lastVerdict).toMatchObject({
+      verdict: "UNKNOWN",
+      confidence: 0,
+    });
+    expect(reloaded.lastVerdict?.reasoning).toContain("rolled back");
   });
 });

--- a/packages/harness/test/harness/parallel.test.ts
+++ b/packages/harness/test/harness/parallel.test.ts
@@ -8,13 +8,16 @@ import {
   branchStopReason,
   buildBackendCommand,
   csvFieldList,
+  loadParallelBranchLaunch,
   parallelBranchBackendOverride,
+  parallelBranchRunOptions,
   renderBranchResult,
   runtimeEnvLines,
 } from "@mobrienv/autoloop-harness/parallel";
 import { buildIterationContext } from "@mobrienv/autoloop-harness/prompt";
 import type { LoopContext } from "@mobrienv/autoloop-harness/types";
 import { describe, expect, it } from "vitest";
+import { writeBranchLaunch } from "../../src/wave/launch-branches.js";
 
 describe("csvFieldList", () => {
   it("extracts comma-separated values from a JSON field", () => {
@@ -56,7 +59,10 @@ describe("parallelBranchBackendOverride", () => {
     backendCommand: "",
     backendArgs: [],
     backendPromptMode: "",
+    backendTimeoutMs: 0,
+    branchTimeoutMs: 0,
     logLevel: "info",
+    presetFile: "",
   };
 
   it("returns empty object when no overrides set", () => {
@@ -111,6 +117,56 @@ describe("parallelBranchBackendOverride", () => {
       command: "claude",
       args: ["--fast"],
       prompt_mode: "pipe",
+    });
+  });
+});
+
+describe("parallel branch launch context", () => {
+  it("round-trips the exact parent preset and reuses it in shared branch mode", () => {
+    const root = mkdtempSync(join(tmpdir(), "autoloop-branch-launch-"));
+    const branchDir = join(root, "branch");
+    mkdirSync(branchDir, { recursive: true });
+    const presetFile = join(root, "generated-preset.toml");
+    writeFileSync(presetFile, 'name = "generated"\n');
+    const spec = {
+      branchId: "lenses.0",
+      waveId: "lenses",
+      objective: "inspect state",
+      emittedTopic: "state.done",
+      routingEvent: "state_lens",
+      allowedRoles: ["state_lens"],
+      allowedEvents: ["state.done"],
+      prompt: "inspect state",
+      branchDir,
+      launchFile: join(branchDir, "launch.json"),
+    } as Parameters<typeof writeBranchLaunch>[0];
+    const parentLoop = {
+      backend: {
+        kind: "pi",
+        provider: "",
+        command: "pi",
+        args: [],
+        promptMode: "arg",
+        timeoutMs: 1_500_000,
+      },
+      runtime: { logLevel: "info" },
+      launch: { presetFile },
+      parallel: { branchTimeoutMs: 1_500_000 },
+    } as unknown as LoopContext;
+
+    writeBranchLaunch(spec, parentLoop);
+    const launch = loadParallelBranchLaunch(branchDir);
+
+    expect(launch.presetFile).toBe(presetFile);
+    expect(launch.backendTimeoutMs).toBe(1_500_000);
+    expect(launch.branchTimeoutMs).toBe(1_500_000);
+    expect(parallelBranchRunOptions(launch, branchDir)).toMatchObject({
+      workDir: branchDir,
+      presetFile,
+      noWorktree: true,
+      trigger: "branch",
+      backendOverride: { timeout_ms: 1_500_000 },
+      configOverride: { parallel: { branch_timeout_ms: "1500000" } },
     });
   });
 });

--- a/packages/harness/test/harness/stage-branch-runner.test.ts
+++ b/packages/harness/test/harness/stage-branch-runner.test.ts
@@ -16,6 +16,9 @@ import type { BranchSpec as WaveBranchSpec } from "../../src/wave/types.js";
 // The spawn boundary: capture what the runner would launch, and return a
 // scripted branch outcome instead of spinning up a real `branch-run` subprocess.
 const launchedSpecs: WaveBranchSpec[] = [];
+const launchBatchSizes: number[] = [];
+const launchTimeouts: number[] = [];
+const writtenTimeouts: number[] = [];
 let scriptedResult: {
   stopReason: string;
   output: string;
@@ -23,10 +26,21 @@ let scriptedResult: {
 };
 
 vi.mock("../../src/wave/launch-branches.js", () => ({
-  writeBranchLaunch: (spec: WaveBranchSpec) => {
+  writeBranchLaunch: (
+    spec: WaveBranchSpec,
+    loop: { parallel: { branchTimeoutMs: number } },
+  ) => {
     launchedSpecs.push(spec);
+    writtenTimeouts.push(loop.parallel.branchTimeoutMs);
   },
-  launchParallelBranches: (_loop: unknown, specs: WaveBranchSpec[]) => specs,
+  launchParallelBranches: (
+    loop: { parallel: { branchTimeoutMs: number } },
+    specs: WaveBranchSpec[],
+  ) => {
+    launchBatchSizes.push(specs.length);
+    launchTimeouts.push(loop.parallel.branchTimeoutMs);
+    return specs;
+  },
   joinParallelBranches: (
     _loop: unknown,
     _iter: unknown,
@@ -51,7 +65,10 @@ vi.mock("../../src/wave/launch-branches.js", () => ({
 
 import type { BranchSpec as StageSpec } from "../../src/fanout-runner.js";
 import type { IterationContext } from "../../src/prompt.js";
-import { buildStageBranchRunner } from "../../src/wave/stage-branch-runner.js";
+import {
+  buildStageBranchRunner,
+  runStageBranchBatch,
+} from "../../src/wave/stage-branch-runner.js";
 
 function makeLoop(): LoopContext {
   const workDir = mkdtempSync(join(tmpdir(), "autoloop-sbr-"));
@@ -79,6 +96,8 @@ function makeLoop(): LoopContext {
     },
     paths: { stateDir, journalFile },
     runtime: { runId: "run-sbr" },
+    parallel: { branchTimeoutMs: 180_000 },
+    stage: { branchTimeoutMs: 1_500_000, concurrency: 2 },
   } as unknown as LoopContext;
 }
 
@@ -99,9 +118,40 @@ function branchSpec(overrides: Partial<StageSpec> = {}): StageSpec {
 
 beforeEach(() => {
   launchedSpecs.length = 0;
+  launchBatchSizes.length = 0;
+  launchTimeouts.length = 0;
+  writtenTimeouts.length = 0;
 });
 
 describe("buildStageBranchRunner — real branch mapping", () => {
+  it("launches each concurrency window before joining it", async () => {
+    const loop = makeLoop();
+    scriptedResult = {
+      stopReason: "completion_event",
+      output: '{"affirm": true}',
+      elapsedMs: 100,
+    };
+    const specs = [
+      branchSpec({ branchId: "verify.0", index: 0 }),
+      branchSpec({ branchId: "verify.1", index: 1 }),
+      branchSpec({ branchId: "verify.2", index: 2 }),
+    ];
+
+    const results = await runStageBranchBatch(
+      loop,
+      iterCtx(),
+      "verify",
+      specs,
+      2,
+    );
+
+    expect(launchBatchSizes).toEqual([2, 1]);
+    expect(launchTimeouts).toEqual([1_500_000, 1_500_000]);
+    expect(writtenTimeouts).toEqual([1_500_000, 1_500_000, 1_500_000]);
+    expect(results).toHaveLength(3);
+    expect(results.every((result) => result.ok)).toBe(true);
+  });
+
   it("maps a completed branch whose output is a JSON object to a live BranchResult", async () => {
     const loop = makeLoop();
     scriptedResult = {

--- a/packages/harness/test/harness/stage.test.ts
+++ b/packages/harness/test/harness/stage.test.ts
@@ -11,9 +11,13 @@ const branchRunnerCalls: string[] = [];
 const stubResults = new Map<string, BranchResult>();
 
 vi.mock("../../src/wave/stage-branch-runner.js", () => ({
-  buildStageBranchRunner:
-    () =>
-    async (spec: { branchId: string }): Promise<BranchResult> => {
+  runStageBranchBatch: async (
+    _loop: unknown,
+    _iter: unknown,
+    _stageId: string,
+    specs: { branchId: string }[],
+  ): Promise<BranchResult[]> =>
+    specs.map((spec) => {
       branchRunnerCalls.push(spec.branchId);
       return (
         stubResults.get(spec.branchId) ?? {
@@ -22,7 +26,7 @@ vi.mock("../../src/wave/stage-branch-runner.js", () => ({
           data: { affirm: true },
         }
       );
-    },
+    }),
 }));
 
 import type { IterationContext } from "../../src/prompt.js";

--- a/packages/presets/presets/autoarchitect.toml
+++ b/packages/presets/presets/autoarchitect.toml
@@ -66,6 +66,11 @@ Rules for the preset you emit:
   work.
 - Where the objective benefits from parallel, heterogeneous verification or
   discovery, compose a fan-out [[stage]] block instead of a single critic role.
+  Configure its runtime controls in `[stage_runtime]` — never `[stage]`, which
+  is invalid beside `[[stage]]` in a single TOML file. For repository-scale
+  analysis use `concurrency` appropriate to the panel and
+  `branch_timeout_ms = 1500000` (25 minutes) unless the objective clearly needs
+  a stricter bound.
   A stage's `trigger` is a plain event some upstream role emits — route it in
   [handoff] to an EMPTY list (e.g. `"panel.judge" = []`) so it validates as
   reachable; the harness intercepts it and launches the branches itself. Every

--- a/test/integration/registry-lifecycle.test.ts
+++ b/test/integration/registry-lifecycle.test.ts
@@ -42,11 +42,11 @@ describe("integration: registry lifecycle", () => {
   it("records failed status when backend exits non-zero", () => {
     const project = makeTempProject("registry-fail");
     const fixture = join(FIXTURES_DIR, "non-zero-exit.json");
-    const _res = runCli(["run", project, "fail test"], {
+    const res = runCli(["run", project, "fail test"], {
       MOCK_FIXTURE_PATH: fixture,
     });
 
-    // The CLI may return non-zero for backend failure
+    expect(res.status).toBe(1);
     const registryPath = join(project, ".autoloop/registry.jsonl");
     if (!pathExists(registryPath)) return; // skip if registry wasn't created (early crash)
 

--- a/test/integration/run-loop.test.ts
+++ b/test/integration/run-loop.test.ts
@@ -180,7 +180,7 @@ describe("integration: run loop with mock backend", () => {
       },
     );
 
-    expect(res.status).toBe(0);
+    expect(res.status).toBe(1);
     expect(res.stdout).toContain("[progress]");
     expect(res.stdout).toContain("outcome=stop:backend_failed");
   });
@@ -202,7 +202,7 @@ describe("integration: run loop with mock backend", () => {
       },
     );
 
-    expect(res.status).toBe(0);
+    expect(res.status).toBe(1);
     expect(res.stdout).toContain("[progress]");
     expect(res.stdout).toContain("outcome=stop:backend_timeout");
   });


### PR DESCRIPTION
## Summary

- make generated Ultra presets safe to adapt and reload by separating fan-out runtime settings into `[stage_runtime]` and rolling back invalid TOML edits
- launch stage branches in real concurrency windows while preserving declaration-order reduction, resume/cache behavior, and budget admission
- propagate the exact generated preset, shared branch mode, backend deadline, and branch deadline into child runs
- enforce a 25-minute repository-scale Ultra minimum without lowering longer or explicit operator values
- return nonzero CLI status for terminal backend, auth, quota, rate-limit, review, parallel-wave, and internal failures while preserving successful controlled stops

## Why

A real `autoloop --ultra` architecture review exposed three runtime failures: adaptive edits could create invalid TOML, stage branches were effectively serialized, and parent deadlines/preset identity did not survive child launch. Follow-up review also found returned backend failures could still exit zero.

## Verification

- build: passed
- focused timeout, preset, metareview, concurrency, and exit-status tests: passed
- executable backend-failure integration: passed
- full serialized suite: **203 files, 2,259 tests passed, 4 skipped**
- independent frozen-diff review: **PASS**
- real patched `--ultra` run: completed in 9 generated-workflow iterations and produced an 807-line `ARCHITECTURE_REVIEW.md` with 61 file/line citations; generated topology revalidated with zero warnings
- forced real-Pi stage smoke: **PASS**, exit 0; three branches started within a 10 ms parent dispatch window, all returned valid JSON, ordered reduction retained `panel.0/1/2`, and `stage.join` emitted `panel.done` with 3 unique items

## Notes

The architecture report was generated in an isolated detached worktree and is validation evidence, not part of this code-change PR. The dynamic review happened to choose a serial nine-role topology, so the separate forced-stage smoke explicitly exercised the concurrent branch path.
