### PR TITLE
feat: T-008 durable waits (wait.request)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [Unreleased]
 
 ### Added
+- **Durable waits (`wait.request`).** An agent can park a named run without a
+  live backend: emit `wait.request`, the harness journals `wait.open`, registry
+  status becomes `waiting`, and the process exits 0. `autoloop resume <run-id>`
+  journals `wait.close` and continues on the same `run_id`. Duration on the
+  request is advisory — nothing sleeps in-process or burns `backend.timeout_ms`.
 - **Backend environment hardening is available as an opt-in policy.** Existing
   presets continue to inherit their process environment unchanged. Setting
   `backend.environment_policy = "hardened"` (or the review-specific override)

--- a/docs/features/human-in-the-loop.md
+++ b/docs/features/human-in-the-loop.md
@@ -57,3 +57,19 @@ journal (or the `--events` stream) for `ask.pending`, relaying the question to a
 human, and writing the answer back with `autoloop control respond`. The
 `respond` request is keyed by `question_id`, so it reaches exactly the turn that
 asked. Ctrl-C / abort cancels a pending ask cleanly.
+
+## Durable waits (process-free)
+
+`human.ask` **blocks the live process** until someone answers. That is the
+wrong primitive for a named nap: the backend stays up and `backend.timeout_ms`
+keeps ticking.
+
+To park a run without a live backend, emit `wait.request` instead:
+
+```bash
+autoloop emit wait.request "reason=nap; duration=300s; name=company-nap"
+```
+
+The harness journals `wait.open`, the process exits 0, and registry status
+becomes `waiting`. Resume the **same** `run_id` with `autoloop resume <run-id>`,
+which journals `wait.close` and continues. See [Journal Reference](../reference/journal.md#durable-waits).

--- a/docs/guides/sdk-embed.md
+++ b/docs/guides/sdk-embed.md
@@ -112,6 +112,8 @@ The event envelope is a discriminated union on `type`. Variants are grouped into
 | `log`             | `{ level: string; message: string }`                                       |
 | `iteration.start` | `{ iteration: number; maxIterations: number; runId: string }`              |
 | `loop.finish`     | `{ iterations: number; stopReason: string; runId: string }`                |
+| `wait.open`       | `{ runId; iteration; waitId; reason; name?; duration? }` — run parked      |
+| `wait.close`      | `{ runId; iteration; waitId }` — parked wait closed on resume              |
 
 **Display-requested** — the harness asks the caller to render something:
 

--- a/docs/reference/journal.md
+++ b/docs/reference/journal.md
@@ -77,7 +77,9 @@ loop.complete   or   loop.stop
 | `review.start` | Before a metareview review pass. | `kind` (`"metareview"`), `backend_kind`, `command`, `prompt_mode`, `prompt`, `timeout_ms` |
 | `review.finish` | After review completes. | `kind` (`"metareview"`), `exit_code`, `timed_out` (boolean), `output` |
 | `loop.complete` | Loop finished successfully. | `reason` (`"completion_event"` or `"completion_promise"`) |
-| `loop.stop` | Loop halted without completion. | `reason` (`"max_iterations"`, `"backend_failed"`, `"backend_timeout"`, `"stalled"`, `"cost_budget"`, or `"max_runtime"`). The `max_iterations` variant also includes `completed_iterations`, `stopped_before_iteration`, and `max_iterations`. The `backend_failed` and `backend_timeout` variants also include `iteration` and `output_tail`. The `max_runtime` variant includes `completed_iterations`, `elapsed_ms`, `max_runtime_ms`, and (when a budget-clamped iteration timed out) `output_tail`. |
+| `loop.stop` | Loop halted without completion. | `reason` (`"max_iterations"`, `"backend_failed"`, `"backend_timeout"`, `"stalled"`, `"cost_budget"`, `"max_runtime"`, or `"waiting"`). The `max_iterations` variant also includes `completed_iterations`, `stopped_before_iteration`, and `max_iterations`. The `backend_failed` and `backend_timeout` variants also include `iteration` and `output_tail`. The `max_runtime` variant includes `completed_iterations`, `elapsed_ms`, `max_runtime_ms`, and (when a budget-clamped iteration timed out) `output_tail`. The `waiting` variant also includes `iteration`, `wait_id`, and `detail`. |
+| `wait.open` | A `wait.request` parked the run. Process exits 0; no backend stays live. | `wait_id`, `reason`, optional `name`, `duration`, `duration_ms` |
+| `wait.close` | Resume closed the parked wait on the same `run_id`. | `wait_id` |
 
 ### Agent events (custom)
 
@@ -164,6 +166,7 @@ Autoloop uses **soft routing with protocol backpressure**. The model receives ad
 3. When the agent emits an event (via `autoloop emit` or detected in backend output), it is checked against the allowed set.
 4. **Coordination events bypass validation** — they are always accepted.
 5. **If the allowed-events list is empty** (no topology or unmapped event), all events are accepted.
+6. **`wait.request` is always accepted** — it parks the run (see Durable waits below). It is not a routing event.
 
 ### On invalid emit
 
@@ -180,6 +183,24 @@ Invalid events are caught at two points:
 
 - **At emit time** — the `autoloop emit` command validates against `AUTOLOOP_ALLOWED_EVENTS` environment variable and rejects immediately.
 - **After iteration** — the harness scans the iteration's journal entries for the latest agent event and validates it against the topology. This catches events emitted through non-standard paths.
+
+## Durable waits
+
+An agent parks the current run without keeping a backend process alive by emitting the reserved topic:
+
+```bash
+autoloop emit wait.request "reason=nap; duration=300s; name=company-nap"
+```
+
+The harness journals `wait.open`, sets registry status to `waiting`, and the process exits 0. Duration is advisory metadata for a host or operator — nothing sleeps in-process. Resume the same `run_id`:
+
+```bash
+autoloop resume <run-id>
+```
+
+Resume journals `wait.close`, then `loop.resume`, and continues. Do not fake a nap with `sleep` / `bin/backoff` — that keeps the process alive and burns `backend.timeout_ms`.
+
+`wait.request` is not a routing event. It does not need to appear in a role `emits` list.
 
 ## Completion detection
 

--- a/packages/cli/src/cli/event-printer.ts
+++ b/packages/cli/src/cli/event-printer.ts
@@ -67,6 +67,18 @@ export function cliPrintEvent(event: LoopEvent): void {
     case "ask.answered":
       // SDK-only marker; the answer is injected into the next prompt.
       return;
+    case "wait.open":
+      process.stderr.write(
+        `\n[wait] parked run ${event.runId} (id=${event.waitId})` +
+          `${event.reason ? `: ${event.reason}` : ""}\n` +
+          `      no live backend; resume with: autoloop resume ${event.runId}\n\n`,
+      );
+      return;
+    case "wait.close":
+      process.stderr.write(
+        `\n[wait] closed ${event.waitId} on ${event.runId}\n\n`,
+      );
+      return;
     case "backend.output":
       printBackendOutputTail(event.output, event.maxLines);
       return;

--- a/packages/cli/src/commands/resume.ts
+++ b/packages/cli/src/commands/resume.ts
@@ -246,7 +246,9 @@ export function printResumeUsage(): void {
   console.log(
     "Continue a previously-terminated or waiting run from where it left off,",
   );
-  console.log("reusing the run_id, journal, memory, working files, and worktree.");
+  console.log(
+    "reusing the run_id, journal, memory, working files, and worktree.",
+  );
   console.log(
     "A parked wait.request is closed (wait.close) on the same run_id.",
   );

--- a/packages/cli/src/commands/resume.ts
+++ b/packages/cli/src/commands/resume.ts
@@ -244,9 +244,12 @@ export function printResumeUsage(): void {
   );
   console.log("");
   console.log(
-    "Continue a previously-terminated run from where it left off, reusing the",
+    "Continue a previously-terminated or waiting run from where it left off,",
   );
-  console.log("run_id, journal, memory, working files, and worktree.");
+  console.log("reusing the run_id, journal, memory, working files, and worktree.");
+  console.log(
+    "A parked wait.request is closed (wait.close) on the same run_id.",
+  );
   console.log("");
   console.log("Flags:");
   console.log(

--- a/packages/cli/src/loops/json.ts
+++ b/packages/cli/src/loops/json.ts
@@ -177,6 +177,7 @@ export function healthJson(stateDir: string): string {
  * Categorization runs on a copy so the reported record is never mutated.
  */
 function healthBucketFor(r: RunRecord): string | null {
+  if (r.status === "waiting") return "waiting";
   const h = categorizeRecords([{ ...r }]);
   if (h.stuck.length > 0) return "stuck";
   if (h.watching.length > 0) return "watching";

--- a/packages/cli/src/loops/list.ts
+++ b/packages/cli/src/loops/list.ts
@@ -6,7 +6,7 @@ import { renderListHeader, renderRunLine } from "./render.js";
 
 /**
  * List runs from the merged registry (root + chain/worktree children).
- * When `all` is false, only active (running) runs are shown.
+ * When `all` is false, only live runs (running or waiting) are shown.
  * When `all` is true, all runs are shown sorted by updated_at descending.
  */
 export function listRuns(stateDir: string, all: boolean): string {

--- a/packages/cli/test/cli/event-printer.test.ts
+++ b/packages/cli/test/cli/event-printer.test.ts
@@ -146,7 +146,9 @@ describe("cliPrintEvent", () => {
   });
 
   it("wait.open prints a park notice with the resume command", () => {
-    const write = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const write = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
     cliPrintEvent({
       type: "wait.open",
       runId: "swift-agent",
@@ -180,7 +182,9 @@ describe("cliPrintEvent", () => {
   });
 
   it("wait.close prints the closed wait id", () => {
-    const write = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const write = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
     cliPrintEvent({
       type: "wait.close",
       runId: "swift-agent",

--- a/packages/cli/test/cli/event-printer.test.ts
+++ b/packages/cli/test/cli/event-printer.test.ts
@@ -145,6 +145,53 @@ describe("cliPrintEvent", () => {
     );
   });
 
+  it("wait.open prints a park notice with the resume command", () => {
+    const write = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    cliPrintEvent({
+      type: "wait.open",
+      runId: "swift-agent",
+      iteration: 1,
+      waitId: "company-nap",
+      reason: "between steps",
+    });
+    expect(write).toHaveBeenCalled();
+    const text = write.mock.calls.map((c) => String(c[0])).join("");
+    expect(text).toContain("[wait] parked run swift-agent");
+    expect(text).toContain("company-nap");
+    expect(text).toContain("autoloop resume swift-agent");
+    write.mockRestore();
+  });
+
+  it("wait.open omits the reason clause when empty", () => {
+    const write = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    cliPrintEvent({
+      type: "wait.open",
+      runId: "r1",
+      iteration: 2,
+      waitId: "wait_r1_2",
+      reason: "",
+    });
+    const text = write.mock.calls.map((c) => String(c[0])).join("");
+    expect(text).toContain("[wait] parked run r1 (id=wait_r1_2)");
+    expect(text).not.toContain(": \n");
+    write.mockRestore();
+  });
+
+  it("wait.close prints the closed wait id", () => {
+    const write = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    cliPrintEvent({
+      type: "wait.close",
+      runId: "swift-agent",
+      iteration: 1,
+      waitId: "company-nap",
+    });
+    const text = write.mock.calls.map((c) => String(c[0])).join("");
+    expect(text).toContain("[wait] closed company-nap");
+    write.mockRestore();
+  });
+
   it("summary builds a LoopContext stub with all fields display.ts reads", () => {
     cliPrintEvent({
       type: "summary",

--- a/packages/cli/test/commands/run-backend-override.test.ts
+++ b/packages/cli/test/commands/run-backend-override.test.ts
@@ -117,6 +117,7 @@ describe("applyGlobalBackendOverride", () => {
     "premature_quit",
     "interrupted",
     "suspended",
+    "waiting",
     "verdict_exit",
     "verdict_takeover",
     "verdict_unknown",

--- a/packages/cli/test/loops/json.test.ts
+++ b/packages/cli/test/loops/json.test.ts
@@ -81,6 +81,17 @@ describe("listRunsJson", () => {
     expect(parsed[0].status).toBe("running");
   });
 
+  it("includes parked waiting runs in the default live list", () => {
+    writeRecords([
+      makeRecord("run-wait-1", { status: "waiting", stop_reason: "waiting" }),
+      makeRecord("run-done-1", { status: "completed" }),
+    ]);
+    const parsed = JSON.parse(listRunsJson(tmpDir, false));
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].run_id).toBe("run-wait-1");
+    expect(parsed[0].status).toBe("waiting");
+  });
+
   it("projects exactly the table fields and omits empty worktree fields", () => {
     writeRecords([makeRecord("run-fields-1", { status: "running" })]);
     const parsed = JSON.parse(listRunsJson(tmpDir, false));
@@ -154,6 +165,17 @@ describe("showRunJson", () => {
     expect(parsed.backend).toBe("mock");
     expect(parsed.work_dir).toBe("/tmp/proj");
     expect(parsed.health).toBe("active");
+  });
+
+  it("derives waiting health for a parked durable wait", () => {
+    writeRecords([
+      makeRecord("run-wait-show", {
+        status: "waiting",
+        stop_reason: "waiting",
+      }),
+    ]);
+    const parsed = JSON.parse(showRunJson(tmpDir, "run-wait-show").output);
+    expect(parsed.health).toBe("waiting");
   });
 
   it("derives recent_completed for a recently completed run", () => {

--- a/packages/core/src/events/guards.ts
+++ b/packages/core/src/events/guards.ts
@@ -11,6 +11,8 @@ const SYSTEM_TOPICS = new Set([
   "backend.start",
   "backend.finish",
   "event.invalid",
+  "wait.open",
+  "wait.close",
 ]);
 
 const COORDINATION_TOPICS = new Set([

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -14,6 +14,7 @@ export type CoordinationTopic =
   | ArtifactTopic;
 export type ChainTopic = "chain.start" | "chain.complete";
 export type OperatorTopic = "operator.guidance" | "operator.guidance.consumed";
+export type WaitTopic = "wait.request" | "wait.open" | "wait.close";
 export type WaveTopic = string;
 export type CoreSystemTopic =
   | LoopTopic
@@ -26,6 +27,7 @@ export type KnownTopic =
   | CoordinationTopic
   | ChainTopic
   | OperatorTopic
+  | WaitTopic
   | WaveTopic
   | string;
 

--- a/packages/core/src/registry/derive.ts
+++ b/packages/core/src/registry/derive.ts
@@ -63,6 +63,25 @@ export function deriveRunRecords(lines: string[]): RunRecord[] {
       continue;
     }
 
+    if (topic === "wait.open") {
+      // Process-free park: the run still owns this run_id, but no backend
+      // process is live. Distinct from loop.stop so a journal-only derive
+      // (no registry rewrite) still surfaces `waiting`.
+      record.status = "waiting";
+      record.stop_reason = "waiting";
+      record.updated_at = record.created_at;
+      record.latest_event = topic;
+      continue;
+    }
+
+    if (topic === "wait.close") {
+      record.status = "running";
+      record.stop_reason = "";
+      record.updated_at = record.created_at;
+      record.latest_event = topic;
+      continue;
+    }
+
     if (topic === "loop.resume") {
       // A terminated run is being continued. Flip it back to running and clear
       // the prior stop reason; subsequent iteration.finish / loop.* events
@@ -117,5 +136,6 @@ export function stopReasonToStatus(reason: string): RegistryStatus {
   // Auth/quota won't self-resolve on retry — surface as failures. Rate-limit
   // and transient outages are availability stops (retryable), not failures.
   if (reason === "auth_failed" || reason === "quota_exhausted") return "failed";
+  if (reason === "waiting") return "waiting";
   return "stopped";
 }

--- a/packages/core/src/registry/discover.ts
+++ b/packages/core/src/registry/discover.ts
@@ -1,7 +1,7 @@
 import { existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { readRegistry } from "./read.js";
-import type { RunRecord } from "./types.js";
+import { isLiveStatus, type RunRecord } from "./types.js";
 
 function listDirs(dir: string): string[] {
   if (!existsSync(dir)) return [];
@@ -71,9 +71,9 @@ export function readMergedRegistry(stateDir: string): RunRecord[] {
   return mergeRecords(recordSets);
 }
 
-/** Active runs from the merged registry view. */
+/** Live runs (running or waiting) from the merged registry view. */
 export function mergedActiveRuns(stateDir: string): RunRecord[] {
-  return readMergedRegistry(stateDir).filter((r) => r.status === "running");
+  return readMergedRegistry(stateDir).filter((r) => isLiveStatus(r.status));
 }
 
 /** Recent runs from the merged registry view, sorted by updated_at desc. */

--- a/packages/core/src/registry/index.ts
+++ b/packages/core/src/registry/index.ts
@@ -15,4 +15,5 @@ export {
 } from "./read.js";
 export { rebuildRegistry } from "./rebuild.js";
 export type { RegistryStatus, RunRecord } from "./types.js";
+export { isLiveStatus } from "./types.js";
 export { appendRegistryEntry } from "./update.js";

--- a/packages/core/src/registry/read.ts
+++ b/packages/core/src/registry/read.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
-import type { RunRecord } from "./types.js";
+import { isLiveStatus, type RunRecord } from "./types.js";
 
 export function readRegistry(path: string): RunRecord[] {
   if (!existsSync(path)) return [];
@@ -23,7 +23,7 @@ export function getRun(path: string, runId: string): RunRecord | undefined {
 }
 
 export function activeRuns(path: string): RunRecord[] {
-  return readRegistry(path).filter((r) => r.status === "running");
+  return readRegistry(path).filter((r) => isLiveStatus(r.status));
 }
 
 export function recentRuns(path: string, limit: number): RunRecord[] {

--- a/packages/core/src/registry/types.ts
+++ b/packages/core/src/registry/types.ts
@@ -1,9 +1,15 @@
 export type RegistryStatus =
   | "running"
+  | "waiting"
   | "completed"
   | "failed"
   | "timed_out"
   | "stopped";
+
+/** A run that still owns the loop identity: live backend, or parked wait. */
+export function isLiveStatus(status: RegistryStatus): boolean {
+  return status === "running" || status === "waiting";
+}
 
 export interface RunRecord {
   run_id: string;

--- a/packages/core/test/events/guards.test.ts
+++ b/packages/core/test/events/guards.test.ts
@@ -51,6 +51,8 @@ describe("isSystemEvent edge cases", () => {
       "backend.start",
       "backend.finish",
       "event.invalid",
+      "wait.open",
+      "wait.close",
     ];
     for (const topic of systemTopics) {
       expect(isSystemEvent(fieldsEvent(topic))).toBe(true);

--- a/packages/core/test/registry/derive.test.ts
+++ b/packages/core/test/registry/derive.test.ts
@@ -169,6 +169,38 @@ describe("deriveRunRecords", () => {
     expect(records[0].stop_reason).toBe("max_iterations");
   });
 
+  it("marks waiting on wait.open and running again on wait.close", () => {
+    const lines = [
+      loopStartLine("run-1"),
+      iterationFinishLine("run-1", "1"),
+      encodeEvent({
+        shape: "fields",
+        run: "run-1",
+        iteration: "1",
+        topic: "wait.open",
+        fields: { wait_id: "company-nap", reason: "nap" },
+      }).trim(),
+    ];
+    const parked = deriveRunRecords(lines);
+    expect(parked[0].status).toBe("waiting");
+    expect(parked[0].stop_reason).toBe("waiting");
+    expect(parked[0].latest_event).toBe("wait.open");
+
+    lines.push(
+      encodeEvent({
+        shape: "fields",
+        run: "run-1",
+        iteration: "1",
+        topic: "wait.close",
+        fields: { wait_id: "company-nap" },
+      }).trim(),
+    );
+    const closed = deriveRunRecords(lines);
+    expect(closed[0].status).toBe("running");
+    expect(closed[0].stop_reason).toBe("");
+    expect(closed[0].latest_event).toBe("wait.close");
+  });
+
   it("transitions a stopped run back to running on loop.resume", () => {
     const lines = [
       loopStartLine("run-1", { max_iterations: "3" }),
@@ -264,5 +296,9 @@ describe("stopReasonToStatus", () => {
   it("maps anything else to stopped", () => {
     expect(stopReasonToStatus("max_iterations")).toBe("stopped");
     expect(stopReasonToStatus("unknown")).toBe("stopped");
+  });
+
+  it("maps waiting to waiting", () => {
+    expect(stopReasonToStatus("waiting")).toBe("waiting");
   });
 });

--- a/packages/core/test/registry/read.test.ts
+++ b/packages/core/test/registry/read.test.ts
@@ -8,6 +8,7 @@ import {
   readRegistry,
   recentRuns,
 } from "../../src/registry/read.js";
+import { isLiveStatus } from "../../src/registry/types.js";
 
 const tmpDir = join(import.meta.dirname ?? ".", ".tmp-registry-read-test");
 const regFile = join(tmpDir, "registry.jsonl");
@@ -118,6 +119,25 @@ describe("activeRuns", () => {
     const active = activeRuns(regFile);
     expect(active).toHaveLength(2);
     expect(active.map((r) => r.run_id).sort()).toEqual(["r1", "r3"]);
+  });
+
+  it("isLiveStatus covers running and waiting only", () => {
+    expect(isLiveStatus("running")).toBe(true);
+    expect(isLiveStatus("waiting")).toBe(true);
+    expect(isLiveStatus("completed")).toBe(false);
+    expect(isLiveStatus("failed")).toBe(false);
+    expect(isLiveStatus("timed_out")).toBe(false);
+    expect(isLiveStatus("stopped")).toBe(false);
+  });
+
+  it("includes parked waiting runs as live", () => {
+    writeReg([
+      makeRecord({ run_id: "r1", status: "waiting" }),
+      makeRecord({ run_id: "r2", status: "stopped" }),
+    ]);
+    const active = activeRuns(regFile);
+    expect(active).toHaveLength(1);
+    expect(active[0].run_id).toBe("r1");
   });
 });
 

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -19,6 +19,10 @@
       "types": "./dist/emit.d.ts",
       "default": "./dist/emit.js"
     },
+    "./wait": {
+      "types": "./dist/wait.d.ts",
+      "default": "./dist/wait.js"
+    },
     "./events": {
       "types": "./dist/events.d.ts",
       "default": "./dist/events.js"

--- a/packages/harness/src/emit.ts
+++ b/packages/harness/src/emit.ts
@@ -72,6 +72,11 @@ const CORE_SYSTEM_TOPICS = new Set([
   // iteration for any preset with lifecycle hooks configured.
   "hook.output",
   "hook.suspend",
+  // Durable-wait lifecycle: harness-written. Omitting these would let
+  // latestAgentEventRecord treat wait.open/wait.close as the acting
+  // role's emit and reject them against topology.
+  "wait.open",
+  "wait.close",
 ]);
 
 export function coreSystemTopic(topic: string): boolean {
@@ -332,6 +337,12 @@ function emitCore(
     return acceptEmit(journalFile, topic, payload, validation);
   }
 
+  // Durable wait: always accepted. The harness parks the run after the
+  // iteration; topology must not reject the reserved wait.request topic.
+  if (topic === "wait.request") {
+    return acceptEmit(journalFile, topic, payload, validation);
+  }
+
   if (coordinationTopic(topic)) {
     return acceptEmit(journalFile, topic, payload, validation);
   }
@@ -561,6 +572,12 @@ export function routingTopic(topic: string): boolean {
     "ask.pending",
     "ask.answered",
     "ask.timeout",
+    // Durable waits are not routing: parking must not move the handoff
+    // position. wait.request is the agent emit; wait.open/wait.close are
+    // harness-written.
+    "wait.request",
+    "wait.open",
+    "wait.close",
     "",
   ]);
   if (nonRouting.has(topic)) return false;

--- a/packages/harness/src/events.ts
+++ b/packages/harness/src/events.ts
@@ -76,6 +76,22 @@ export type LoopEvent =
       questionId: string;
       answer: string;
     }
+  // Durable wait: the run parked (process-free) or a parked wait closed.
+  | {
+      type: "wait.open";
+      runId: string;
+      iteration: number;
+      waitId: string;
+      reason: string;
+      name?: string;
+      duration?: string;
+    }
+  | {
+      type: "wait.close";
+      runId: string;
+      iteration: number;
+      waitId: string;
+    }
   | { type: "backend.output"; output: string; maxLines?: number }
   | { type: "failure.diagnostic"; output: string; stopReason: StopReason }
   // Emit-boundary file-mod audit (ralph parity): the acting role modified

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -463,7 +463,6 @@ export {
   type ResumeResult,
   resume,
 } from "./resume.js";
-export { emitCmd as emit };
 export {
   isWaitLifecycleTopic,
   isWaitRequestTopic,
@@ -474,6 +473,7 @@ export {
   WAIT_REQUEST_TOPIC,
   waitIdFor,
 } from "./wait.js";
+export { emitCmd as emit };
 
 export async function runParallelBranchCli(
   projectDir: string,

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -340,8 +340,14 @@ export async function driveLoop(
     runOptions.signal?.removeEventListener("abort", onAbort);
   }
 
-  // Post-run worktree lifecycle: status update, automerge, cleanup
-  if (loop.runtime.isolationMode === "worktree" && loop.paths.worktreeMetaDir) {
+  // Post-run worktree lifecycle: status update, automerge, cleanup.
+  // A parked wait keeps the worktree for resume on the same run_id —
+  // do not mark it failed or clean it.
+  if (
+    loop.runtime.isolationMode === "worktree" &&
+    loop.paths.worktreeMetaDir &&
+    summary.stopReason !== "waiting"
+  ) {
     const succeeded = summary.stopReason === "completed";
     const wtStatus = succeeded ? "completed" : "failed";
     try {
@@ -458,6 +464,16 @@ export {
   resume,
 } from "./resume.js";
 export { emitCmd as emit };
+export {
+  isWaitLifecycleTopic,
+  isWaitRequestTopic,
+  openWaitFromLines,
+  parseWaitRequest,
+  WAIT_CLOSE_TOPIC,
+  WAIT_OPEN_TOPIC,
+  WAIT_REQUEST_TOPIC,
+  waitIdFor,
+} from "./wait.js";
 
 export async function runParallelBranchCli(
   projectDir: string,

--- a/packages/harness/src/iteration.ts
+++ b/packages/harness/src/iteration.ts
@@ -36,13 +36,6 @@ import { materializeOpenFrom } from "@mobrienv/autoloop-core/tasks";
 import * as topology from "@mobrienv/autoloop-core/topology";
 import { awaitHumanResponse } from "./ask.js";
 import {
-  isWaitRequestTopic,
-  parseWaitRequest,
-  waitIdFor,
-  WAIT_OPEN_TOPIC,
-  waitOpenFields,
-} from "./wait.js";
-import {
   backoffDelayMs,
   circuitDecision,
   countTransientPauses,
@@ -83,6 +76,13 @@ import {
 } from "./stop.js";
 import { readSuspendState, resumeRequested } from "./suspend-state.js";
 import type { LoopContext, RunSummary } from "./types.js";
+import {
+  isWaitRequestTopic,
+  parseWaitRequest,
+  WAIT_OPEN_TOPIC,
+  waitIdFor,
+  waitOpenFields,
+} from "./wait.js";
 import {
   continueAfterParallelJoin,
   executeDeclarativeWave,

--- a/packages/harness/src/iteration.ts
+++ b/packages/harness/src/iteration.ts
@@ -36,6 +36,13 @@ import { materializeOpenFrom } from "@mobrienv/autoloop-core/tasks";
 import * as topology from "@mobrienv/autoloop-core/topology";
 import { awaitHumanResponse } from "./ask.js";
 import {
+  isWaitRequestTopic,
+  parseWaitRequest,
+  waitIdFor,
+  WAIT_OPEN_TOPIC,
+  waitOpenFields,
+} from "./wait.js";
+import {
   backoffDelayMs,
   circuitDecision,
   countTransientPauses,
@@ -72,6 +79,7 @@ import {
   stopBackendTimeout,
   stopMaxRuntime,
   stopSuspended,
+  stopWaiting,
 } from "./stop.js";
 import { readSuspendState, resumeRequested } from "./suspend-state.js";
 import type { LoopContext, RunSummary } from "./types.js";
@@ -614,6 +622,12 @@ export async function finishIteration(
     return finishAskIteration(loop, iter, emitted.payload, iterate, progress);
   }
 
+  // Durable wait: park the run without a live backend. Handled before
+  // routing so wait.request is never treated as a topology/invalid event.
+  if (isWaitRequestTopic(emitted.topic)) {
+    return finishWaitIteration(loop, iter, emitted.payload, progress);
+  }
+
   if (
     invalidEvent(
       emitted.topic,
@@ -807,6 +821,41 @@ async function finishAskIteration(
   });
   progress(loop.ask.event, "ask:answered");
   return iterate(loop, iter.iteration + 1);
+}
+
+/**
+ * Park the run on `wait.request`. Journals `wait.open`, then returns a
+ * `waiting` stop so the process can exit 0 with no live backend. Resume
+ * on the same run_id journals `wait.close`.
+ */
+function finishWaitIteration(
+  loop: LoopContext,
+  iter: IterationContext,
+  payload: string,
+  progress: (emittedTopic: string, outcome: string) => void,
+): RunSummary {
+  const runId = loop.runtime.runId;
+  const request = parseWaitRequest(payload);
+  const waitId = waitIdFor(runId, iter.iteration, request.name);
+
+  appendEvent(
+    loop.paths.journalFile,
+    runId,
+    String(iter.iteration),
+    WAIT_OPEN_TOPIC,
+    waitOpenFields(waitId, request),
+  );
+  loop.onEvent?.({
+    type: "wait.open",
+    runId,
+    iteration: iter.iteration,
+    waitId,
+    reason: request.reason,
+    name: request.name || undefined,
+    duration: request.duration || undefined,
+  });
+  progress("wait.request", "wait:open");
+  return stopWaiting(loop, iter.iteration, waitId, request.reason);
 }
 
 async function rejectInvalidAndContinue(

--- a/packages/harness/src/prompt.ts
+++ b/packages/harness/src/prompt.ts
@@ -403,6 +403,8 @@ export function renderIterationPromptText(
     loop.completion.event +
     ' "brief completion summary"\n' +
     loop.paths.toolPath +
+    ' emit wait.request "reason=nap; duration=300s"\n' +
+    loop.paths.toolPath +
     ' memory add learning "durable lesson"\n' +
     loop.paths.toolPath +
     ' memory add preference Workflow "short preference note"\n' +
@@ -418,7 +420,8 @@ export function renderIterationPromptText(
     " inspect scratchpad --format md`, and `" +
     loop.paths.toolPath +
     " inspect memory --format md`.\n" +
-    "Plain text alone does not publish an event. Prefer the event tool over the stdout completion promise.\n"
+    "Plain text alone does not publish an event. Prefer the event tool over the stdout completion promise.\n" +
+    "To park this run without a live backend (same run_id, process exits 0), emit `wait.request`. Resume later with `autoloop resume <run-id>`. Do not sleep or backoff in-process — that burns backend.timeout_ms.\n"
   );
 }
 

--- a/packages/harness/src/registry-bridge.ts
+++ b/packages/harness/src/registry-bridge.ts
@@ -92,6 +92,12 @@ export function registryTerminal(
   record.stop_reason = stopReason;
   record.updated_at = new Date().toISOString();
   record.latest_event = latestEvent;
+  // Process-free waiting (and any other non-running terminal) must not
+  // claim a live PID. A leftover pid would make doctor/reaper treat a
+  // parked wait as an orphaned running process.
+  if (status !== "running") {
+    delete record.pid;
+  }
   // Verified-outcome ledger: persist the gate-verified outcome facts so ROI /
   // A-B / regression analytics read a real numerator, not a re-derived one.
   record.outcome = deriveOutcome(status, stopReason);

--- a/packages/harness/src/resume.ts
+++ b/packages/harness/src/resume.ts
@@ -26,11 +26,6 @@ import {
 import { registryStart } from "./registry-bridge.js";
 import { completeLoop } from "./stop.js";
 import {
-  openWaitFromLines,
-  WAIT_CLOSE_TOPIC,
-  waitCloseFields,
-} from "./wait.js";
-import {
   clearResumeRequest,
   clearSuspendState,
   readSuspendState,
@@ -41,6 +36,11 @@ import type {
   RunSummary,
   StopReason,
 } from "./types.js";
+import {
+  openWaitFromLines,
+  WAIT_CLOSE_TOPIC,
+  waitCloseFields,
+} from "./wait.js";
 
 export interface ResumeOptions {
   /** Additional iterations to grant beyond the resume point. */

--- a/packages/harness/src/resume.ts
+++ b/packages/harness/src/resume.ts
@@ -26,6 +26,11 @@ import {
 import { registryStart } from "./registry-bridge.js";
 import { completeLoop } from "./stop.js";
 import {
+  openWaitFromLines,
+  WAIT_CLOSE_TOPIC,
+  waitCloseFields,
+} from "./wait.js";
+import {
   clearResumeRequest,
   clearSuspendState,
   readSuspendState,
@@ -97,7 +102,8 @@ export function determineResumeIteration(
   if (stopReason === "backend_failed" || stopReason === "backend_timeout") {
     return registryIteration;
   }
-  // interrupted / stopped / unknown: trust the journal.
+  // waiting / interrupted / stopped / unknown: trust the journal.
+  // A wait.request parks after iteration.finish, so this resumes at N+1.
   const lines = readRunLines(journalFile, runId);
   const finished = lines.some(
     (line) =>
@@ -288,6 +294,28 @@ export async function resume(
   loop = initStore(loop);
   ensureLayout(loop.paths.stateDir);
   installRuntimeTools(loop);
+
+  // Close a parked durable wait on this same run_id before the resume
+  // marker. Hosts and `loops show` key off wait.close, not loop.resume.
+  const parked = openWaitFromLines(
+    readRunLines(loop.paths.journalFile, loop.runtime.runId),
+    loop.runtime.runId,
+  );
+  if (parked) {
+    appendEvent(
+      loop.paths.journalFile,
+      loop.runtime.runId,
+      parked.iteration,
+      WAIT_CLOSE_TOPIC,
+      waitCloseFields(parked.waitId),
+    );
+    loop.onEvent?.({
+      type: "wait.close",
+      runId: loop.runtime.runId,
+      iteration: Number(parked.iteration) || resumeIteration,
+      waitId: parked.waitId,
+    });
+  }
 
   // Append the resume marker before any iteration so the scratchpad and derive
   // path see it. It's a system topic — routing ignores it.

--- a/packages/harness/src/scratchpad.ts
+++ b/packages/harness/src/scratchpad.ts
@@ -18,7 +18,14 @@ interface ResumeMarker {
   addIterations: string;
 }
 
-type ScratchpadEntry = IterationEntry | ResumeMarker;
+interface WaitMarker {
+  kind: "wait";
+  phase: "open" | "close";
+  waitId: string;
+  reason: string;
+}
+
+type ScratchpadEntry = IterationEntry | ResumeMarker | WaitMarker;
 
 export function renderRunScratchpadFull(lines: string[]): string {
   const entries = collectScratchpadEntries(lines);
@@ -59,6 +66,20 @@ function collectScratchpadEntries(lines: string[]): ScratchpadEntry[] {
         previousStopReason: event.fields.previous_stop_reason ?? "",
         addIterations: event.fields.add_iterations ?? "",
       });
+    } else if (event.topic === "wait.open") {
+      entries.push({
+        kind: "wait",
+        phase: "open",
+        waitId: event.fields.wait_id ?? "",
+        reason: event.fields.reason ?? "",
+      });
+    } else if (event.topic === "wait.close") {
+      entries.push({
+        kind: "wait",
+        phase: "close",
+        waitId: event.fields.wait_id ?? "",
+        reason: event.fields.reason ?? "",
+      });
     }
   }
   return entries;
@@ -71,6 +92,9 @@ function renderScratchpadEntries(entries: ScratchpadEntry[]): string {
 function scratchpadEntryText(entry: ScratchpadEntry): string {
   if (entry.kind === "resume") {
     return `${resumeMarkerText(entry)}\n\n`;
+  }
+  if (entry.kind === "wait") {
+    return `${waitMarkerText(entry)}\n\n`;
   }
   return (
     heading(2, `Iteration ${entry.iteration}`) +
@@ -89,9 +113,21 @@ function resumeMarkerText(entry: ResumeMarker): string {
   return `--- resumed (was: ${reason}, adding ${adding} iterations) ---`;
 }
 
+function waitMarkerText(entry: WaitMarker): string {
+  const id = entry.waitId || "wait";
+  if (entry.phase === "open") {
+    const reason = entry.reason ? `: ${entry.reason}` : "";
+    return `--- wait.open ${id}${reason} ---`;
+  }
+  return `--- wait.close ${id} ---`;
+}
+
 function compactScratchpadItem(entry: ScratchpadEntry): string {
   if (entry.kind === "resume") {
     return resumeMarkerText(entry);
+  }
+  if (entry.kind === "wait") {
+    return waitMarkerText(entry);
   }
   return (
     "Iteration " +

--- a/packages/harness/src/stop.ts
+++ b/packages/harness/src/stop.ts
@@ -430,6 +430,48 @@ export function stopSuspended(
   return { iterations: iteration, stopReason: "suspended" };
 }
 
+/**
+ * Process-free park: the current iteration already finished, wait.open is
+ * already in the journal, and the process is about to exit 0. Distinct from
+ * `stopSuspended` (hook failure) — this is the approved wait.request product.
+ */
+export function stopWaiting(
+  loop: LoopContext,
+  iteration: number,
+  waitId: string,
+  reason: string,
+): RunSummary {
+  log(
+    loop,
+    "info",
+    `loop wait open run_id=${loop.runtime.runId} wait_id=${waitId} iteration=${iteration}`,
+  );
+  loop.onEvent?.({
+    type: "progress",
+    runId: loop.runtime.runId,
+    iteration,
+    recentEvent: "wait.open",
+    allowedRoles: [],
+    emittedTopic: "wait.request",
+    outcome: "wait:open",
+  });
+  appendEvent(
+    loop.paths.journalFile,
+    loop.runtime.runId,
+    String(iteration),
+    "loop.stop",
+    jsonField("reason", "waiting") +
+      ", " +
+      jsonField("iteration", String(iteration)) +
+      ", " +
+      jsonField("wait_id", waitId) +
+      ", " +
+      jsonField("detail", reason),
+  );
+  registryStop(loop, iteration, "waiting");
+  return { iterations: iteration, stopReason: "waiting" };
+}
+
 export function completeLoop(
   loop: LoopContext,
   iteration: number,

--- a/packages/harness/src/types.ts
+++ b/packages/harness/src/types.ts
@@ -371,9 +371,9 @@ export interface RunOptions {
  * `packages/harness/test/harness/stop-reason.test.ts`):
  * - `stop.ts` — `max_iterations`, `backend_failed`, `backend_timeout`,
  *   `stalled`, `cost_budget`, `max_runtime`, `review_unknown`,
- *   `premature_quit`, `suspended`, and `completeLoop()` which echoes the
- *   `completion_event`/`completion_promise`/`verdict_*` literals its
- *   callers pass in.
+ *   `premature_quit`, `suspended`, `waiting`, and `completeLoop()` which
+ *   echoes the `completion_event`/`completion_promise`/`verdict_*`
+ *   literals its callers pass in.
  * - `index.ts` — `interrupted`, `error`, and `verdict_unknown` /
  *   `verdict_exit` / `verdict_takeover` (via `completeLoop`).
  * - `iteration.ts` — `completion_event`, `completion_promise` (via
@@ -393,14 +393,15 @@ export interface RunOptions {
  *   never reaches `RunSummary` and is intentionally **not** part of this
  *   union.
  *
- * Categories (23 values enumerated by the originating issue, plus two
- * additional real terminal literals — `parallel_wave_invalid` and `suspended` —
- * discovered during implementation; see the parallel-wave and hooks notes above):
+ * Categories (23 values enumerated by the originating issue, plus three
+ * additional real terminal literals — `parallel_wave_invalid`, `suspended`,
+ * and `waiting` — discovered during implementation; see the parallel-wave,
+ * hooks, and durable-wait notes):
  * - success (3): `completed`, `completion_event`, `completion_promise`
  * - failures (7): `backend_failed`, `backend_timeout`, `auth_failed`,
  *   `quota_exhausted`, `rate_limited`, `transient_error`, `review_unknown`
- * - stops (7): `max_iterations`, `stalled`, `cost_budget`, `max_runtime`,
- *   `premature_quit`, `interrupted`, `suspended`
+ * - stops (8): `max_iterations`, `stalled`, `cost_budget`, `max_runtime`,
+ *   `premature_quit`, `interrupted`, `suspended`, `waiting`
  * - verdicts (3): `verdict_exit`, `verdict_takeover`, `verdict_unknown`
  * - held (1): `completion_held`
  * - parallel (3): `parallel_wave_timeout`, `parallel_wave_failed`,
@@ -429,7 +430,7 @@ export const STOP_REASONS = [
   "rate_limited",
   "transient_error",
   "review_unknown",
-  // stops (7)
+  // stops (8)
   "max_iterations",
   "stalled",
   "cost_budget",
@@ -437,6 +438,7 @@ export const STOP_REASONS = [
   "premature_quit",
   "interrupted",
   "suspended",
+  "waiting",
   // verdicts (3)
   "verdict_exit",
   "verdict_takeover",

--- a/packages/harness/src/wait.ts
+++ b/packages/harness/src/wait.ts
@@ -1,0 +1,164 @@
+// Durable waits (T-008): park a named run without a live backend.
+//
+// An agent emits the reserved `wait.request` topic. The harness journals
+// `wait.open`, flips the registry to `waiting`, and returns so the process
+// can exit 0. Nothing polls. Nothing holds `backend.timeout_ms`. Resume
+// on the same run_id journals `wait.close` and continues.
+//
+// Duration on the request is advisory metadata for a host/operator — v1
+// does not spawn a sleeper. That is the whole point versus `bin/backoff`.
+
+import { jsonField, parseDurationMs } from "@mobrienv/autoloop-core";
+import { decodeEvent } from "@mobrienv/autoloop-core/events/decode";
+
+export const WAIT_REQUEST_TOPIC = "wait.request";
+export const WAIT_OPEN_TOPIC = "wait.open";
+export const WAIT_CLOSE_TOPIC = "wait.close";
+
+const PAIR_RE = /([A-Za-z_][\w.-]*)\s*=\s*([^;]*?)\s*;/g;
+const NAME_RE = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+
+export interface WaitRequest {
+  /** Operator-facing name; empty when the payload did not supply one. */
+  name: string;
+  /** Free-text why this run is parking. */
+  reason: string;
+  /** Raw duration token from the payload (advisory). */
+  duration: string;
+  /** Parsed duration in ms, or 0 when absent/invalid. */
+  durationMs: number;
+}
+
+export interface OpenWait {
+  waitId: string;
+  reason: string;
+  name: string;
+  duration: string;
+  iteration: string;
+}
+
+export function isWaitRequestTopic(topic: string): boolean {
+  return topic === WAIT_REQUEST_TOPIC;
+}
+
+export function isWaitLifecycleTopic(topic: string): boolean {
+  return topic === WAIT_OPEN_TOPIC || topic === WAIT_CLOSE_TOPIC;
+}
+
+/**
+ * Parse a `wait.request` payload. Structured `key=value;` pairs win when
+ * present (`name`, `duration`, `reason`); otherwise the whole string is the
+ * reason. Unknown keys are ignored.
+ */
+export function parseWaitRequest(payload: string): WaitRequest {
+  const text = payload.trim();
+  const pairs = parsePairs(text);
+  if (!pairs) {
+    return {
+      name: "",
+      reason: text,
+      duration: "",
+      durationMs: 0,
+    };
+  }
+  const name = pairs.name?.trim() ?? "";
+  const duration = pairs.duration?.trim() ?? "";
+  const reason = (pairs.reason?.trim() || leftoverReason(text)).trim();
+  return {
+    name,
+    reason,
+    duration,
+    durationMs: durationMsOf(duration),
+  };
+}
+
+export function waitIdFor(
+  runId: string,
+  iteration: number,
+  name: string,
+): string {
+  const sanitized = sanitizeWaitName(name);
+  if (sanitized) return sanitized;
+  return `wait_${runId}_${iteration}`;
+}
+
+export function sanitizeWaitName(name: string): string {
+  const cleaned = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (!cleaned || !NAME_RE.test(cleaned)) return "";
+  return cleaned;
+}
+
+export function waitOpenFields(
+  waitId: string,
+  request: WaitRequest,
+): string {
+  const parts = [
+    jsonField("wait_id", waitId),
+    jsonField("reason", request.reason),
+  ];
+  if (request.name) parts.push(jsonField("name", request.name));
+  if (request.duration) parts.push(jsonField("duration", request.duration));
+  if (request.durationMs > 0) {
+    parts.push(jsonField("duration_ms", String(request.durationMs)));
+  }
+  return parts.join(", ");
+}
+
+export function waitCloseFields(waitId: string): string {
+  return jsonField("wait_id", waitId);
+}
+
+/**
+ * Latest unmatched `wait.open` for `runId`, or null when every open has a
+ * later `wait.close`. Used by resume to close the parked wait on the same
+ * run_id.
+ */
+export function openWaitFromLines(
+  lines: string[],
+  runId: string,
+): OpenWait | null {
+  let open: OpenWait | null = null;
+  for (const line of lines) {
+    const event = decodeEvent(line);
+    if (!event || event.run !== runId) continue;
+    if (event.topic === WAIT_OPEN_TOPIC && event.shape === "fields") {
+      open = {
+        waitId: event.fields.wait_id ?? "",
+        reason: event.fields.reason ?? "",
+        name: event.fields.name ?? "",
+        duration: event.fields.duration ?? "",
+        iteration: event.iteration ?? "",
+      };
+    } else if (event.topic === WAIT_CLOSE_TOPIC) {
+      open = null;
+    }
+  }
+  return open;
+}
+
+function parsePairs(payload: string): Record<string, string> | null {
+  const pairs: Record<string, string> = {};
+  let saw = false;
+  PAIR_RE.lastIndex = 0;
+  let match = PAIR_RE.exec(payload);
+  while (match) {
+    saw = true;
+    pairs[match[1]] = match[2].trim();
+    match = PAIR_RE.exec(payload);
+  }
+  return saw ? pairs : null;
+}
+
+function leftoverReason(payload: string): string {
+  return payload.replace(/([A-Za-z_][\w.-]*)\s*=\s*([^;]*?)\s*;/g, "").trim();
+}
+
+function durationMsOf(raw: string): number {
+  if (!raw) return 0;
+  const parsed = parseDurationMs(raw);
+  return parsed !== null && parsed > 0 ? parsed : 0;
+}

--- a/packages/harness/src/wait.ts
+++ b/packages/harness/src/wait.ts
@@ -8,8 +8,11 @@
 // Duration on the request is advisory metadata for a host/operator — v1
 // does not spawn a sleeper. That is the whole point versus `bin/backoff`.
 
-import { jsonField, parseDurationMs } from "@mobrienv/autoloop-core";
-import { decodeEvent } from "@mobrienv/autoloop-core/events/decode";
+import {
+  decodeEvent,
+  jsonField,
+  parseDurationMs,
+} from "@mobrienv/autoloop-core";
 
 export const WAIT_REQUEST_TOPIC = "wait.request";
 export const WAIT_OPEN_TOPIC = "wait.open";
@@ -92,10 +95,7 @@ export function sanitizeWaitName(name: string): string {
   return cleaned;
 }
 
-export function waitOpenFields(
-  waitId: string,
-  request: WaitRequest,
-): string {
+export function waitOpenFields(waitId: string, request: WaitRequest): string {
   const parts = [
     jsonField("wait_id", waitId),
     jsonField("reason", request.reason),

--- a/packages/harness/test/harness/ask.test.ts
+++ b/packages/harness/test/harness/ask.test.ts
@@ -117,6 +117,9 @@ describe("ask topics are non-routing", () => {
     expect(routingTopic("ask.pending")).toBe(false);
     expect(routingTopic("ask.answered")).toBe(false);
     expect(routingTopic("ask.timeout")).toBe(false);
+    expect(routingTopic("wait.request")).toBe(false);
+    expect(routingTopic("wait.open")).toBe(false);
+    expect(routingTopic("wait.close")).toBe(false);
   });
 
   it("still treats ordinary success events as routing", () => {

--- a/packages/harness/test/harness/emit.test.ts
+++ b/packages/harness/test/harness/emit.test.ts
@@ -64,6 +64,12 @@ describe("coreSystemTopic", () => {
     expect(coreSystemTopic("hook.suspend")).toBe(true);
   });
 
+  it("recognizes durable-wait lifecycle records as system topics", () => {
+    expect(coreSystemTopic("wait.open")).toBe(true);
+    expect(coreSystemTopic("wait.close")).toBe(true);
+    expect(coreSystemTopic("wait.request")).toBe(false);
+  });
+
   it("rejects non-system topics", () => {
     expect(coreSystemTopic("task.complete")).toBe(false);
     expect(coreSystemTopic("gaps.identified")).toBe(false);
@@ -213,6 +219,12 @@ describe("routingTopic", () => {
 
   it("loop.start is routing", () => {
     expect(routingTopic("loop.start")).toBe(true);
+  });
+
+  it("durable wait topics are not routing", () => {
+    expect(routingTopic("wait.request")).toBe(false);
+    expect(routingTopic("wait.open")).toBe(false);
+    expect(routingTopic("wait.close")).toBe(false);
   });
 });
 

--- a/packages/harness/test/harness/prompt.test.ts
+++ b/packages/harness/test/harness/prompt.test.ts
@@ -69,6 +69,15 @@ describe("routingEventFromLines", () => {
     expect(routingEventFromLines(lines)).toBe("gaps.identified");
   });
 
+  it("does not treat wait.request as a routing event", () => {
+    const lines = [
+      payloadLine("gaps.identified", "found stuff"),
+      payloadLine("wait.request", "name=nap; reason=hold;"),
+      fieldsLine("wait.open", { wait_id: "nap", reason: "hold" }),
+    ];
+    expect(routingEventFromLines(lines)).toBe("gaps.identified");
+  });
+
   it("tracks latest routing event through multiple events", () => {
     const lines = [
       payloadLine("gaps.identified", "a"),

--- a/packages/harness/test/harness/resume-iteration.test.ts
+++ b/packages/harness/test/harness/resume-iteration.test.ts
@@ -82,4 +82,9 @@ describe("determineResumeIteration", () => {
       3,
     );
   });
+
+  it("waiting with iteration.finish resumes at the next iteration", () => {
+    const journal = writeJournal([finish("1")]);
+    expect(determineResumeIteration(journal, RUN, "waiting", 1)).toBe(2);
+  });
 });

--- a/packages/harness/test/harness/resume.test.ts
+++ b/packages/harness/test/harness/resume.test.ts
@@ -194,4 +194,35 @@ describe("harness.resume integration", () => {
     const resumeIters = runIteration.mock.calls.map((c) => c[1]);
     expect(resumeIters).toEqual([4, 5, 6]);
   });
+
+  it("closes an open durable wait on the same run_id before loop.resume", async () => {
+    const dir = makeProject(3);
+    await run(dir, "prompt", "autoloop", { workDir: dir });
+    const journalFile = join(dir, ".autoloop", "journal.jsonl");
+    appendEvent(
+      journalFile,
+      "run-resume-test",
+      "3",
+      "wait.open",
+      `"wait_id": "company-nap", "reason": "between steps"`,
+    );
+
+    runIteration.mockClear();
+    const waiting = {
+      ...recordFor(dir),
+      status: "waiting" as const,
+      stop_reason: "waiting",
+    };
+    const result = await resume(waiting, { addIterations: 1 });
+    expect(result.resumedFromIteration).toBe(4);
+
+    const journal = readFileSync(journalFile, "utf-8");
+    const openAt = journal.indexOf('"topic": "wait.open"');
+    const closeAt = journal.indexOf('"topic": "wait.close"');
+    const resumeAt = journal.indexOf('"topic": "loop.resume"');
+    expect(openAt).toBeGreaterThan(-1);
+    expect(closeAt).toBeGreaterThan(openAt);
+    expect(resumeAt).toBeGreaterThan(closeAt);
+    expect(journal).toContain('"wait_id": "company-nap"');
+  });
 });

--- a/packages/harness/test/harness/resume.test.ts
+++ b/packages/harness/test/harness/resume.test.ts
@@ -197,11 +197,12 @@ describe("harness.resume integration", () => {
 
   it("closes an open durable wait on the same run_id before loop.resume", async () => {
     const dir = makeProject(3);
-    await run(dir, "prompt", "autoloop", { workDir: dir });
+    const first = await run(dir, "prompt", "autoloop", { workDir: dir });
+    const runId = first.runId ?? "run-resume-test";
     const journalFile = join(dir, ".autoloop", "journal.jsonl");
     appendEvent(
       journalFile,
-      "run-resume-test",
+      runId,
       "3",
       "wait.open",
       `"wait_id": "company-nap", "reason": "between steps"`,
@@ -210,6 +211,7 @@ describe("harness.resume integration", () => {
     runIteration.mockClear();
     const waiting = {
       ...recordFor(dir),
+      run_id: runId,
       status: "waiting" as const,
       stop_reason: "waiting",
     };

--- a/packages/harness/test/harness/scratchpad.test.ts
+++ b/packages/harness/test/harness/scratchpad.test.ts
@@ -200,3 +200,53 @@ describe("loop.resume scratchpad marker", () => {
     );
   });
 });
+
+function waitLine(
+  topic: "wait.open" | "wait.close",
+  waitId: string,
+  reason = "",
+): string {
+  return encodeEvent({
+    shape: "fields",
+    run: "r1",
+    iteration: "1",
+    topic,
+    fields: { wait_id: waitId, reason },
+    rawFields: { wait_id: waitId, reason },
+  }).trim();
+}
+
+describe("wait scratchpad markers", () => {
+  it("renders wait.open and wait.close between iterations", () => {
+    const lines = [
+      iterFinishLine("1", "0", "before"),
+      waitLine("wait.open", "company-nap", "between steps"),
+      waitLine("wait.close", "company-nap"),
+      iterFinishLine("2", "0", "after"),
+    ];
+    const result = renderRunScratchpadFull(lines);
+    expect(result).toContain("--- wait.open company-nap: between steps ---");
+    expect(result).toContain("--- wait.close company-nap ---");
+  });
+
+  it("falls back when wait_id is missing", () => {
+    const lines = [waitLine("wait.open", "", ""), waitLine("wait.close", "")];
+    const result = renderRunScratchpadFull(lines);
+    expect(result).toContain("--- wait.open wait ---");
+    expect(result).toContain("--- wait.close wait ---");
+  });
+
+  it("renders wait markers in the compacted earlier section", () => {
+    const lines = [
+      iterFinishLine("1", "0", "a"),
+      waitLine("wait.open", "nap", "hold"),
+      iterFinishLine("2", "0", "b"),
+      iterFinishLine("3", "0", "c"),
+      iterFinishLine("4", "0", "d"),
+      iterFinishLine("5", "0", "e"),
+    ];
+    const result = renderRunScratchpadPrompt(lines);
+    expect(result).toContain("Earlier iterations (compacted)");
+    expect(result).toContain("--- wait.open nap: hold ---");
+  });
+});

--- a/packages/harness/test/harness/stop-reason.test.ts
+++ b/packages/harness/test/harness/stop-reason.test.ts
@@ -53,6 +53,7 @@ function isKnownStopReason(reason: StopReason): true {
     case "premature_quit":
     case "interrupted":
     case "suspended":
+    case "waiting":
     case "verdict_exit":
     case "verdict_takeover":
     case "verdict_unknown":
@@ -70,8 +71,8 @@ function isKnownStopReason(reason: StopReason): true {
 }
 
 describe("StopReason exhaustiveness", () => {
-  it("has exactly the 25 documented literals (23 from the issue + parallel_wave_invalid + suspended)", () => {
-    expect(STOP_REASONS.length).toBe(25);
+  it("has exactly the 26 documented literals (23 from the issue + parallel_wave_invalid + suspended + waiting)", () => {
+    expect(STOP_REASONS.length).toBe(26);
     expect(new Set(STOP_REASONS).size).toBe(STOP_REASONS.length);
   });
 

--- a/packages/harness/test/harness/wait.test.ts
+++ b/packages/harness/test/harness/wait.test.ts
@@ -236,7 +236,13 @@ describe("finishIteration parks on wait.request", () => {
         requiredEvents: [],
         mustBeLast: false,
       },
-      topology: { roles: [], handoff: {}, handoffKeys: [], gates: [], stages: [] },
+      topology: {
+        roles: [],
+        handoff: {},
+        handoffKeys: [],
+        gates: [],
+        stages: [],
+      },
       paths: {
         journalFile,
         registryFile,

--- a/packages/harness/test/harness/wait.test.ts
+++ b/packages/harness/test/harness/wait.test.ts
@@ -1,0 +1,291 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { encodeEvent } from "@mobrienv/autoloop-core";
+import { appendAgentEvent, appendEvent } from "@mobrienv/autoloop-core/journal";
+import { emit } from "@mobrienv/autoloop-harness/emit";
+import { finishIteration } from "@mobrienv/autoloop-harness/iteration";
+import type { LoopContext } from "@mobrienv/autoloop-harness/types";
+import {
+  isWaitLifecycleTopic,
+  isWaitRequestTopic,
+  openWaitFromLines,
+  parseWaitRequest,
+  sanitizeWaitName,
+  WAIT_CLOSE_TOPIC,
+  WAIT_OPEN_TOPIC,
+  WAIT_REQUEST_TOPIC,
+  waitCloseFields,
+  waitIdFor,
+  waitOpenFields,
+} from "@mobrienv/autoloop-harness/wait";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("wait.request topics", () => {
+  it("recognizes the reserved request and lifecycle names", () => {
+    expect(isWaitRequestTopic(WAIT_REQUEST_TOPIC)).toBe(true);
+    expect(isWaitRequestTopic("human.ask")).toBe(false);
+    expect(isWaitLifecycleTopic(WAIT_OPEN_TOPIC)).toBe(true);
+    expect(isWaitLifecycleTopic(WAIT_CLOSE_TOPIC)).toBe(true);
+    expect(isWaitLifecycleTopic(WAIT_REQUEST_TOPIC)).toBe(false);
+  });
+});
+
+describe("parseWaitRequest", () => {
+  it("treats free text as the reason", () => {
+    const parsed = parseWaitRequest("nap until morning");
+    expect(parsed.reason).toBe("nap until morning");
+    expect(parsed.name).toBe("");
+    expect(parsed.duration).toBe("");
+    expect(parsed.durationMs).toBe(0);
+  });
+
+  it("trims a blank payload to an empty reason", () => {
+    const parsed = parseWaitRequest("   ");
+    expect(parsed.reason).toBe("");
+    expect(parsed.name).toBe("");
+  });
+
+  it("reads structured name, duration, and reason pairs", () => {
+    const parsed = parseWaitRequest(
+      "name=company-nap; duration=300s; reason=between company steps;",
+    );
+    expect(parsed.name).toBe("company-nap");
+    expect(parsed.duration).toBe("300s");
+    expect(parsed.durationMs).toBe(300_000);
+    expect(parsed.reason).toBe("between company steps");
+  });
+
+  it("keeps leftover prose as the reason when reason= is absent", () => {
+    const parsed = parseWaitRequest("duration=5m; hold for review");
+    expect(parsed.duration).toBe("5m");
+    expect(parsed.durationMs).toBe(300_000);
+    expect(parsed.reason).toBe("hold for review");
+  });
+
+  it("ignores unknown keys and invalid durations", () => {
+    const parsed = parseWaitRequest("foo=bar; duration=nope; reason=park;");
+    expect(parsed.reason).toBe("park");
+    expect(parsed.duration).toBe("nope");
+    expect(parsed.durationMs).toBe(0);
+  });
+
+  it("accepts a bare-millisecond duration", () => {
+    const parsed = parseWaitRequest("duration=1500; reason=short;");
+    expect(parsed.durationMs).toBe(1500);
+  });
+});
+
+describe("waitIdFor / sanitizeWaitName", () => {
+  it("uses a sanitized supplied name", () => {
+    expect(waitIdFor("swift-agent", 3, "Company Nap")).toBe("company-nap");
+    expect(sanitizeWaitName("Company Nap")).toBe("company-nap");
+  });
+
+  it("falls back to wait_<runId>_<iteration> when the name is empty or illegal", () => {
+    expect(waitIdFor("swift-agent", 3, "")).toBe("wait_swift-agent_3");
+    expect(waitIdFor("swift-agent", 3, "!!!")).toBe("wait_swift-agent_3");
+    expect(sanitizeWaitName("")).toBe("");
+    expect(sanitizeWaitName("---")).toBe("");
+  });
+});
+
+describe("wait open/close field encoding", () => {
+  it("includes optional name and duration when present", () => {
+    const fields = waitOpenFields("company-nap", {
+      name: "company-nap",
+      reason: "between steps",
+      duration: "300s",
+      durationMs: 300_000,
+    });
+    expect(fields).toContain('"wait_id": "company-nap"');
+    expect(fields).toContain('"reason": "between steps"');
+    expect(fields).toContain('"name": "company-nap"');
+    expect(fields).toContain('"duration": "300s"');
+    expect(fields).toContain('"duration_ms": "300000"');
+  });
+
+  it("omits empty optional fields", () => {
+    const fields = waitOpenFields("wait_run_1", {
+      name: "",
+      reason: "nap",
+      duration: "",
+      durationMs: 0,
+    });
+    expect(fields).toContain('"wait_id": "wait_run_1"');
+    expect(fields).toContain('"reason": "nap"');
+    expect(fields).not.toContain('"name"');
+    expect(fields).not.toContain("duration");
+  });
+
+  it("encodes wait.close with the wait id", () => {
+    expect(waitCloseFields("company-nap")).toContain(
+      '"wait_id": "company-nap"',
+    );
+  });
+});
+
+describe("openWaitFromLines", () => {
+  const run = "swift-agent";
+
+  function openLine(waitId: string, iteration = "1"): string {
+    return encodeEvent({
+      shape: "fields",
+      run,
+      iteration,
+      topic: WAIT_OPEN_TOPIC,
+      fields: { wait_id: waitId, reason: "nap" },
+    }).trim();
+  }
+
+  function closeLine(waitId: string): string {
+    return encodeEvent({
+      shape: "fields",
+      run,
+      topic: WAIT_CLOSE_TOPIC,
+      fields: { wait_id: waitId },
+    }).trim();
+  }
+
+  it("returns the latest unmatched wait.open", () => {
+    const open = openWaitFromLines([openLine("wait_a")], run);
+    expect(open).toEqual({
+      waitId: "wait_a",
+      reason: "nap",
+      name: "",
+      duration: "",
+      iteration: "1",
+    });
+  });
+
+  it("returns null when the latest open has been closed", () => {
+    expect(
+      openWaitFromLines([openLine("wait_a"), closeLine("wait_a")], run),
+    ).toBeNull();
+  });
+
+  it("ignores other runs and malformed lines", () => {
+    const other = encodeEvent({
+      shape: "fields",
+      run: "other",
+      topic: WAIT_OPEN_TOPIC,
+      fields: { wait_id: "other-wait" },
+    }).trim();
+    expect(openWaitFromLines(["not-json", other], run)).toBeNull();
+  });
+
+  it("reopens after a close when a later wait.open appears", () => {
+    const open = openWaitFromLines(
+      [openLine("wait_a"), closeLine("wait_a"), openLine("wait_b", "4")],
+      run,
+    );
+    expect(open?.waitId).toBe("wait_b");
+    expect(open?.iteration).toBe("4");
+  });
+});
+
+describe("emit accepts wait.request regardless of topology", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("journals wait.request even when allowed events are restricted", () => {
+    const dir = mkdtempSync(join(tmpdir(), "autoloop-wait-emit-"));
+    mkdirSync(join(dir, ".autoloop"), { recursive: true });
+    writeFileSync(join(dir, "autoloops.toml"), "");
+    const journalFile = join(dir, ".autoloop", "journal.jsonl");
+    appendEvent(journalFile, "run-1", "1", "loop.start", "");
+    vi.stubEnv("AUTOLOOP_JOURNAL_FILE", journalFile);
+    vi.stubEnv("AUTOLOOP_RUN_ID", "run-1");
+    vi.stubEnv("AUTOLOOP_ITERATION", "1");
+    vi.stubEnv("AUTOLOOP_ALLOWED_EVENTS", "review.ready,task.complete");
+    vi.stubEnv("AUTOLOOP_RECENT_EVENT", "loop.start");
+
+    const result = emit(dir, "wait.request", "name=nap; reason=hold;");
+    expect(result.ok).toBe(true);
+    expect(result.topic).toBe("wait.request");
+    const journal = readFileSync(journalFile, "utf-8");
+    expect(journal).toContain('"topic": "wait.request"');
+    expect(journal).not.toContain('"topic": "event.invalid"');
+  });
+});
+
+describe("finishIteration parks on wait.request", () => {
+  it("journals wait.open and returns waiting without calling iterate", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "autoloop-wait-finish-"));
+    const stateDir = join(dir, ".autoloop");
+    mkdirSync(stateDir, { recursive: true });
+    const journalFile = join(stateDir, "journal.jsonl");
+    const registryFile = join(stateDir, "registry.jsonl");
+    appendEvent(journalFile, "swift-agent", "1", "loop.start", "");
+    appendAgentEvent(
+      journalFile,
+      "swift-agent",
+      "1",
+      "wait.request",
+      "name=company-nap; duration=300s; reason=between steps;",
+    );
+
+    const events: Array<{ type: string }> = [];
+    const loop = {
+      ask: { enabled: true, event: "human.ask", timeoutMs: 0, pollMs: 0 },
+      parallel: { enabled: false },
+      completion: {
+        promise: "LOOP_COMPLETE",
+        event: "task.complete",
+        requiredEvents: [],
+        mustBeLast: false,
+      },
+      topology: { roles: [], handoff: {}, handoffKeys: [], gates: [], stages: [] },
+      paths: {
+        journalFile,
+        registryFile,
+        tasksFile: join(stateDir, "tasks.jsonl"),
+        stateDir,
+      },
+      runtime: { runId: "swift-agent" },
+      launch: {
+        preset: "test",
+        trigger: "cli",
+        createdAt: new Date().toISOString(),
+        parentRunId: "",
+      },
+      objective: "park",
+      backend: { kind: "command", command: "echo", args: [] },
+      limits: { maxIterations: 5 },
+      lastVerdict: undefined,
+      onEvent: (e: { type: string }) => {
+        events.push(e);
+      },
+    } as unknown as LoopContext;
+
+    const iterate = vi.fn();
+    const summary = await finishIteration(
+      loop,
+      {
+        iteration: 1,
+        recentEvent: "loop.start",
+        allowedRoles: ["builder"],
+        allowedEvents: ["review.ready"],
+      },
+      "parking",
+      iterate,
+    );
+
+    expect(iterate).not.toHaveBeenCalled();
+    expect(summary.stopReason).toBe("waiting");
+    expect(summary.runId).toBeUndefined();
+    expect(summary.iterations).toBe(1);
+    const journal = readFileSync(journalFile, "utf-8");
+    expect(journal).toContain('"topic": "wait.open"');
+    expect(journal).toContain('"wait_id": "company-nap"');
+    expect(journal).toContain('"topic": "loop.stop"');
+    expect(journal).toContain('"reason": "waiting"');
+    expect(events.some((e) => e.type === "wait.open")).toBe(true);
+    const record = JSON.parse(
+      readFileSync(registryFile, "utf-8").trim().split("\n").at(-1) ?? "{}",
+    );
+    expect(record.status).toBe("waiting");
+    expect(record.pid).toBeUndefined();
+  });
+});

--- a/packages/harness/test/harness/wait.test.ts
+++ b/packages/harness/test/harness/wait.test.ts
@@ -74,6 +74,23 @@ describe("parseWaitRequest", () => {
     const parsed = parseWaitRequest("duration=1500; reason=short;");
     expect(parsed.durationMs).toBe(1500);
   });
+
+  it("treats an empty or zero duration as advisory-absent", () => {
+    const empty = parseWaitRequest("name=nap; duration=; leftover prose");
+    expect(empty.duration).toBe("");
+    expect(empty.durationMs).toBe(0);
+    expect(empty.reason).toBe("leftover prose");
+
+    const zero = parseWaitRequest("duration=0; reason=now;");
+    expect(zero.duration).toBe("0");
+    expect(zero.durationMs).toBe(0);
+  });
+
+  it("falls back to leftover prose when reason= is blank", () => {
+    const parsed = parseWaitRequest("name=nap; reason=   ; hold the line");
+    expect(parsed.name).toBe("nap");
+    expect(parsed.reason).toBe("hold the line");
+  });
 });
 
 describe("waitIdFor / sanitizeWaitName", () => {
@@ -172,6 +189,21 @@ describe("openWaitFromLines", () => {
       fields: { wait_id: "other-wait" },
     }).trim();
     expect(openWaitFromLines(["not-json", other], run)).toBeNull();
+  });
+
+  it("defaults missing wait.open fields to empty strings", () => {
+    const bare = JSON.stringify({
+      run,
+      topic: WAIT_OPEN_TOPIC,
+      fields: {},
+    });
+    expect(openWaitFromLines([bare], run)).toEqual({
+      waitId: "",
+      reason: "",
+      name: "",
+      duration: "",
+      iteration: "",
+    });
   });
 
   it("reopens after a close when a later wait.open appears", () => {

--- a/packages/harness/test/registry-bridge.test.ts
+++ b/packages/harness/test/registry-bridge.test.ts
@@ -222,4 +222,16 @@ describe("registryStop", () => {
     registryStop(loop, 2, "backend_failed");
     expect(readLines()[1].outcome).toBe("failed");
   });
+
+  it("parks a waiting run without a live pid", () => {
+    const loop = makeLoopContext();
+    registryStart(loop);
+    expect(readLines()[0].pid).toBe(process.pid);
+    registryStop(loop, 1, "waiting");
+    const r = readLines()[1];
+    expect(r.status).toBe("waiting");
+    expect(r.stop_reason).toBe("waiting");
+    expect(r.pid).toBeUndefined();
+    expect(r.outcome).toBe("stopped");
+  });
 });

--- a/test/fixtures/backend/wait-request.json
+++ b/test/fixtures/backend/wait-request.json
@@ -1,0 +1,7 @@
+{
+  "output": "Parking this run until the host resumes it.",
+  "exit_code": 0,
+  "delay_ms": 0,
+  "emit_event": "wait.request",
+  "emit_payload": "name=company-nap; duration=300s; reason=between company steps;"
+}

--- a/test/integration/durable-wait.test.ts
+++ b/test/integration/durable-wait.test.ts
@@ -1,0 +1,144 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+  ensureBuild,
+  FIXTURES_DIR,
+  makeTempProject,
+  runCli,
+} from "../helpers/runtime.js";
+
+beforeAll(() => {
+  ensureBuild();
+});
+
+function soleRunId(project: string): string {
+  const [runId] = readdirSync(join(project, ".autoloop", "runs"));
+  return runId;
+}
+
+function journalOf(project: string): string {
+  return readFileSync(join(project, ".autoloop", "journal.jsonl"), "utf-8");
+}
+
+function registryRecord(
+  project: string,
+  runId: string,
+): { status: string; stop_reason: string; pid?: number; run_id: string } {
+  const path = join(project, ".autoloop", "registry.jsonl");
+  const lines = readFileSync(path, "utf-8")
+    .trim()
+    .split("\n")
+    .filter(Boolean);
+  let latest: {
+    status: string;
+    stop_reason: string;
+    pid?: number;
+    run_id: string;
+  } | null = null;
+  for (const line of lines) {
+    const rec = JSON.parse(line) as {
+      status: string;
+      stop_reason: string;
+      pid?: number;
+      run_id: string;
+    };
+    if (rec.run_id === runId) latest = rec;
+  }
+  if (!latest) throw new Error(`no registry record for ${runId}`);
+  return latest;
+}
+
+function topicCount(journal: string, topic: string): number {
+  return journal
+    .split("\n")
+    .filter((line) => line.includes(`"topic": "${topic}"`)).length;
+}
+
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("integration: durable wait.request (T-008 verify gate)", () => {
+  it("parks, exits 0, stays process-free, then resumes on the same run_id", () => {
+    const project = makeTempProject("durable-wait");
+    const first = runCli(
+      ["run", project, "park between company steps", "--max-iterations", "4"],
+      { MOCK_FIXTURE_PATH: join(FIXTURES_DIR, "wait-request.json") },
+    );
+
+    // 3. process exits 0 while waiting
+    expect(first.status).toBe(0);
+
+    const runId = soleRunId(project);
+    expect(runId).toBeTruthy();
+    const parkedJournal = journalOf(project);
+    const parked = registryRecord(project, runId);
+
+    // 1. wait.request
+    expect(parkedJournal).toContain('"topic": "wait.request"');
+    expect(parkedJournal).toContain("company-nap");
+    expect(parkedJournal).toContain("between company steps");
+
+    // 5. wait.open
+    expect(parkedJournal).toContain('"topic": "wait.open"');
+    expect(parkedJournal).toContain('"wait_id": "company-nap"');
+    expect(first.stderr).toContain("[wait] parked run");
+    expect(first.stderr).toContain(`autoloop resume ${runId}`);
+
+    // 2. waiting state with no live backend process
+    expect(parked.status).toBe("waiting");
+    expect(parked.stop_reason).toBe("waiting");
+    expect(parked.pid).toBeUndefined();
+    expect(existsSync(join(project, ".autoloop", "runs", runId))).toBe(true);
+
+    // 4. no backend burning timeout during the wait — the iteration that
+    // requested the wait produced exactly one backend.start, then parked.
+    const backendsBefore = topicCount(parkedJournal, "backend.start");
+    expect(backendsBefore).toBe(1);
+    expect(parkedJournal).not.toContain('"topic": "wait.close"');
+    expect(parkedJournal).not.toContain('"topic": "loop.resume"');
+
+    // Default loops list includes parked waits (live, not hidden).
+    const loops = runCli(["loops", "--json"], {}, project);
+    expect(loops.status).toBe(0);
+    expect(loops.stdout).toContain(runId);
+    expect(loops.stdout).toContain('"status": "waiting"');
+
+    // Resume on the same run_id with a completing fixture. The parked
+    // process is already gone — this is a new process, same journal.
+    const resume = runCli(
+      ["resume", runId],
+      { MOCK_FIXTURE_PATH: join(FIXTURES_DIR, "complete-success.json") },
+      project,
+    );
+    expect(resume.status).toBe(0);
+    expect(resume.stdout).toContain(`resumed ${runId}`);
+
+    const resumedJournal = journalOf(project);
+    const finished = registryRecord(project, runId);
+
+    // 6. resume  7. wait.close  8. same run_id throughout
+    expect(resumedJournal).toContain('"topic": "wait.close"');
+    expect(resumedJournal).toContain('"topic": "loop.resume"');
+    expect(resume.stderr).toContain("[wait] closed company-nap");
+    expect(finished.run_id).toBe(runId);
+    expect(parked.run_id).toBe(runId);
+
+    // After wait.close the loop invoked the backend again (new process).
+    expect(topicCount(resumedJournal, "backend.start")).toBeGreaterThan(
+      backendsBefore,
+    );
+    expect(resumedJournal).toContain('"topic": "loop.complete"');
+
+    // The parked pid never came back — waiting was process-free.
+    if (parked.pid !== undefined) {
+      expect(pidAlive(parked.pid)).toBe(false);
+    }
+  });
+});

--- a/test/integration/durable-wait.test.ts
+++ b/test/integration/durable-wait.test.ts
@@ -26,10 +26,7 @@ function registryRecord(
   runId: string,
 ): { status: string; stop_reason: string; pid?: number; run_id: string } {
   const path = join(project, ".autoloop", "registry.jsonl");
-  const lines = readFileSync(path, "utf-8")
-    .trim()
-    .split("\n")
-    .filter(Boolean);
+  const lines = readFileSync(path, "utf-8").trim().split("\n").filter(Boolean);
   let latest: {
     status: string;
     stop_reason: string;

--- a/test/setup/hermetic-env.ts
+++ b/test/setup/hermetic-env.ts
@@ -22,3 +22,15 @@ if (!process.env.AUTOLOOP_CONFIG) {
   writeFileSync(cfg, "");
   process.env.AUTOLOOP_CONFIG = cfg;
 }
+
+// `git commit` in beforeEach (file-mod-audit, tamper, postconditions) inherits
+// the developer's global commit.gpgsign / core.fsmonitor. Signing + fsmonitor
+// on throwaway /tmp repos stalls past vitest's 10s hookTimeout under coverage.
+// GIT_CONFIG_* is `git -c` precedence and leaves the rest of global config.
+if (!process.env.GIT_CONFIG_COUNT) {
+  process.env.GIT_CONFIG_COUNT = "2";
+  process.env.GIT_CONFIG_KEY_0 = "commit.gpgsign";
+  process.env.GIT_CONFIG_VALUE_0 = "false";
+  process.env.GIT_CONFIG_KEY_1 = "core.fsmonitor";
+  process.env.GIT_CONFIG_VALUE_1 = "false";
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -81,6 +81,7 @@ export default defineConfig({
       "@mobrienv/autoloop-harness/types": `${HARNESS}/types.ts`,
       "@mobrienv/autoloop-harness/events": `${HARNESS}/events.ts`,
       "@mobrienv/autoloop-harness/emit": `${HARNESS}/emit.ts`,
+      "@mobrienv/autoloop-harness/wait": `${HARNESS}/wait.ts`,
       "@mobrienv/autoloop-harness/ask": `${HARNESS}/ask.ts`,
       "@mobrienv/autoloop-harness/artifacts": `${HARNESS}/artifacts.ts`,
       "@mobrienv/autoloop-harness/config-helpers": `${HARNESS}/config-helpers.ts`,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -123,8 +123,10 @@ export default defineConfig({
     env: { TZ: "UTC" },
     // Integration tests under test/worktree and test/integration spawn git/node
     // subprocesses. Cap worker pool so subprocess-heavy tests don't starve each
-    // other; bump testTimeout to absorb spiky CI/load.
+    // other; bump timeouts to absorb spiky CI/load. hookTimeout covers
+    // beforeEach git init/commit (default 10s is too tight under coverage).
     testTimeout: 60000,
+    hookTimeout: 60000,
     poolOptions: {
       threads: {
         maxThreads: 4,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Parks a named run without a live backend, then resumes on the same `run_id`.

PRs #65 and #72 do not implement `wait.request` — they are Stage 0/1 soundness and `--events` parent-dir creation. This is the T-008 vehicle.

The July spec (`docs/superpowers/specs/2026-07-19-durable-waits-sdk-host.md`) is not on main. Implementation follows the verify gate plus existing wait/ask/resume types.

## What shipped

An agent emits reserved `wait.request` (always accepted; not a routing event). The harness:

1. journals `wait.open`
2. sets registry status to `waiting` and clears the PID
3. returns `stopReason: "waiting"` so the process **exits 0**
4. does not sleep or hold `backend.timeout_ms`

`autoloop resume <run-id>` journals `wait.close` then `loop.resume` and continues on the **same** `run_id`. Duration on the request is advisory metadata for a host/operator — v1 does not spawn a sleeper.

`human.ask` still blocks the live process (HITL). This is the process-free park, not a second wait product.

## Verify gate (one `run_id`)

Covered by `test/integration/durable-wait.test.ts` plus unit tests:

1. `wait.request`
2. process-free `waiting` (no live PID)
3. process exits 0
4. no backend start between `wait.open` and `wait.close`
5. `wait.open`
6. `resume`
7. `wait.close`
8. same `run_id` throughout

Local evidence: the integration test passed on this branch (park → exit 0 → waiting/no pid → resume → wait.close → loop.complete, same id).

## Out of scope

Wait card UI, T-009, `/ops` dashboard chrome, roles, `vision.md` / `owner.md`, spark/Comfy.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86b0f5a2-e17f-4cc0-a176-1545f4f788b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86b0f5a2-e17f-4cc0-a176-1545f4f788b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

