### PR TITLE
feat(harness): T-009 frozen-paths guard

### DIFF
--- a/packages/core/src/config-schema.ts
+++ b/packages/core/src/config-schema.ts
@@ -46,6 +46,13 @@ export function defaults(): Config {
       // the working tree against HEAD and emit a policy.file_modification_violation
       // event if the acting role has disallowed_tools/read_only and files changed.
       audit_file_mods: "false",
+      // T-009 frozen-paths guard (opt-in): CSV of workdir-relative glob paths
+      // (e.g. "vision.md,docs/owner.md") that loop roles must not modify.
+      // Empty disables the guard entirely.
+      frozen_paths: "",
+      // When true, a frozen-path violation additionally denies the acting
+      // role's completion claim (observational by default).
+      frozen_paths_block: "false",
     },
     backend: {
       kind: "",

--- a/packages/core/src/topology.ts
+++ b/packages/core/src/topology.ts
@@ -45,6 +45,15 @@ export interface Role {
    * by the emit-boundary file-mod audit alongside `disallowedTools`.
    */
   readOnly?: boolean;
+  /**
+   * Glob paths (workdir-relative, e.g. "docs/vision.md") this loop role must
+   * not modify. Consulted by the emit-boundary file-mod audit: a role with a
+   * frozen_paths list that changes a matching file is flagged (and, under
+   * `event_loop.frozen_paths_block`, its completion claim is denied). Roles
+   * without the field are unrestricted, so writes made outside any loop role
+   * (e.g. operator/owner edits) are unaffected.
+   */
+  frozenPaths?: string[];
 }
 
 export interface RoleAggregate {
@@ -503,6 +512,10 @@ function parseRolePermissions(r: Record<string, unknown>): Partial<Role> {
   if (typeof r.read_only === "boolean") {
     out.readOnly = r.read_only;
   }
+  if (Array.isArray(r.frozen_paths)) {
+    const paths = r.frozen_paths.map(String).filter((t) => t !== "");
+    if (paths.length > 0) out.frozenPaths = paths;
+  }
   return out;
 }
 
@@ -611,11 +624,18 @@ function renderRoleBackendLines(role: Role, indent: string): string[] {
   if (role.readOnly !== undefined) {
     lines.push(`${indent}read_only: ${role.readOnly}`);
   }
+  if (role.frozenPaths !== undefined) {
+    lines.push(`${indent}frozen_paths: ${listText(role.frozenPaths)}`);
+  }
   return lines;
 }
 
 function roleHasPermissions(role: Role): boolean {
-  return role.disallowedTools !== undefined || role.readOnly !== undefined;
+  return (
+    role.disallowedTools !== undefined ||
+    role.readOnly !== undefined ||
+    role.frozenPaths !== undefined
+  );
 }
 
 function rolePrompt(role: Role, projectDir: string): string {

--- a/packages/core/test/topology.test.ts
+++ b/packages/core/test/topology.test.ts
@@ -175,6 +175,30 @@ emits = ["review.ready"]
     expect(topo.roles[1].disallowedTools).toBeUndefined();
     expect(topo.roles[1].readOnly).toBeUndefined();
   });
+
+  it("parses role frozen_paths permissions", () => {
+    const dir = tmpDir("role-frozen-paths");
+    writeFileSync(
+      join(dir, "topology.toml"),
+      `
+[[role]]
+id = "critic"
+prompt = "Review."
+emits = ["review.ready"]
+frozen_paths = ["vision.md", "docs/owner.md"]
+
+[[role]]
+id = "builder"
+prompt = "Build."
+emits = ["review.ready"]
+`,
+    );
+
+    const topo = loadTopology(dir);
+
+    expect(topo.roles[0].frozenPaths).toEqual(["vision.md", "docs/owner.md"]);
+    expect(topo.roles[1].frozenPaths).toBeUndefined();
+  });
 });
 
 describe("suggestedRoles", () => {

--- a/packages/harness/src/config-helpers.ts
+++ b/packages/harness/src/config-helpers.ts
@@ -638,6 +638,10 @@ export function reloadLoop(loop: LoopContext): LoopContext {
       fileModAudit: truthySetting(
         config.get(cfg, "event_loop.audit_file_mods", "false"),
       ),
+      frozenPaths: splitCsv(config.get(cfg, "event_loop.frozen_paths", "")),
+      frozenPathsBlock: truthySetting(
+        config.get(cfg, "event_loop.frozen_paths_block", "false"),
+      ),
     },
     acceptance: {
       // Accept either a single `verify_cmd` or a `verify_cmds` list; merge both.

--- a/packages/harness/src/emit.ts
+++ b/packages/harness/src/emit.ts
@@ -77,6 +77,16 @@ const CORE_SYSTEM_TOPICS = new Set([
   // role's emit and reject them against topology.
   "wait.open",
   "wait.close",
+  // Policy guards (harness-written at the emit boundary). Omitting these
+  // made latestAgentEventRecord treat an audit violation as the acting
+  // role's emit and reject it against topology, resetting routing.
+  "policy.file_modification_violation",
+  "policy.frozen_path_violation",
+  // Harness-written guidance consumption marker (prompt.ts journals it
+  // whenever operator guidance is delivered into a prompt). Omitting it let
+  // latestAgentEventRecord treat it as the acting role's emit, rejecting the
+  // completion claim on the very iteration that consumed the guidance.
+  "operator.guidance.consumed",
 ]);
 
 export function coreSystemTopic(topic: string): boolean {

--- a/packages/harness/src/events.ts
+++ b/packages/harness/src/events.ts
@@ -104,6 +104,15 @@ export type LoopEvent =
       files: string[];
       reason: "disallowed_tools" | "read_only";
     }
+  // T-009 frozen-paths guard: the acting role changed files matching its
+  // frozen_paths globs (or the run-wide event_loop.frozen_paths list).
+  | {
+      type: "policy.frozen_path_violation";
+      runId: string;
+      iteration: number;
+      role: string;
+      files: string[];
+    }
   | {
       type: "summary";
       runId: string;

--- a/packages/harness/src/file-mod-audit.ts
+++ b/packages/harness/src/file-mod-audit.ts
@@ -1,6 +1,14 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
 import { jsonField } from "@mobrienv/autoloop-core";
 import { appendEvent } from "@mobrienv/autoloop-core/journal";
-import { changedFiles, isGitRepo } from "./git-diff.js";
+import { changedFiles, isGitRepo, listWorkTreeFiles } from "./git-diff.js";
 import type { IterationContext } from "./prompt.js";
 import type { LoopContext } from "./types.js";
 
@@ -12,82 +20,328 @@ export interface FileModViolation {
   reason: FileModViolationReason;
 }
 
+export interface FrozenPathViolation {
+  role: string;
+  files: string[];
+}
+
 export interface FileModAuditResult {
   ran: boolean;
   violated: boolean;
   violations: FileModViolation[];
+  /** T-009 frozen-paths guard: true when a frozen path was modified. */
+  frozenViolated: boolean;
+  frozenViolations: FrozenPathViolation[];
+  /** Frozen paths the guard restored to their pre-iteration state. */
+  frozenReverts: string[];
+}
+
+/** Pre-iteration state of one frozen path (bytes, or its absence). */
+export interface FrozenPathSnapshotEntry {
+  path: string;
+  existed: boolean;
+  /** Raw bytes when `existed`; Buffers keep restore byte-exact for any file type. */
+  contents?: Buffer;
+}
+
+export interface FrozenPathSnapshot {
+  entries: FrozenPathSnapshotEntry[];
 }
 
 /**
- * Ralph-parity emit-boundary audit (opt-in via `event_loop.audit_file_mods`).
- * Compares the working tree against HEAD after every iteration; if the
- * single acting role (`iter.allowedRoles[0]`, the same convention used for
- * per-role backend overrides) declares `disallowedTools`/`readOnly` and
- * files changed during the iteration, journals + emits a typed
- * `policy.file_modification_violation` event carrying the role and file
- * list. Purely observational: the harness itself never stops or rejects
- * completion on this result — it exists for parent orchestrators to react to.
+ * Compile one workdir-relative glob into an anchored RegExp. A single star
+ * matches within one path segment; a double star matches across segments (a
+ * leading double star also matches a root-level file, a trailing one matches
+ * everything below). Every other character is escaped literally.
+ */
+export function globToRegExp(pattern: string): RegExp {
+  let source = "";
+  let i = 0;
+  while (i < pattern.length) {
+    if (pattern.startsWith("**/", i)) {
+      const prevSlash = i === 0 || pattern[i - 1] === "/";
+      source += prevSlash ? "(?:.*/)?" : ".*/";
+      i += 3;
+      continue;
+    }
+    if (pattern.startsWith("**", i)) {
+      source += ".*";
+      i += 2;
+      continue;
+    }
+    const ch = pattern[i] as string;
+    if (ch === "*") {
+      source += "[^/]*";
+    } else if (/[a-zA-Z0-9_\-./]/.test(ch)) {
+      source += ch;
+    } else {
+      source += `\\${ch}`;
+    }
+    i += 1;
+  }
+  return new RegExp(`^${source}$`);
+}
+
+/** Combined matcher for a frozen-paths pattern list (no patterns never matches). */
+export function frozenPathMatcher(
+  patterns: string[],
+): (file: string) => boolean {
+  const regexes = patterns
+    .map((p) => p.trim())
+    .filter((p) => p !== "")
+    .map(globToRegExp);
+  if (regexes.length === 0) return () => false;
+  return (file: string) => regexes.some((re) => re.test(file));
+}
+
+function resolveActingRole(
+  loop: LoopContext,
+  iter: IterationContext,
+): {
+  id: string;
+  frozenPaths?: string[];
+  readOnly?: boolean;
+  disallowedTools?: string[];
+} | null {
+  // Autoloop runs a single backend per iteration; allowedRoles[0] is the
+  // acting role for this turn (same convention prompt.ts uses to resolve
+  // per-role backend overrides). Ambiguous/empty routing is skipped rather
+  // than guessed, to avoid false-positive violations.
+  if (iter.allowedRoles.length !== 1) return null;
+  const roleId = iter.allowedRoles[0];
+  return loop.topology.roles.find((r) => r.id === roleId) ?? null;
+}
+
+/** Global policy patterns plus the acting role's own frozen_paths. */
+export function frozenPatternsFor(
+  loop: LoopContext,
+  role: { frozenPaths?: string[] } | null,
+): string[] {
+  return [...(loop.policy?.frozenPaths ?? []), ...(role?.frozenPaths ?? [])];
+}
+
+/**
+ * Snapshot every work-tree file matching `patterns` (tracked + untracked,
+ * non-ignored). Captured before the backend runs so the guard can restore
+ * byte-exact contents after the iteration, whatever the backend did.
+ */
+export function captureFrozenSnapshot(
+  workDir: string,
+  patterns: string[],
+): FrozenPathSnapshot {
+  const matcher = frozenPathMatcher(patterns);
+  const entries: FrozenPathSnapshotEntry[] = [];
+  for (const path of listWorkTreeFiles(workDir)) {
+    if (!matcher(path)) continue;
+    const absolute = join(workDir, path);
+    if (existsSync(absolute)) {
+      entries.push({ path, existed: true, contents: readFileSync(absolute) });
+    } else {
+      // Listed (e.g. tracked in the index) but absent from the work tree:
+      // the frozen state is "absent".
+      entries.push({ path, existed: false });
+    }
+  }
+  return { entries };
+}
+
+/**
+ * T-009 frozen-paths guard, open phase. Global `event_loop.frozen_paths` plus
+ * the acting role's `frozen_paths` declare workdir-relative glob paths a loop
+ * role must not modify. When any patterns apply, snapshot the matching files
+ * before the backend runs; `runFileModAudit` restores them after. Returns
+ * null when the guard is inactive (no patterns, or ambiguous/unknown acting
+ * role — mirroring the ralph-parity audit's no-guessing rule).
+ */
+export function beginFileModAudit(
+  loop: LoopContext,
+  iter: IterationContext,
+): FrozenPathSnapshot | null {
+  const role = resolveActingRole(loop, iter);
+  if (!role) return null;
+  const patterns = frozenPatternsFor(loop, role);
+  if (patterns.length === 0) return null;
+  return captureFrozenSnapshot(loop.paths.workDir, patterns);
+}
+
+function equalBuffers(a: Buffer | null, b: Buffer | null): boolean {
+  if (a === null || b === null) return a === b;
+  return a.equals(b);
+}
+
+/** Paths whose current bytes differ from the snapshot (or that appeared). */
+function detectFrozenModifications(
+  workDir: string,
+  snapshot: FrozenPathSnapshot,
+  patterns: string[],
+): string[] {
+  const matcher = frozenPathMatcher(patterns);
+  const snap = new Map(snapshot.entries.map((e) => [e.path, e]));
+  const candidates = new Set<string>();
+  for (const path of listWorkTreeFiles(workDir)) {
+    if (matcher(path)) candidates.add(path);
+  }
+  for (const entry of snapshot.entries) candidates.add(entry.path);
+
+  const modified: string[] = [];
+  for (const path of candidates) {
+    const absolute = join(workDir, path);
+    const exists = existsSync(absolute);
+    const entry = snap.get(path);
+    if (!entry) {
+      // Created this iteration (no snapshot entry) — the path set is frozen
+      // along with the bytes.
+      if (exists) modified.push(path);
+      continue;
+    }
+    const current = exists ? readFileSync(absolute) : null;
+    const original =
+      entry.existed && entry.contents !== undefined ? entry.contents : null;
+    if (!equalBuffers(current, original)) modified.push(path);
+  }
+  return modified;
+}
+
+function restoreSnapshot(
+  workDir: string,
+  snapshot: FrozenPathSnapshot,
+  modified: Set<string>,
+): string[] {
+  const reverted: string[] = [];
+  for (const entry of snapshot.entries) {
+    if (!modified.has(entry.path)) continue;
+    const absolute = join(workDir, entry.path);
+    if (entry.existed && entry.contents !== undefined) {
+      mkdirSync(dirname(absolute), { recursive: true });
+      writeFileSync(absolute, entry.contents);
+      reverted.push(entry.path);
+    } else if (!entry.existed && existsSync(absolute)) {
+      unlinkSync(absolute);
+      reverted.push(entry.path);
+    }
+  }
+  // Created-then-frozen paths have no snapshot entry: remove them.
+  for (const path of modified) {
+    if (snapshot.entries.some((e) => e.path === path)) continue;
+    const absolute = join(workDir, path);
+    if (existsSync(absolute)) {
+      unlinkSync(absolute);
+      reverted.push(path);
+    }
+  }
+  return reverted;
+}
+
+/**
+ * Emit-boundary file-mod audit. Two independent, opt-in guards share this
+ * seam:
  *
- * No-ops (returns `{ ran: false, ... }`) when the policy is disabled, and
- * `{ ran: true, violated: false, ... }` outside a git work tree, when no
- * files changed, when the acting role is ambiguous/unknown, or when the
- * acting role has no file-mutation restriction.
+ * 1. Ralph-parity audit (`event_loop.audit_file_mods`, purely
+ *    observational): diffs the working tree against HEAD after the
+ *    iteration; if the acting role declares `disallowedTools`/`readOnly`
+ *    and files changed, journals + emits a typed
+ *    `policy.file_modification_violation` event. Never alters control flow.
+ *
+ * 2. T-009 frozen-paths guard (active whenever frozen patterns exist via
+ *    `event_loop.frozen_paths` or the role's `frozen_paths`): detects
+ *    modification of frozen paths by content-diff against the snapshot from
+ *    {@link beginFileModAudit} — self-consistent even when HEAD already
+ *    differs (uncommitted operator edits are protected, not flagged) —
+ *    restores the pre-iteration bytes, and journals + emits
+ *    `policy.frozen_path_violation`. Under
+ *    `event_loop.frozen_paths_block` the caller additionally denies the
+ *    acting role's completion claim. Writes made outside any loop role
+ *    (owner/operator edits between iterations) are untouched: the snapshot
+ *    is per-iteration and only in-iteration drift is reverted.
+ *
+ * Returns `ran: false` when neither guard is active.
  */
 export function runFileModAudit(
   loop: LoopContext,
   iter: IterationContext,
   iteration: number,
+  snapshot?: FrozenPathSnapshot | null,
 ): FileModAuditResult {
-  if (!loop.policy?.fileModAudit) {
-    return { ran: false, violated: false, violations: [] };
-  }
-  const workDir = loop.paths.workDir;
-  if (!isGitRepo(workDir)) {
-    return { ran: true, violated: false, violations: [] };
-  }
-
-  const files = changedFiles(workDir);
-  if (files.length === 0) {
-    return { ran: true, violated: false, violations: [] };
-  }
-
-  // Autoloop runs a single backend per iteration; allowedRoles[0] is the
-  // acting role for this turn (same convention prompt.ts uses to resolve
-  // per-role backend overrides). Ambiguous/empty routing is skipped rather
-  // than guessed, to avoid false-positive violations.
-  if (iter.allowedRoles.length !== 1) {
-    return { ran: true, violated: false, violations: [] };
-  }
-  const roleId = iter.allowedRoles[0];
-  const role = loop.topology.roles.find((r) => r.id === roleId);
-  if (!role) {
-    return { ran: true, violated: false, violations: [] };
+  const role = resolveActingRole(loop, iter);
+  const auditEnabled = loop.policy?.fileModAudit === true;
+  const frozenPatterns = role ? frozenPatternsFor(loop, role) : [];
+  const frozenActive = frozenPatterns.length > 0;
+  const clean: FileModAuditResult = {
+    ran: true,
+    violated: false,
+    violations: [],
+    frozenViolated: false,
+    frozenViolations: [],
+    frozenReverts: [],
+  };
+  if (!auditEnabled && !frozenActive) {
+    return { ...clean, ran: false };
   }
 
-  const reason: FileModViolationReason | null = role.readOnly
-    ? "read_only"
-    : (role.disallowedTools?.length ?? 0) > 0
-      ? "disallowed_tools"
-      : null;
-  if (!reason) {
-    return { ran: true, violated: false, violations: [] };
+  // Frozen-paths guard: revert first so the journaled state reflects the
+  // post-restore tree.
+  if (frozenActive && snapshot) {
+    const frozenFiles = detectFrozenModifications(
+      loop.paths.workDir,
+      snapshot,
+      frozenPatterns,
+    );
+    if (frozenFiles.length > 0) {
+      const reverted = restoreSnapshot(
+        loop.paths.workDir,
+        snapshot,
+        new Set(frozenFiles),
+      );
+      appendEvent(
+        loop.paths.journalFile,
+        loop.runtime.runId,
+        String(iteration),
+        "policy.frozen_path_violation",
+        `${jsonField("role", role?.id ?? "")}, ${jsonField("files", frozenFiles.join(","))}, ${jsonField("reverted", reverted.join(","))}`,
+      );
+      loop.onEvent?.({
+        type: "policy.frozen_path_violation",
+        runId: loop.runtime.runId,
+        iteration,
+        role: role?.id ?? "",
+        files: frozenFiles,
+      });
+      clean.frozenViolated = true;
+      clean.frozenViolations = [{ role: role?.id ?? "", files: frozenFiles }];
+      clean.frozenReverts = reverted;
+    }
   }
 
-  const violation: FileModViolation = { role: roleId, files, reason };
-  appendEvent(
-    loop.paths.journalFile,
-    loop.runtime.runId,
-    String(iteration),
-    "policy.file_modification_violation",
-    `${jsonField("role", roleId)}, ${jsonField("files", files.join(","))}, ${jsonField("reason", reason)}`,
-  );
-  loop.onEvent?.({
-    type: "policy.file_modification_violation",
-    runId: loop.runtime.runId,
-    iteration,
-    role: roleId,
-    files,
-    reason,
-  });
-  return { ran: true, violated: true, violations: [violation] };
+  // Ralph-parity audit: git-diff vs HEAD, observational, restricted roles only.
+  if (auditEnabled && role && isGitRepo(loop.paths.workDir)) {
+    const files = changedFiles(loop.paths.workDir);
+    if (files.length > 0) {
+      const reason: FileModViolationReason | null = role.readOnly
+        ? "read_only"
+        : (role.disallowedTools?.length ?? 0) > 0
+          ? "disallowed_tools"
+          : null;
+      if (reason) {
+        appendEvent(
+          loop.paths.journalFile,
+          loop.runtime.runId,
+          String(iteration),
+          "policy.file_modification_violation",
+          `${jsonField("role", role.id)}, ${jsonField("files", files.join(","))}, ${jsonField("reason", reason)}`,
+        );
+        loop.onEvent?.({
+          type: "policy.file_modification_violation",
+          runId: loop.runtime.runId,
+          iteration,
+          role: role.id,
+          files,
+          reason,
+        });
+        clean.violated = true;
+        clean.violations = [{ role: role.id, files, reason }];
+      }
+    }
+  }
+
+  return clean;
 }

--- a/packages/harness/src/git-diff.ts
+++ b/packages/harness/src/git-diff.ts
@@ -1,4 +1,6 @@
 import { spawnSync } from "node:child_process";
+import { readdirSync, type Stats, statSync } from "node:fs";
+import { join } from "node:path";
 
 export interface AddedLine {
   file: string;
@@ -77,4 +79,60 @@ export function changedFiles(workDir: string): string[] {
 export function porcelainStatus(workDir: string): string[] {
   const res = git(workDir, ["status", "--porcelain"]);
   return res.ok ? res.stdout.split("\n").filter(Boolean) : [];
+}
+
+const WALK_SKIP = new Set([".git", "node_modules"]);
+
+/** Bounded recursive file listing used when git is unavailable (non-repo). */
+function walkFiles(workDir: string): string[] {
+  const out: string[] = [];
+  const visit = (dir: string, depth: number): void => {
+    if (depth > 20) return;
+    let names: string[] = [];
+    try {
+      names = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const name of names) {
+      const absolute = join(dir, name);
+      let stat: Stats | undefined;
+      try {
+        stat = statSync(absolute);
+      } catch {
+        continue;
+      }
+      if (stat.isDirectory()) {
+        if (!WALK_SKIP.has(name)) visit(absolute, depth + 1);
+      } else if (stat.isFile()) {
+        out.push(absolute.slice(workDir.length + 1));
+      }
+    }
+  };
+  visit(workDir, 0);
+  return out;
+}
+
+/**
+ * Every file currently in the work tree (tracked + untracked, non-ignored),
+ * as workdir-relative paths with forward slashes. Falls back to a bounded
+ * recursive walk outside a git repo so the frozen-paths snapshot stays
+ * functional without git.
+ */
+export function listWorkTreeFiles(workDir: string): string[] {
+  const res = git(workDir, [
+    "ls-files",
+    "--cached",
+    "--others",
+    "--exclude-standard",
+    "--",
+    ".",
+  ]);
+  if (res.ok) {
+    return res.stdout
+      .split("\n")
+      .filter(Boolean)
+      .map((f) => f.replaceAll("\\", "/"));
+  }
+  return walkFiles(workDir);
 }

--- a/packages/harness/src/iteration.ts
+++ b/packages/harness/src/iteration.ts
@@ -47,7 +47,12 @@ import {
   parallelTriggerTopic,
   systemTopic,
 } from "./emit.js";
-import { runFileModAudit } from "./file-mod-audit.js";
+import {
+  beginFileModAudit,
+  type FileModAuditResult,
+  type FrozenPathSnapshot,
+  runFileModAudit,
+} from "./file-mod-audit.js";
 import { loopStartMs } from "./guards.js";
 import { buildHookEnv, captureGitSha, runPhaseHooks } from "./hooks.js";
 import {
@@ -111,6 +116,14 @@ export async function runIteration(
   }
 
   let iter = buildIterationContext(loop, iteration);
+
+  // T-009 frozen-paths guard (open phase): when frozen patterns apply to the
+  // acting role, snapshot the matching files before the backend runs so
+  // runFileModAudit can detect + revert in-iteration modifications.
+  const frozenSnapshot: FrozenPathSnapshot | null = beginFileModAudit(
+    loop,
+    iter,
+  );
 
   // Clamp the iteration timeout to the remaining loop wall-clock budget so a
   // long iteration never overshoots event_loop.max_runtime. Applied before
@@ -279,7 +292,10 @@ export async function runIteration(
   // Emit-boundary file-mod audit (opt-in): flag file writes by a role with
   // disallowed_tools/read_only. Purely observational — journals/emits a typed
   // event for parent orchestrators; never alters control flow itself.
-  runFileModAudit(loop, iter, iteration);
+  // T-009 frozen-paths guard: when frozen patterns apply, in-iteration
+  // modifications of frozen paths are reverted to the pre-iteration bytes and
+  // journaled/emitted as policy.frozen_path_violation.
+  const fileModAudit = runFileModAudit(loop, iter, iteration, frozenSnapshot);
   log(loop, "debug", `iteration ${iteration} finish exit_code=${exitCode}`);
   loop.onEvent?.({
     type: "iteration.footer",
@@ -303,7 +319,7 @@ export async function runIteration(
   if (exitCode !== 0) {
     return handleBackendFailure(loop, iteration, output, iterate);
   }
-  return finishIteration(loop, iter, output, iterate);
+  return finishIteration(loop, iter, output, iterate, fileModAudit);
 }
 
 /**
@@ -592,6 +608,17 @@ export async function finishIteration(
   iter: IterationContext,
   output: string,
   iterate: (loop: LoopContext, iteration: number) => Promise<RunSummary>,
+  // Result of the emit-boundary audit run just before this call (same
+  // iteration). Carries the T-009 frozen-path violations used by the
+  // frozen_paths_block deny gate below.
+  fileModAudit: FileModAuditResult = {
+    ran: false,
+    violated: false,
+    violations: [],
+    frozenViolated: false,
+    frozenViolations: [],
+    frozenReverts: [],
+  },
 ): Promise<RunSummary> {
   const runLines = readRunLines(loop.paths.journalFile, loop.runtime.runId);
   const allTopics = runLines.map(extractTopic).filter((t) => t !== "");
@@ -723,6 +750,29 @@ export async function finishIteration(
     resolved.action === "complete_event" ||
     resolved.action === "complete_promise"
   ) {
+    // T-009 frozen-paths guard (block mode): a frozen-path violation denies
+    // the done-claim outright — before the acceptance gate — so a completion
+    // announced on top of reverted writes is never accepted. The violation is
+    // re-injected as operator guidance for the next iteration.
+    if (loop.policy?.frozenPathsBlock === true && fileModAudit.frozenViolated) {
+      const denied = fileModAudit.frozenViolations
+        .map((v) => `- \`${v.role}\`: ${v.files.join(", ")}`)
+        .join("\n");
+      const message =
+        "Completion was blocked: frozen-path files were modified during " +
+        "this iteration and have been restored to their prior state. " +
+        "Do not modify frozen paths; re-route the work instead. " +
+        `Frozen-path violations:\n\n${denied}`;
+      appendOperatorEvent(
+        loop.paths.journalFile,
+        loop.runtime.runId,
+        String(iter.iteration),
+        "operator.guidance",
+        message,
+      );
+      progress(emitted.topic, "blocked:frozen_path");
+      return iterate(loop, iter.iteration + 1);
+    }
     const reason =
       resolved.action === "complete_event"
         ? "completion_event"

--- a/packages/harness/src/types.ts
+++ b/packages/harness/src/types.ts
@@ -109,6 +109,18 @@ export interface LoopContext {
      * observational — never alters loop control flow on its own.
      */
     fileModAudit: boolean;
+    /**
+     * T-009 frozen-paths guard: global CSV of workdir-relative glob paths
+     * (e.g. "vision.md,docs/owner.md") that loop roles must not modify.
+     * Empty disables the guard entirely. Per-role opt-in via topology
+     * Role.frozenPaths; a role without the field never matches. Guard runs
+     * inside the emit-boundary audit, so it also requires audit_file_mods
+     * to be enabled. Observational by default; `frozen_paths_block` upgrades
+     * a violation to deny the acting role's completion claim.
+     */
+    frozenPaths: string[];
+    /** Deny the completion claim on a frozen-path violation. Default false. */
+    frozenPathsBlock: boolean;
   };
   /**
    * Out-of-band acceptance gate. On a done-claim the HARNESS (not the agent's

--- a/packages/harness/test/harness/config-helpers.test.ts
+++ b/packages/harness/test/harness/config-helpers.test.ts
@@ -408,7 +408,7 @@ describe("buildLoopContext", () => {
     });
   });
 
-  it("defaults completion.mustBeLast and policy.fileModAudit to false", () => {
+  it("defaults completion.mustBeLast, policy.fileModAudit, and frozen paths to off", () => {
     const projectDir = makeProject("event_loop.max_iterations = 1\n");
 
     const loop = buildLoopContext(projectDir, null, "node dist/main.js", {
@@ -417,6 +417,8 @@ describe("buildLoopContext", () => {
 
     expect(loop.completion.mustBeLast).toBe(false);
     expect(loop.policy.fileModAudit).toBe(false);
+    expect(loop.policy.frozenPaths).toEqual([]);
+    expect(loop.policy.frozenPathsBlock).toBe(false);
   });
 
   it("inherits backend environments by default", () => {
@@ -471,6 +473,23 @@ describe("buildLoopContext", () => {
 
     expect(loop.completion.mustBeLast).toBe(true);
     expect(loop.policy.fileModAudit).toBe(true);
+  });
+
+  it("reads event_loop.frozen_paths and event_loop.frozen_paths_block from TOML", () => {
+    const projectDir = makeProject(
+      [
+        "event_loop.max_iterations = 1",
+        'event_loop.frozen_paths = "vision.md, docs/owner.md"',
+        "event_loop.frozen_paths_block = true",
+      ].join("\n"),
+    );
+
+    const loop = buildLoopContext(projectDir, null, "node dist/main.js", {
+      workDir: projectDir,
+    });
+
+    expect(loop.policy.frozenPaths).toEqual(["vision.md", "docs/owner.md"]);
+    expect(loop.policy.frozenPathsBlock).toBe(true);
   });
 
   it("normalizes legacy kiro backend config to the ACP kiro provider", () => {

--- a/packages/harness/test/harness/emit.test.ts
+++ b/packages/harness/test/harness/emit.test.ts
@@ -70,6 +70,17 @@ describe("coreSystemTopic", () => {
     expect(coreSystemTopic("wait.request")).toBe(false);
   });
 
+  it("recognizes guidance consumption markers as system topics", () => {
+    // Regression: operator.guidance.consumed is harness-written (prompt.ts
+    // journals it whenever operator guidance is delivered into a prompt).
+    // Missing from the system set, latestAgentEventRecord treated it as the
+    // acting role's emit and rejected the completion claim on the very
+    // iteration that consumed the guidance (observed in the T-009 frozen-
+    // paths deny-gate E2E: a compliant retry iteration never completed).
+    expect(coreSystemTopic("operator.guidance.consumed")).toBe(true);
+    expect(systemTopic("operator.guidance.consumed")).toBe(true);
+  });
+
   it("rejects non-system topics", () => {
     expect(coreSystemTopic("task.complete")).toBe(false);
     expect(coreSystemTopic("gaps.identified")).toBe(false);

--- a/packages/harness/test/harness/file-mod-audit.test.ts
+++ b/packages/harness/test/harness/file-mod-audit.test.ts
@@ -1,9 +1,21 @@
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { extractField, extractTopic } from "@mobrienv/autoloop-core/journal";
-import { runFileModAudit } from "@mobrienv/autoloop-harness/file-mod-audit";
+import {
+  beginFileModAudit,
+  frozenPathMatcher,
+  globToRegExp,
+  runFileModAudit,
+} from "@mobrienv/autoloop-harness/file-mod-audit";
 import type { IterationContext } from "@mobrienv/autoloop-harness/prompt";
 import type { LoopContext } from "@mobrienv/autoloop-harness/types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -59,13 +71,27 @@ describe("runFileModAudit", () => {
     writeFileSync(join(workDir, "app.ts"), "export const x = 2;\n");
     const loop = makeLoop(false, [{ id: "critic", readOnly: true }]);
     const result = runFileModAudit(loop, makeIter(["critic"]), 2);
-    expect(result).toEqual({ ran: false, violated: false, violations: [] });
+    expect(result).toEqual({
+      ran: false,
+      violated: false,
+      violations: [],
+      frozenViolated: false,
+      frozenViolations: [],
+      frozenReverts: [],
+    });
   });
 
   it("runs but does not violate when no files changed", () => {
     const loop = makeLoop(true, [{ id: "critic", readOnly: true }]);
     const result = runFileModAudit(loop, makeIter(["critic"]), 2);
-    expect(result).toEqual({ ran: true, violated: false, violations: [] });
+    expect(result).toEqual({
+      ran: true,
+      violated: false,
+      violations: [],
+      frozenViolated: false,
+      frozenViolations: [],
+      frozenReverts: [],
+    });
   });
 
   it("does not violate when the acting role has no restrictions", () => {
@@ -133,14 +159,28 @@ describe("runFileModAudit", () => {
       { id: "builder" },
     ]);
     const result = runFileModAudit(loop, makeIter(["critic", "builder"]), 2);
-    expect(result).toEqual({ ran: true, violated: false, violations: [] });
+    expect(result).toEqual({
+      ran: true,
+      violated: false,
+      violations: [],
+      frozenViolated: false,
+      frozenViolations: [],
+      frozenReverts: [],
+    });
   });
 
   it("skips the audit when the acting role is unknown to the topology", () => {
     writeFileSync(join(workDir, "app.ts"), "export const x = 2;\n");
     const loop = makeLoop(true, [{ id: "builder" }]);
     const result = runFileModAudit(loop, makeIter(["ghost"]), 2);
-    expect(result).toEqual({ ran: true, violated: false, violations: [] });
+    expect(result).toEqual({
+      ran: true,
+      violated: false,
+      violations: [],
+      frozenViolated: false,
+      frozenViolations: [],
+      frozenReverts: [],
+    });
   });
 
   it("runs but does not violate outside a git work tree", () => {
@@ -155,6 +195,225 @@ describe("runFileModAudit", () => {
       runtime: { runId: "r" },
     } as unknown as LoopContext;
     const result = runFileModAudit(loop, makeIter(["critic"]), 2);
-    expect(result).toEqual({ ran: true, violated: false, violations: [] });
+    expect(result).toEqual({
+      ran: true,
+      violated: false,
+      violations: [],
+      frozenViolated: false,
+      frozenViolations: [],
+      frozenReverts: [],
+    });
+  });
+});
+
+describe("T-009 frozen-paths guard", () => {
+  function frozenLoop(
+    roles: Array<{ id: string; frozenPaths?: string[]; readOnly?: boolean }>,
+    policy?: Partial<{ frozenPaths: string[]; frozenPathsBlock: boolean }>,
+  ): LoopContext {
+    return {
+      policy: {
+        fileModAudit: false,
+        frozenPaths: policy?.frozenPaths ?? [],
+        frozenPathsBlock: policy?.frozenPathsBlock ?? false,
+      },
+      topology: { roles },
+      paths: { workDir, journalFile },
+      runtime: { runId: "run-frozen" },
+    } as unknown as LoopContext;
+  }
+
+  function gitShaOf(path: string): string {
+    const res = spawnSync("git", ["hash-object", path], {
+      cwd: workDir,
+      encoding: "utf-8",
+    });
+    return res.stdout.trim();
+  }
+
+  it("globToRegExp matches within/across segments and escapes metacharacters", () => {
+    expect(globToRegExp("vision.md").test("vision.md")).toBe(true);
+    expect(globToRegExp("vision.md").test("docs/vision.md")).toBe(false);
+    expect(globToRegExp("**/vision.md").test("docs/vision.md")).toBe(true);
+    expect(globToRegExp("**/vision.md").test("vision.md")).toBe(true);
+    expect(globToRegExp("docs/**").test("docs/a/b.md")).toBe(true);
+    expect(globToRegExp("docs/**").test("other/a.md")).toBe(false);
+    expect(globToRegExp("a+b(c).md").test("a+b(c).md")).toBe(true);
+    expect(globToRegExp("a+b(c).md").test("ab(c).md")).toBe(false);
+    expect(globToRegExp("docs/*.md").test("docs/a.md")).toBe(true);
+    expect(globToRegExp("docs/*.md").test("docs/sub/a.md")).toBe(false);
+  });
+
+  it("frozenPathMatcher with no patterns never matches", () => {
+    expect(frozenPathMatcher([])("vision.md")).toBe(false);
+  });
+
+  it("reverts an in-iteration write to a global frozen path and journals the violation", () => {
+    const vision = join(workDir, "vision.md");
+    writeFileSync(vision, "# Vision v1\n");
+    git(workDir, ["add", "."]);
+    git(workDir, ["commit", "-qm", "vision"]);
+    const shaBefore = gitShaOf(vision);
+
+    const loop = frozenLoop([{ id: "builder" }], {
+      frozenPaths: ["vision.md"],
+      frozenPathsBlock: true,
+    });
+    const onEvent = vi.fn();
+    loop.onEvent = onEvent;
+    const snapshot = beginFileModAudit(loop, makeIter(["builder"]));
+    expect(snapshot).not.toBeNull();
+
+    // The "backend" modifies the frozen file mid-iteration.
+    writeFileSync(vision, "# hijacked\n");
+    const result = runFileModAudit(loop, makeIter(["builder"]), 2, snapshot);
+
+    expect(result.frozenViolated).toBe(true);
+    expect(result.frozenViolations).toEqual([
+      { role: "builder", files: ["vision.md"] },
+    ]);
+    expect(result.frozenReverts).toEqual(["vision.md"]);
+    // File restored byte-exact.
+    expect(gitShaOf(vision)).toBe(shaBefore);
+    // Journaled + emitted.
+    const raw = readFileSync(journalFile, "utf-8");
+    const journaled = raw
+      .split("\n")
+      .filter((l) => extractTopic(l) === "policy.frozen_path_violation");
+    expect(journaled.length).toBe(1);
+    expect(extractField(journaled[0] ?? "", "role")).toBe("builder");
+    expect(extractField(journaled[0] ?? "", "files")).toBe("vision.md");
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "policy.frozen_path_violation",
+        role: "builder",
+        files: ["vision.md"],
+      }),
+    );
+  });
+
+  it("removes a file created under a frozen glob and restores deletions", () => {
+    const loop = frozenLoop([{ id: "builder" }], {
+      frozenPaths: ["docs/**"],
+    });
+    const snapshot = beginFileModAudit(loop, makeIter(["builder"]));
+    // Backend creates docs/owner.md under the frozen glob...
+    mkdirSync(join(workDir, "docs"), { recursive: true });
+    writeFileSync(join(workDir, "docs", "owner.md"), "new\n");
+    const created = runFileModAudit(loop, makeIter(["builder"]), 2, snapshot);
+    expect(created.frozenViolated).toBe(true);
+    expect(existsSync(join(workDir, "docs", "owner.md"))).toBe(false);
+
+    // ...and deletes a pre-existing frozen file (snapshot "absent" restore).
+    writeFileSync(join(workDir, "docs", "keeper.md"), "keep\n");
+    const snapshot2 = beginFileModAudit(loop, makeIter(["builder"]));
+    unlinkSync(join(workDir, "docs", "keeper.md"));
+    const deleted = runFileModAudit(loop, makeIter(["builder"]), 2, snapshot2);
+    expect(deleted.frozenViolated).toBe(true);
+    expect(readFileSync(join(workDir, "docs", "keeper.md"), "utf-8")).toBe(
+      "keep\n",
+    );
+  });
+
+  it("leaves pre-existing uncommitted frozen-file edits alone (owner writes unaffected)", () => {
+    const vision = join(workDir, "vision.md");
+    writeFileSync(vision, "# owner local edit\n");
+    git(workDir, ["add", "."]);
+    git(workDir, ["commit", "-qm", "base"]);
+    // Owner edits between iterations (uncommitted).
+    writeFileSync(vision, "# owner uncommitted edit\n");
+
+    const loop = frozenLoop([{ id: "builder" }], {
+      frozenPaths: ["vision.md"],
+    });
+    const snapshot = beginFileModAudit(loop, makeIter(["builder"]));
+    // Builder does NOT touch the file this iteration.
+    const result = runFileModAudit(loop, makeIter(["builder"]), 2, snapshot);
+    expect(result.frozenViolated).toBe(false);
+    expect(readFileSync(vision, "utf-8")).toBe("# owner uncommitted edit\n");
+  });
+
+  it("a role without frozen paths and an empty global list skips the guard", () => {
+    writeFileSync(join(workDir, "vision.md"), "x\n");
+    const loop = frozenLoop([{ id: "builder" }]);
+    expect(beginFileModAudit(loop, makeIter(["builder"]))).toBeNull();
+    const result = runFileModAudit(loop, makeIter(["builder"]), 2, null);
+    expect(result.frozenViolated).toBe(false);
+    expect(result.ran).toBe(false);
+  });
+
+  it("respects per-role frozen_paths: restricted role flagged, unrestricted role free", () => {
+    const vision = join(workDir, "vision.md");
+    writeFileSync(vision, "# Vision\n");
+    git(workDir, ["add", "."]);
+    git(workDir, ["commit", "-qm", "vision"]);
+
+    const loop = frozenLoop([
+      { id: "critic", frozenPaths: ["vision.md"] },
+      { id: "owner", frozenPaths: [] },
+    ]);
+    const snapshot = beginFileModAudit(loop, makeIter(["critic"]));
+    expect(snapshot).not.toBeNull();
+    writeFileSync(vision, "# critic rewrote\n");
+    const flagged = runFileModAudit(loop, makeIter(["critic"]), 2, snapshot);
+    expect(flagged.frozenViolated).toBe(true);
+    expect(readFileSync(vision, "utf-8")).toBe("# Vision\n");
+
+    // Owner-style role (no frozen paths) writing the same file: not touched.
+    writeFileSync(vision, "# owner authoritative edit\n");
+    const snapshot2 = beginFileModAudit(loop, makeIter(["owner"]));
+    expect(snapshot2).toBeNull();
+    const free = runFileModAudit(loop, makeIter(["owner"]), 3, snapshot2);
+    expect(free.frozenViolated).toBe(false);
+    expect(readFileSync(vision, "utf-8")).toBe("# owner authoritative edit\n");
+  });
+
+  it("snapshot is per-iteration: a prior iteration's committed change is not reverted", () => {
+    const vision = join(workDir, "vision.md");
+    writeFileSync(vision, "# v1\n");
+    git(workDir, ["add", "."]);
+    git(workDir, ["commit", "-qm", "v1"]);
+
+    const loop = frozenLoop([{ id: "builder" }], {
+      frozenPaths: ["vision.md"],
+    });
+    // Iteration 2: builder writes and the audit restores.
+    const snap1 = beginFileModAudit(loop, makeIter(["builder"]));
+    writeFileSync(vision, "# v2 by builder\n");
+    runFileModAudit(loop, makeIter(["builder"]), 2, snap1);
+    expect(readFileSync(vision, "utf-8")).toBe("# v1\n");
+
+    // Iteration 3: fresh snapshot sees restored bytes; no violation without
+    // new modification.
+    const snap2 = beginFileModAudit(loop, makeIter(["builder"]));
+    const clean = runFileModAudit(loop, makeIter(["builder"]), 3, snap2);
+    expect(clean.frozenViolated).toBe(false);
+  });
+
+  it("skips the guard when the acting role is ambiguous or unknown", () => {
+    writeFileSync(join(workDir, "vision.md"), "x\n");
+    const loop = frozenLoop([{ id: "builder" }], {
+      frozenPaths: ["vision.md"],
+    });
+    expect(beginFileModAudit(loop, makeIter(["a", "b"]))).toBeNull();
+    expect(beginFileModAudit(loop, makeIter(["ghost"]))).toBeNull();
+    const ambiguous = runFileModAudit(loop, makeIter(["a", "b"]), 2, null);
+    expect(ambiguous.ran).toBe(false);
+  });
+
+  it("works without git via the filesystem walk fallback", () => {
+    const nonRepo = mkdtempSync(join(tmpdir(), "autoloop-frozen-nogit-"));
+    const vision = join(nonRepo, "vision.md");
+    writeFileSync(vision, "# no git\n");
+    const loop = frozenLoop([{ id: "builder" }], {
+      frozenPaths: ["vision.md"],
+    });
+    loop.paths.workDir = nonRepo;
+    const snapshot = beginFileModAudit(loop, makeIter(["builder"]));
+    expect(snapshot?.entries.map((e) => e.path)).toEqual(["vision.md"]);
+    writeFileSync(vision, "# changed\n");
+    const result = runFileModAudit(loop, makeIter(["builder"]), 2, snapshot);
+    expect(result.frozenViolated).toBe(true);
+    expect(readFileSync(vision, "utf-8")).toBe("# no git\n");
   });
 });

--- a/packages/harness/test/harness/iteration.test.ts
+++ b/packages/harness/test/harness/iteration.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -863,5 +864,116 @@ describe("completionEmittedLast", () => {
     ];
     // completion was emitted in turn 1; step.done followed it in that turn.
     expect(completionEmittedLast(lines, "task.complete")).toBe(false);
+  });
+});
+
+describe("runIteration T-009 frozen-paths deny gate", () => {
+  function frozenLoop(): LoopContext {
+    const loop = makeAcpLoop();
+    const vision = join(loop.paths.workDir, "vision.md");
+    writeFileSync(vision, "# Vision v1\n");
+    git(loop.paths.workDir, ["init", "-q"]);
+    git(loop.paths.workDir, ["config", "user.email", "t@t.t"]);
+    git(loop.paths.workDir, ["config", "user.name", "t"]);
+    git(loop.paths.workDir, ["add", "."]);
+    git(loop.paths.workDir, ["commit", "-qm", "vision"]);
+    loop.topology = {
+      name: "",
+      completion: "",
+      roles: [{ id: "builder", prompt: "Build.", emits: ["task.complete"] }],
+      handoff: { "loop.start": ["builder"] },
+      handoffKeys: ["loop.start"],
+    };
+    loop.policy = {
+      fileModAudit: false,
+      frozenPaths: ["vision.md"],
+      frozenPathsBlock: true,
+    };
+    loop.completion.mustBeLast = false;
+    return loop;
+  }
+
+  function git(cwd: string, args: string[]): void {
+    spawnSync("git", args, { cwd, encoding: "utf-8" });
+  }
+
+  it("denies a done-claim after a frozen-path write and re-injects guidance", async () => {
+    const loop = frozenLoop();
+    const vision = join(loop.paths.workDir, "vision.md");
+    acpMocks.initAcpSession.mockResolvedValue({
+      provider: { id: "claude-agent-acp" },
+      process: { pid: 1234 },
+    } as unknown as AcpSession);
+    // Backend mutates the frozen file, then claims DONE.
+    acpMocks.runAcpIteration.mockImplementation(async () => {
+      writeFileSync(vision, "# hijacked by builder\n");
+      return { output: "DONE", exitCode: 0, timedOut: false };
+    });
+
+    const summary = await runIteration(loop, 1, async () => ({
+      iterations: 1,
+      stopReason: "continued",
+      runId: loop.runtime.runId,
+    }));
+
+    // Claim denied: loop continues instead of completing.
+    expect(summary.stopReason).toBe("continued");
+    expect(readFileSync(vision, "utf-8")).toBe("# Vision v1\n");
+    const journal = readFileSync(loop.paths.journalFile, "utf-8");
+    expect(journal).toContain("policy.frozen_path_violation");
+    expect(journal).toContain("Completion was blocked: frozen-path files");
+    expect(journal).not.toContain('"state": "accepted"');
+  });
+
+  it("accepts a clean done-claim when frozen paths are untouched", async () => {
+    const loop = frozenLoop();
+    acpMocks.initAcpSession.mockResolvedValue({
+      provider: { id: "claude-agent-acp" },
+      process: { pid: 1234 },
+    } as unknown as AcpSession);
+    acpMocks.runAcpIteration.mockResolvedValue({
+      output: "DONE",
+      exitCode: 0,
+      timedOut: false,
+    });
+
+    const summary = await runIteration(loop, 1, async () => ({
+      iterations: 1,
+      stopReason: "continued",
+      runId: loop.runtime.runId,
+    }));
+
+    expect(summary.stopReason).toBe("completion_promise");
+    const journal = readFileSync(loop.paths.journalFile, "utf-8");
+    expect(journal).toContain('"state": "accepted"');
+    expect(journal).not.toContain("policy.frozen_path_violation");
+  });
+
+  it("observational mode (frozen_paths_block=false) journals but still completes", async () => {
+    const loop = frozenLoop();
+    loop.policy = {
+      ...loop.policy,
+      frozenPathsBlock: false,
+    } as LoopContext["policy"];
+    const vision = join(loop.paths.workDir, "vision.md");
+    acpMocks.initAcpSession.mockResolvedValue({
+      provider: { id: "claude-agent-acp" },
+      process: { pid: 1234 },
+    } as unknown as AcpSession);
+    acpMocks.runAcpIteration.mockImplementation(async () => {
+      writeFileSync(vision, "# hijacked\n");
+      return { output: "DONE", exitCode: 0, timedOut: false };
+    });
+
+    const summary = await runIteration(loop, 1, async () => ({
+      iterations: 1,
+      stopReason: "continued",
+      runId: loop.runtime.runId,
+    }));
+
+    expect(summary.stopReason).toBe("completion_promise");
+    const journal = readFileSync(loop.paths.journalFile, "utf-8");
+    expect(journal).toContain("policy.frozen_path_violation");
+    expect(journal).toContain('"state": "accepted"');
   });
 });


### PR DESCRIPTION
## What

Land T-009 frozen-paths guard (T-010). Opt-in policy tokens:

- `frozen_paths`: CSV of workdir-relative glob paths that loop roles must not modify (empty disables).
- `frozen_paths_block`: when true, a frozen-path violation denies the acting role's completion claim.

In-iteration modifications of frozen paths are reverted to the pre-iteration
bytes and journaled/emitted as `policy.frozen_path_violation`; block mode also
injects `operator.guidance` and denies completion.

## Verification

- `npm run build`: exit 0
- `npm test`: 208 files passed / 2371 tests passed, 1 failed, 4 skipped
  - The 1 failure is the known pre-existing local-only `quick.test.ts`
    `guide without an active run` (fails identically on clean main @ 9ba5687 — verified via stash).
- All touched test suites green: file-mod-audit (19), iteration (38), config-helpers (85), topology (60), emit (48).

No code changes beyond the verified T-009 patch: 14 files, +920/-71.