### PR TITLE
Surface parked waiting runs in health buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
   compile time.
 
 ### Fixed
+- **Parked waiting runs appear in run health.** `categorizeRecords` now
+  buckets `status=waiting` (no PID required) instead of dropping them, so
+  `autoloop loops health` and `GET /api/runs` list a `waiting` bucket
+  alongside active, watching, stuck, failed, and completed.
 - **Configured prompt files cannot escape their declared roots.** Objective,
   review, harness-instruction, and topology role paths now reject parent
   traversal and symlink escapes while preserving optional and explicitly empty

--- a/docs/features/dashboard.md
+++ b/docs/features/dashboard.md
@@ -31,7 +31,7 @@ The SPA has four zones:
 
 1. **Header** — title and last-updated timestamp.
 2. **Chat box** — preset dropdown, prompt textarea, and Start button. Submit with the button or `Cmd/Ctrl+Enter`.
-3. **Run list** — collapsible sections grouped by health status: active, watching, stuck, failed, completed. Each entry shows run ID prefix, preset, iteration count, latest event, and age. Worktree runs display a `WT` badge; merged worktrees show a checkmark.
+3. **Run list** — collapsible sections grouped by health status: active, waiting, watching, stuck, failed, completed. Each entry shows run ID prefix, preset, iteration count, latest event, and age. Worktree runs display a `WT` badge; merged worktrees show a checkmark. Parked durable waits (`status=waiting`, no live PID) land in the waiting section.
 4. **Detail pane** — appears when a run is clicked. Shows status, preset, objective, iteration, workspace path, timestamps, duration, and merge info (for worktree runs). Below, an events timeline lists journal entries with color-coded left borders by category (system, backend, review, error, coordination, completion). A "Show backend events" toggle controls verbose event visibility.
 
 ### Event rendering
@@ -50,7 +50,7 @@ All routes are under `/api/` and return JSON. The SPA polls these on a 3-second 
 
 Returns all runs categorized by health status using the same `categorizeRuns()` logic as `autoloop loops`.
 
-Response buckets: `active`, `watching`, `stuck`, `recentFailed`, `recentCompleted`. Each run record includes worktree merge metadata when applicable.
+Response buckets: `waiting`, `active`, `watching`, `stuck`, `recentFailed`, `recentCompleted`. Each run record includes worktree merge metadata when applicable. Parked durable waits (`status=waiting`) appear in `waiting`.
 
 ### `GET /api/runs/:id`
 

--- a/docs/features/operator-health.md
+++ b/docs/features/operator-health.md
@@ -7,6 +7,7 @@ The health system classifies running loops into buckets using preset-specific th
 | Bucket | Meaning |
 |--------|---------|
 | **Active** | Running and recently updated — no concern. |
+| **Waiting** | Parked durable wait (`status=waiting`). No live PID; resume the same `run_id` to continue. |
 | **Watching** | Quiet longer than the preset's warning threshold but not yet stuck. Investigate soon. |
 | **Stuck** | Quiet longer than the preset's stuck threshold. Likely needs intervention. |
 | **Failed** | Failed or timed out within the last 24 hours. |
@@ -29,9 +30,9 @@ Unknown presets fall back to the default policy.
 
 All operator surfaces share the same classification logic from `packages/core/src/runs-health.ts`, which exports `categorizeRuns`, `categorizeRecords`, and `policyForPreset`:
 
-- **`autoloop loops health`** (`packages/cli/src/loops/health.ts`) — prints a summary with stuck, watching, failed, and active sections.
+- **`autoloop loops health`** (`packages/cli/src/loops/health.ts`) — prints a summary with stuck, watching, waiting, failed, and active sections.
 - **`autoloop loops watch <run-id>`** (`packages/cli/src/loops/watch.ts`) — prints a one-line advisory when a run transitions into the watching or stuck band.
-- **Dashboard `/api/runs`** (`packages/dashboard/src/routes/api.ts`) — returns JSON with `active`, `watching`, `stuck`, `recentFailed`, and `recentCompleted` arrays.
+- **Dashboard `/api/runs`** (`packages/dashboard/src/routes/api.ts`) — returns JSON with `waiting`, `active`, `watching`, `stuck`, `recentFailed`, and `recentCompleted` arrays.
 
 ## Design Notes
 

--- a/packages/cli/src/loops/health.ts
+++ b/packages/cli/src/loops/health.ts
@@ -32,7 +32,7 @@ function renderHealth(h: HealthResult, verbose: boolean): string {
   const hasExceptions =
     h.stuck.length > 0 || h.recentFailed.length > 0 || h.watching.length > 0;
 
-  if (!hasExceptions && h.active.length === 0) {
+  if (!hasExceptions && h.active.length === 0 && h.waiting.length === 0) {
     return (
       "All clear. 0 active, " +
       h.recentCompleted.length +
@@ -40,7 +40,7 @@ function renderHealth(h: HealthResult, verbose: boolean): string {
     );
   }
 
-  if (!hasExceptions) {
+  if (!hasExceptions && h.waiting.length === 0) {
     return (
       "All clear. " +
       h.active.length +
@@ -56,6 +56,8 @@ function renderHealth(h: HealthResult, verbose: boolean): string {
     "Health: " +
       h.active.length +
       " active, " +
+      h.waiting.length +
+      " waiting, " +
       h.watching.length +
       " watching, " +
       h.stuck.length +
@@ -76,6 +78,13 @@ function renderHealth(h: HealthResult, verbose: boolean): string {
     lines.push("WATCHING:");
     lines.push(renderListHeader());
     for (const r of h.watching) lines.push(renderRunLine(r));
+    lines.push("");
+  }
+
+  if (h.waiting.length > 0) {
+    lines.push("WAITING:");
+    lines.push(renderListHeader());
+    for (const r of h.waiting) lines.push(renderRunLine(r));
     lines.push("");
   }
 

--- a/packages/cli/src/loops/json.ts
+++ b/packages/cli/src/loops/json.ts
@@ -160,6 +160,7 @@ export function healthJson(stateDir: string): string {
   });
   return JSON.stringify(
     {
+      waiting: bucket(h.waiting),
       active: bucket(h.active),
       watching: bucket(h.watching),
       stuck: bucket(h.stuck),
@@ -177,8 +178,8 @@ export function healthJson(stateDir: string): string {
  * Categorization runs on a copy so the reported record is never mutated.
  */
 function healthBucketFor(r: RunRecord): string | null {
-  if (r.status === "waiting") return "waiting";
   const h = categorizeRecords([{ ...r }]);
+  if (h.waiting.length > 0) return "waiting";
   if (h.stuck.length > 0) return "stuck";
   if (h.watching.length > 0) return "watching";
   if (h.active.length > 0) return "active";

--- a/packages/cli/test/loops/health.test.ts
+++ b/packages/cli/test/loops/health.test.ts
@@ -1,6 +1,9 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { RunRecord } from "@mobrienv/autoloop-core/registry/types";
-import { describe, expect, it } from "vitest";
-import { categorizeRecords } from "../../src/loops/health.js";
+import { afterEach, describe, expect, it } from "vitest";
+import { categorizeRecords, healthSummary } from "../../src/loops/health.js";
 
 function makeRun(overrides: Partial<RunRecord> = {}): RunRecord {
   return {
@@ -128,5 +131,95 @@ describe("categorizeRecords", () => {
     ];
     const result = categorizeRecords(records, NOW);
     expect(result.active).toHaveLength(1);
+  });
+
+  it("classifies status=waiting with no PID as waiting, not dropped", () => {
+    const records = [
+      makeRun({
+        run_id: "run-wait-parked",
+        status: "waiting",
+        stop_reason: "waiting",
+        latest_event: "wait.open",
+        updated_at: new Date(NOW - 60 * 1000).toISOString(),
+      }),
+    ];
+    const result = categorizeRecords(records, NOW);
+    expect(result.waiting).toHaveLength(1);
+    expect(result.waiting[0].run_id).toBe("run-wait-parked");
+    expect(result.active).toHaveLength(0);
+    expect(result.watching).toHaveLength(0);
+    expect(result.stuck).toHaveLength(0);
+    expect(result.recentFailed).toHaveLength(0);
+    expect(result.recentCompleted).toHaveLength(0);
+  });
+
+  it("keeps parked waiting runs even when older than the 24h recent window", () => {
+    const records = [
+      makeRun({
+        run_id: "run-wait-old",
+        status: "waiting",
+        stop_reason: "waiting",
+        updated_at: new Date(NOW - 48 * 60 * 60 * 1000).toISOString(),
+      }),
+    ];
+    const result = categorizeRecords(records, NOW);
+    expect(result.waiting).toHaveLength(1);
+    expect(result.waiting[0].run_id).toBe("run-wait-old");
+  });
+
+  it("does not move waiting runs into watching or stuck by age", () => {
+    const records = [
+      makeRun({
+        run_id: "run-wait-long",
+        status: "waiting",
+        preset: "autosimplify",
+        stop_reason: "waiting",
+        updated_at: new Date(NOW - 20 * 60 * 1000).toISOString(),
+      }),
+    ];
+    const result = categorizeRecords(records, NOW);
+    expect(result.waiting).toHaveLength(1);
+    expect(result.watching).toHaveLength(0);
+    expect(result.stuck).toHaveLength(0);
+  });
+});
+
+describe("healthSummary waiting bucket", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of dirs) rmSync(dir, { recursive: true, force: true });
+    dirs.length = 0;
+  });
+
+  function writeRegistry(records: RunRecord[]): string {
+    const stateDir = join(
+      tmpdir(),
+      `health-wait-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(stateDir, { recursive: true });
+    dirs.push(stateDir);
+    writeFileSync(
+      join(stateDir, "registry.jsonl"),
+      `${records.map((r) => JSON.stringify(r)).join("\n")}\n`,
+    );
+    return stateDir;
+  }
+
+  it("lists a parked waiting run in the WAITING section", () => {
+    const stateDir = writeRegistry([
+      makeRun({
+        run_id: "run-wait-health",
+        status: "waiting",
+        stop_reason: "waiting",
+        latest_event: "wait.open",
+        updated_at: new Date().toISOString(),
+      }),
+    ]);
+    const output = healthSummary(stateDir, false);
+    expect(output).toContain("WAITING:");
+    expect(output).toContain("run-wait-health");
+    expect(output).toMatch(/1 waiting/);
+    expect(output).not.toContain("All clear");
   });
 });

--- a/packages/cli/test/loops/json.test.ts
+++ b/packages/cli/test/loops/json.test.ts
@@ -282,11 +282,32 @@ describe("healthJson", () => {
       count: 1,
       run_ids: ["run-completed"],
     });
+    expect(parsed.waiting).toEqual({ count: 0, run_ids: [] });
+  });
+
+  it("includes a parked waiting run in the waiting bucket", () => {
+    writeRecords([
+      makeRecord("run-wait-health", {
+        status: "waiting",
+        stop_reason: "waiting",
+        latest_event: "wait.open",
+        updated_at: isoAgo(0),
+      }),
+    ]);
+    const parsed = JSON.parse(healthJson(tmpDir));
+    expect(parsed.waiting).toEqual({
+      count: 1,
+      run_ids: ["run-wait-health"],
+    });
+    expect(parsed.active).toEqual({ count: 0, run_ids: [] });
+    expect(parsed.watching).toEqual({ count: 0, run_ids: [] });
+    expect(parsed.stuck).toEqual({ count: 0, run_ids: [] });
   });
 
   it("returns zeroed buckets when no registry exists", () => {
     const parsed = JSON.parse(healthJson(tmpDir));
     for (const key of [
+      "waiting",
       "active",
       "watching",
       "stuck",

--- a/packages/core/src/runs-health.ts
+++ b/packages/core/src/runs-health.ts
@@ -1,7 +1,8 @@
 /**
- * Run-health classification: bucket `RunRecord`s into active / watching /
- * stuck / recently-failed / recently-completed based on preset-specific
- * age thresholds.
+ * Run-health classification: bucket `RunRecord`s into waiting / active /
+ * watching / stuck / recently-failed / recently-completed. Age bands use
+ * preset-specific thresholds; parked `status=waiting` runs are a live
+ * bucket of their own (no PID required).
  *
  * Pure-ish — reads the registry via `readMergedRegistry` but otherwise is
  * a deterministic function of (records, nowMs). Used by the CLI `loops
@@ -70,6 +71,7 @@ export function policyForPreset(preset: string): SupervisionPolicy {
 }
 
 export interface HealthResult {
+  waiting: RunRecord[];
   active: RunRecord[];
   watching: RunRecord[];
   stuck: RunRecord[];
@@ -91,6 +93,7 @@ export function categorizeRecords(
   records: RunRecord[],
   nowMs: number = Date.now(),
 ): HealthResult {
+  const waiting: RunRecord[] = [];
   const active: RunRecord[] = [];
   const watching: RunRecord[] = [];
   const stuck: RunRecord[] = [];
@@ -98,6 +101,13 @@ export function categorizeRecords(
   const recentCompleted: RunRecord[] = [];
 
   for (const r of records) {
+    // Parked durable waits are live without a PID. Always surface them —
+    // they are not aged into watching/stuck and not gated by the 24h window.
+    if (r.status === "waiting") {
+      waiting.push(r);
+      continue;
+    }
+
     if (r.status === "running") {
       // If PID is recorded and the process is dead, treat as stopped
       if (r.pid != null && !isProcessAlive(r.pid)) {
@@ -131,7 +141,7 @@ export function categorizeRecords(
     }
   }
 
-  return { active, watching, stuck, recentFailed, recentCompleted };
+  return { waiting, active, watching, stuck, recentFailed, recentCompleted };
 }
 
 function elapsedMs(r: RunRecord, nowMs: number): number | null {

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -32,7 +32,7 @@ interface DashboardContext {
 }
 ```
 
-Run classification (`active` / `watching` / `stuck`) is provided by
+Run classification (`waiting` / `active` / `watching` / `stuck`) is provided by
 `@mobrienv/autoloop-core/runs-health::categorizeRuns` directly — no
 injection needed there.
 

--- a/packages/dashboard/src/routes/api.ts
+++ b/packages/dashboard/src/routes/api.ts
@@ -35,6 +35,7 @@ export function buildRunsPayload(
 ): ReturnType<typeof categorizeRuns> {
   const result = categorizeRuns(ctx.stateDir);
   for (const bucket of [
+    result.waiting,
     result.active,
     result.watching,
     result.stuck,

--- a/packages/dashboard/src/views/shell.ts
+++ b/packages/dashboard/src/views/shell.ts
@@ -10,7 +10,7 @@ export function htmlShell(projectName?: string): string {
 :root {
   --bg: #fff; --fg: #1a1a1a; --muted: #666; --border: #e0e0e0;
   --card-bg: #fafafa; --badge-bg: #eee;
-  --active: #2563eb; --watching: #d97706; --stuck: #dc2626;
+  --active: #2563eb; --waiting: #0891b2; --watching: #d97706; --stuck: #dc2626;
   --failed: #dc2626; --completed: #16a34a;
   --cat-loop: #06b6d4; --cat-iteration: #d97706; --cat-backend: #666;
   --cat-review: #c026d3; --cat-coordination: #2563eb; --cat-error: #dc2626;
@@ -40,6 +40,7 @@ header .updated { font-size: 0.75rem; color: var(--muted); font-family: monospac
 .section[open] summary::before { content: "\\25bc "; }
 .badge { display: inline-block; font-size: 0.7rem; padding: 0.1rem 0.4rem; border-radius: 8px; background: var(--badge-bg); margin-left: 0.3rem; font-weight: normal; }
 .badge[data-status="active"] { background: var(--active); color: #fff; }
+.badge[data-status="waiting"] { background: var(--waiting); color: #fff; }
 .badge[data-status="watching"] { background: var(--watching); color: #fff; }
 .badge[data-status="stuck"] { background: var(--stuck); color: #fff; }
 .badge[data-status="failed"] { background: var(--failed); color: #fff; }
@@ -489,7 +490,7 @@ header .updated { font-size: 0.75rem; color: var(--muted); font-family: monospac
 <script>
 function dashboard() {
   return {
-    runs: { active: [], watching: [], stuck: [], recentFailed: [], recentCompleted: [] },
+    runs: { waiting: [], active: [], watching: [], stuck: [], recentFailed: [], recentCompleted: [] },
     presets: [],
     selectedRun: null,
     selectedRunDetail: null,
@@ -500,7 +501,7 @@ function dashboard() {
     eventSource: null,
     streamRetryDelay: 1000,
     lastUpdated: null,
-    sectionOpen: { active: false, watching: false, stuck: false, failed: false, completed: false },
+    sectionOpen: { waiting: false, active: false, watching: false, stuck: false, failed: false, completed: false },
     sectionUserToggled: {},
     sectionShowAll: {},
     showVerbose: false,
@@ -541,8 +542,10 @@ function dashboard() {
       };
       const fc = cap("failed", this.runs.recentFailed);
       const cc = cap("completed", this.runs.recentCompleted);
+      const wc = cap("waiting", this.runs.waiting || []);
       return [
         { key: "active", label: "Active", items: this.runs.active, total: this.runs.active.length, capped: false },
+        { key: "waiting", label: "Waiting", items: wc.items, total: wc.total, capped: wc.capped },
         { key: "watching", label: "Watching", items: this.runs.watching, total: this.runs.watching.length, capped: false },
         { key: "stuck", label: "Stuck", items: this.runs.stuck, total: this.runs.stuck.length, capped: false },
         { key: "failed", label: "Failed", items: fc.items, total: fc.total, capped: fc.capped },
@@ -588,12 +591,12 @@ function dashboard() {
 
     applyRuns(data) {
       const byRecent = (a, b) => new Date(b.updated_at || 0) - new Date(a.updated_at || 0);
-      for (const key of ['active', 'watching', 'stuck', 'recentFailed', 'recentCompleted']) {
+      for (const key of ['waiting', 'active', 'watching', 'stuck', 'recentFailed', 'recentCompleted']) {
         if (data[key]) data[key].sort(byRecent);
       }
       this.runs = data;
       this.lastUpdated = new Date().toLocaleTimeString();
-      const defaultOpen = ['active', 'watching', 'stuck'];
+      const defaultOpen = ['active', 'waiting', 'watching', 'stuck'];
       for (const cat of this.categories) {
         if (!this.sectionUserToggled[cat.key]) {
           this.sectionOpen[cat.key] = cat.items.length > 0 && defaultOpen.includes(cat.key);

--- a/packages/dashboard/test/api.test.ts
+++ b/packages/dashboard/test/api.test.ts
@@ -108,6 +108,56 @@ describe("dashboard /api/runs", () => {
     expect(body.stuck).toHaveLength(1);
     expect(body.watching).toHaveLength(0);
   });
+
+  it("returns waiting bucket for parked status=waiting runs with no PID", async () => {
+    const { registryPath, projectDir, stateDir } = makeTempRegistry();
+
+    const updatedAt = new Date().toISOString();
+    const record = JSON.stringify({
+      run_id: "run-api-wait-001",
+      status: "waiting",
+      preset: "autocode",
+      objective: "parked durable wait",
+      trigger: "cli",
+      project_dir: projectDir,
+      work_dir: projectDir,
+      state_dir: join(projectDir, ".autoloop"),
+      journal_file: join(projectDir, ".autoloop", "journal.jsonl"),
+      parent_run_id: "",
+      backend: "mock",
+      backend_args: [],
+      created_at: updatedAt,
+      updated_at: updatedAt,
+      iteration: 2,
+      max_iterations: 10,
+      stop_reason: "waiting",
+      latest_event: "wait.open",
+    });
+    writeFileSync(registryPath, `${record}\n`, "utf-8");
+
+    const app = createApp({
+      registryPath,
+      journalPath: join(projectDir, ".autoloop", "journal.jsonl"),
+      stateDir,
+      bundleRoot: projectDir,
+      projectDir,
+      selfCmd: "autoloop",
+      listPresets: () => [],
+    });
+
+    const res = await app.request("/api/runs");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.waiting).toHaveLength(1);
+    expect(body.waiting[0].run_id).toBe("run-api-wait-001");
+    expect(body.waiting[0].status).toBe("waiting");
+    expect(body.waiting[0].pid).toBeUndefined();
+    expect(body.active).toHaveLength(0);
+    expect(body.watching).toHaveLength(0);
+    expect(body.stuck).toHaveLength(0);
+    expect(body.recentFailed).toHaveLength(0);
+    expect(body.recentCompleted).toHaveLength(0);
+  });
 });
 
 describe("dashboard /api/runs max_iterations", () => {
@@ -152,6 +202,7 @@ describe("dashboard /api/runs max_iterations", () => {
     const body = await res.json();
     // Find our run in one of the buckets
     const allRuns = [
+      ...(body.waiting || []),
       ...(body.active || []),
       ...(body.watching || []),
       ...(body.stuck || []),
@@ -232,6 +283,7 @@ describe("dashboard /api/runs worktree merge enrichment", () => {
     expect(listRes.status).toBe(200);
     const listBody = await listRes.json();
     const allRuns = [
+      ...(listBody.waiting || []),
       ...(listBody.active || []),
       ...(listBody.watching || []),
       ...(listBody.stuck || []),

--- a/packages/dashboard/test/pages.test.ts
+++ b/packages/dashboard/test/pages.test.ts
@@ -328,6 +328,13 @@ describe("section open/close state preservation", () => {
     const html = htmlShell();
     expect(html).toContain("!this.sectionUserToggled[cat.key]");
   });
+
+  it("includes waiting alongside the other run-list buckets", () => {
+    const html = htmlShell();
+    expect(html).toContain('key: "waiting"');
+    expect(html).toContain('label: "Waiting"');
+    expect(html).toContain("this.runs.waiting");
+  });
 });
 
 describe("POST /api/runs input validation", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Parked durable waits use `status=waiting` and have no live PID. Run health only bucketed active / watching / stuck / failed / completed, so those runs disappeared from `autoloop loops health` and `GET /api/runs`.

## Change

- `categorizeRecords` classifies `status=waiting` into a `waiting` bucket (no PID required; not dropped by the 24h recent window).
- `autoloop loops health` (text and `--json`) and `GET /api/runs` include that bucket.
- Dashboard run-list docs list waiting alongside the other health sections.
- Existing buckets stay the same.

## Tests

- A record with `status=waiting` and no PID is classified as waiting, not dropped.
- Waiting runs appear in health JSON and `GET /api/runs`.
- Active / watching / stuck / failed / completed classification is unchanged.

Memory stays on the default jsonl plugin. This does not add a wait card UI, extra dashboard chrome, or a parallel wait API.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e708ace-d2c7-465b-8931-f87944b8b0f1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e708ace-d2c7-465b-8931-f87944b8b0f1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

