### PR TITLE
fix(cli): create parent dir for --events path (#68)

### DIFF
--- a/packages/cli/src/cli/events-sink.ts
+++ b/packages/cli/src/cli/events-sink.ts
@@ -12,7 +12,8 @@
 // result (runId, iterations, stopReason), so a consumer gets the outcome from
 // the stream without parsing the journal.
 
-import { closeSync, openSync, writeSync } from "node:fs";
+import { closeSync, mkdirSync, openSync, writeSync } from "node:fs";
+import { dirname } from "node:path";
 import type { LoopEvent } from "@mobrienv/autoloop-harness/events";
 
 export interface EventSink {
@@ -27,6 +28,11 @@ export interface EventSink {
  * is best-effort: a write failure is swallowed so it can never crash the loop.
  */
 export function ndjsonEventSink(path: string): EventSink {
+  // Ensure the parent directory exists so `--events <nested/path/file.jsonl>`
+  // works from a fresh project without an existing state directory. This
+  // mirrors how other AutoLoop state/log paths create their parents and avoids
+  // an ENOENT from `openSync` when the directory does not yet exist.
+  mkdirSync(dirname(path), { recursive: true });
   const fd = openSync(path, "a");
   return {
     onEvent(event: LoopEvent): void {

--- a/packages/cli/test/cli/events-sink.test.ts
+++ b/packages/cli/test/cli/events-sink.test.ts
@@ -24,6 +24,21 @@ const sampleEvents: LoopEvent[] = [
 ];
 
 describe("ndjsonEventSink", () => {
+  it("creates the parent directory of a nested --events path", () => {
+    const dir = mkdtempSync(join(tmpdir(), "autoloop-events-"));
+    // Use a nested path whose parent does not yet exist.
+    const nested = join(dir, "deep", "sub", "events.ndjson");
+    const sink = ndjsonEventSink(nested);
+    sink.onEvent(sampleEvents[0]);
+    sink.close();
+
+    const lines = readFileSync(nested, "utf-8")
+      .split("\n")
+      .filter((l) => l.trim() !== "");
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]).type).toBe("iteration.start");
+  });
+
   it("writes one valid NDJSON line per event", () => {
     const path = tmpFile("events.ndjson");
     const sink = ndjsonEventSink(path);

--- a/test/integration/run-loop.test.ts
+++ b/test/integration/run-loop.test.ts
@@ -292,21 +292,29 @@ describe("integration: run loop with mock backend", () => {
     expect(result.stopReason).toBeTruthy();
   });
 
-  it("fails cleanly (no stack trace) when the --events path is unwritable", () => {
-    const project = makeTempProject("events-unwritable");
+  it("creates parent dirs for a nested --events path and writes the stream (#72)", () => {
+    const project = makeTempProject("events-nested");
     const fixture = join(FIXTURES_DIR, "complete-success.json");
-    // Parent directories do not exist -> openSync('a') throws ENOENT.
-    const badPath = join(project, "no", "such", "dir", "events.ndjson");
+    // Nested path whose parents do not exist; ndjsonEventSink mkdir -p's them
+    // so the loop runs and writes the stream (was ENOENT before #72).
+    const nestedPath = join(project, "no", "such", "dir", "events.ndjson");
     const res = runCli(
-      ["run", project, "events unwritable", "--events", badPath],
+      ["run", project, "events nested", "--events", nestedPath],
       { MOCK_FIXTURE_PATH: fixture },
     );
 
-    expect(res.stderr).toContain("cannot open --events file");
-    // Clean message, not a raw thrown stack.
-    expect(res.stderr).not.toMatch(/\n\s+at\s+.+:\d+:\d+/);
-    // The loop never started.
-    expect(pathExists(join(project, ".autoloop/journal.jsonl"))).toBe(false);
+    expect(res.status).toBe(0);
+    // Parent directories were created and the NDJSON stream was written.
+    expect(pathExists(nestedPath)).toBe(true);
+    const lines = readText(nestedPath)
+      .split("\n")
+      .filter((l) => l.trim() !== "");
+    expect(lines.length).toBeGreaterThan(0);
+    for (const line of lines) {
+      expect(() => JSON.parse(line)).not.toThrow();
+    }
+    // The loop actually ran.
+    expect(pathExists(join(project, ".autoloop/journal.jsonl"))).toBe(true);
   });
 
   it("stamps every journal line with the versioned, timestamped contract (#31)", () => {


### PR DESCRIPTION
## What

`ndjsonEventSink` now creates the parent directory of an explicitly requested `--events` path before opening the file, so a fresh project without an existing state directory no longer fails with ENOENT (exit 2, 'cannot open --events file').

Re-prepares https://github.com/mikeyobrien/autoloop/pull/72, which was closed unmerged (superseded by the #73/#74 landings). The cherry-pick onto current main is clean.

## Tests

- Full suite: **209 files, 2349 passed, 4 skipped, 0 failed**
- New integration test: nested `--events` path whose parents do not exist -> exit 0, NDJSON stream written, journal exists
- Replaces the old 'unwritable --events path fails cleanly' test, which asserted the pre-fix behavior (ENOENT on nested paths). A genuinely unwritable leaf (e.g. under a read-only dir) still fails cleanly via the existing openSync error path.
- biome clean

Fixes #68.