### PR TITLE
chore(release): v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-09-10
+
 ### Added
 - **Memory plugins.** Loop memory is selected by `memory.kind` (default
   `jsonl`, same `.autoloop/memory.jsonl` store). A second plugin can be
@@ -20,11 +22,10 @@
   `backend.environment_policy = "hardened"` (or the review-specific override)
   removes process-injection and Git-authority variables, repository-owned or
   relative `PATH` entries, and rejects credential-bearing proxy URLs.
-- **Standalone binaries provide a Node-free installation channel.** GitHub
-  releases now attach Bun-compiled executables for macOS and Linux on arm64
-  and x64, plus a `SHA256SUMS` file. `scripts/build-standalone.sh` builds all
-  four targets (or a selected host/target) and embeds the package version at
-  compile time.
+- **Frozen-paths guard.** Opt-in `event_loop.frozen_paths` lists workdir-relative
+  globs that loop roles must not modify. In-iteration writes are reverted and
+  journaled as `policy.frozen_path_violation`. `event_loop.frozen_paths_block`
+  also denies the acting role's completion claim and injects operator guidance.
 
 ### Fixed
 - **Parked waiting runs appear in run health.** `categorizeRecords` now
@@ -35,6 +36,21 @@
   review, harness-instruction, and topology role paths now reject parent
   traversal and symlink escapes while preserving optional and explicitly empty
   file semantics.
+- **`--events` creates missing parent directories** instead of failing when the
+  events path's parent does not exist.
+- **Dashboard `POST /runs` spawn no longer crashes** when the CLI self-command
+  contains quoted arguments.
+
+## [0.10.1] - 2026-07-19
+
+### Added
+- **Standalone binaries provide a Node-free installation channel.** GitHub
+  releases now attach Bun-compiled executables for macOS and Linux on arm64
+  and x64, plus a `SHA256SUMS` file. `scripts/build-standalone.sh` builds all
+  four targets (or a selected host/target) and embeds the package version at
+  compile time.
+
+### Fixed
 - **Generated tool wrappers reliably re-invoke every CLI distribution.**
   Checkout builds now use the Node interpreter instead of asking `/bin/sh` to
   execute the ESM entry point, while standalone builds re-invoke their binary

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mobrienv/autoloop",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mobrienv/autoloop",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "MIT",
       "workspaces": [
         "packages/core",
@@ -21,10 +21,10 @@
         "packages/linear-sync"
       ],
       "dependencies": {
-        "@mobrienv/autoloop-cli": "0.10.1",
-        "@mobrienv/autoloop-core": "0.10.1",
-        "@mobrienv/autoloop-harness": "0.10.1",
-        "@mobrienv/autoloop-presets": "0.10.1"
+        "@mobrienv/autoloop-cli": "0.11.0",
+        "@mobrienv/autoloop-core": "0.11.0",
+        "@mobrienv/autoloop-harness": "0.11.0",
+        "@mobrienv/autoloop-presets": "0.11.0"
       },
       "bin": {
         "autoloop": "bin/autoloop"
@@ -6421,12 +6421,12 @@
     },
     "packages/backends": {
       "name": "@mobrienv/autoloop-backends",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.18.0",
         "@anthropic-ai/claude-agent-sdk": "^0.3.173",
-        "@mobrienv/autoloop-core": "0.10.1"
+        "@mobrienv/autoloop-core": "0.11.0"
       },
       "engines": {
         "node": ">=18"
@@ -6434,16 +6434,16 @@
     },
     "packages/cli": {
       "name": "@mobrienv/autoloop-cli",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.18.0",
         "@hono/node-server": "^1.13.7",
-        "@mobrienv/autoloop-core": "0.10.1",
-        "@mobrienv/autoloop-dashboard": "0.10.1",
-        "@mobrienv/autoloop-harness": "0.10.1",
-        "@mobrienv/autoloop-kanban": "0.10.1",
-        "@mobrienv/autoloop-presets": "0.10.1"
+        "@mobrienv/autoloop-core": "0.11.0",
+        "@mobrienv/autoloop-dashboard": "0.11.0",
+        "@mobrienv/autoloop-harness": "0.11.0",
+        "@mobrienv/autoloop-kanban": "0.11.0",
+        "@mobrienv/autoloop-presets": "0.11.0"
       },
       "engines": {
         "node": ">=18"
@@ -6451,7 +6451,7 @@
     },
     "packages/core": {
       "name": "@mobrienv/autoloop-core",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5"
@@ -6462,11 +6462,11 @@
     },
     "packages/dashboard": {
       "name": "@mobrienv/autoloop-dashboard",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "@mobrienv/autoloop-core": "0.10.1",
-        "@mobrienv/autoloop-harness": "0.10.1",
+        "@mobrienv/autoloop-core": "0.11.0",
+        "@mobrienv/autoloop-harness": "0.11.0",
         "hono": "^4.6.14"
       },
       "engines": {
@@ -6475,10 +6475,10 @@
     },
     "packages/gh-sync": {
       "name": "@mobrienv/autoloop-gh-sync",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "@mobrienv/autoloop-issue-sync-core": "0.10.1"
+        "@mobrienv/autoloop-issue-sync-core": "0.11.0"
       },
       "bin": {
         "autoloop-gh-sync": "dist/cli.js"
@@ -6489,13 +6489,13 @@
     },
     "packages/harness": {
       "name": "@mobrienv/autoloop-harness",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.18.0",
         "@iarna/toml": "^2.2.5",
-        "@mobrienv/autoloop-backends": "0.10.1",
-        "@mobrienv/autoloop-core": "0.10.1"
+        "@mobrienv/autoloop-backends": "0.11.0",
+        "@mobrienv/autoloop-core": "0.11.0"
       },
       "engines": {
         "node": ">=18"
@@ -6503,10 +6503,10 @@
     },
     "packages/issue-sync-core": {
       "name": "@mobrienv/autoloop-issue-sync-core",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "@mobrienv/autoloop-core": "0.10.1"
+        "@mobrienv/autoloop-core": "0.11.0"
       },
       "engines": {
         "node": ">=18"
@@ -6514,12 +6514,12 @@
     },
     "packages/kanban": {
       "name": "@mobrienv/autoloop-kanban",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@homebridge/node-pty-prebuilt-multiarch": "^0.13.1",
         "@iarna/toml": "^2.2.5",
-        "@mobrienv/autoloop-core": "0.10.1",
+        "@mobrienv/autoloop-core": "0.11.0",
         "hono": "^4.6.14",
         "ws": "^8.18.0"
       },
@@ -6533,11 +6533,11 @@
     },
     "packages/linear-sync": {
       "name": "@mobrienv/autoloop-linear-sync",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@linear/sdk": "^33.0.0",
-        "@mobrienv/autoloop-issue-sync-core": "0.10.1"
+        "@mobrienv/autoloop-issue-sync-core": "0.11.0"
       },
       "bin": {
         "autoloop-linear-open": "bin/autoloop-linear-open",
@@ -6549,7 +6549,7 @@
     },
     "packages/presets": {
       "name": "@mobrienv/autoloop-presets",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mobrienv/autoloop",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "MIT",
   "description": "Simpler, opinionated loop harness for inspectable long-running agent workflows",
   "type": "module",
@@ -95,9 +95,9 @@
     "vitest": "^3.0.0"
   },
   "dependencies": {
-    "@mobrienv/autoloop-cli": "0.10.1",
-    "@mobrienv/autoloop-core": "0.10.1",
-    "@mobrienv/autoloop-harness": "0.10.1",
-    "@mobrienv/autoloop-presets": "0.10.1"
+    "@mobrienv/autoloop-cli": "0.11.0",
+    "@mobrienv/autoloop-core": "0.11.0",
+    "@mobrienv/autoloop-harness": "0.11.0",
+    "@mobrienv/autoloop-presets": "0.11.0"
   }
 }

--- a/packages/backends/package.json
+++ b/packages/backends/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mobrienv/autoloop-backends",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "MIT",
   "description": "autoloop backend drivers (Claude Agent SDK, ACP/kiro bridge, pi RPC, shell command runner)",
   "type": "module",
@@ -54,7 +54,7 @@
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.18.0",
     "@anthropic-ai/claude-agent-sdk": "^0.3.173",
-    "@mobrienv/autoloop-core": "0.10.1"
+    "@mobrienv/autoloop-core": "0.11.0"
   },
   "scripts": {
     "build": "tsc"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mobrienv/autoloop-cli",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "MIT",
   "description": "autoloop CLI (main entry, commands, dashboard, chains, loops inspector)",
   "type": "module",
@@ -50,11 +50,11 @@
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.18.0",
     "@hono/node-server": "^1.13.7",
-    "@mobrienv/autoloop-core": "0.10.1",
-    "@mobrienv/autoloop-dashboard": "0.10.1",
-    "@mobrienv/autoloop-harness": "0.10.1",
-    "@mobrienv/autoloop-kanban": "0.10.1",
-    "@mobrienv/autoloop-presets": "0.10.1"
+    "@mobrienv/autoloop-core": "0.11.0",
+    "@mobrienv/autoloop-dashboard": "0.11.0",
+    "@mobrienv/autoloop-harness": "0.11.0",
+    "@mobrienv/autoloop-kanban": "0.11.0",
+    "@mobrienv/autoloop-presets": "0.11.0"
   },
   "scripts": {
     "build": "tsc"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mobrienv/autoloop-core",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "MIT",
   "description": "Pure core utilities for autoloop (events, journal, topology, config schema)",
   "type": "module",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mobrienv/autoloop-dashboard",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "MIT",
   "description": "Hono-based read-only dashboard for autoloop runs (API + HTML)",
   "type": "module",
@@ -24,8 +24,8 @@
     "directory": "packages/dashboard"
   },
   "dependencies": {
-    "@mobrienv/autoloop-core": "0.10.1",
-    "@mobrienv/autoloop-harness": "0.10.1",
+    "@mobrienv/autoloop-core": "0.11.0",
+    "@mobrienv/autoloop-harness": "0.11.0",
     "hono": "^4.6.14"
   },
   "scripts": {

--- a/packages/gh-sync/package.json
+++ b/packages/gh-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mobrienv/autoloop-gh-sync",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "MIT",
   "description": "GitHub issue sync adapter for autoloop (wraps gh CLI)",
   "type": "module",
@@ -27,7 +27,7 @@
     "directory": "packages/gh-sync"
   },
   "dependencies": {
-    "@mobrienv/autoloop-issue-sync-core": "0.10.1"
+    "@mobrienv/autoloop-issue-sync-core": "0.11.0"
   },
   "scripts": {
     "build": "tsc"

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mobrienv/autoloop-harness",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "MIT",
   "description": "autoloop harness runtime (iteration loop, metareview, wave orchestration, backend drivers)",
   "type": "module",
@@ -226,8 +226,8 @@
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.18.0",
     "@iarna/toml": "^2.2.5",
-    "@mobrienv/autoloop-backends": "0.10.1",
-    "@mobrienv/autoloop-core": "0.10.1"
+    "@mobrienv/autoloop-backends": "0.11.0",
+    "@mobrienv/autoloop-core": "0.11.0"
   },
   "scripts": {
     "build": "tsc"

--- a/packages/issue-sync-core/package.json
+++ b/packages/issue-sync-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mobrienv/autoloop-issue-sync-core",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "MIT",
   "description": "Tracker-agnostic issue sync core for autoloop (pull/push/release, state file, adapter interface)",
   "type": "module",
@@ -27,7 +27,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@mobrienv/autoloop-core": "0.10.1"
+    "@mobrienv/autoloop-core": "0.11.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/kanban/package.json
+++ b/packages/kanban/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mobrienv/autoloop-kanban",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "MIT",
   "description": "tmux-backed kanban board that spawns autoloop runs per task",
   "type": "module",
@@ -27,7 +27,7 @@
   "dependencies": {
     "@homebridge/node-pty-prebuilt-multiarch": "^0.13.1",
     "@iarna/toml": "^2.2.5",
-    "@mobrienv/autoloop-core": "0.10.1",
+    "@mobrienv/autoloop-core": "0.11.0",
     "hono": "^4.6.14",
     "ws": "^8.18.0"
   },

--- a/packages/linear-sync/package.json
+++ b/packages/linear-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mobrienv/autoloop-linear-sync",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "MIT",
   "description": "Linear issue sync adapter for autoloop (@linear/sdk + LINEAR_API_KEY)",
   "type": "module",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@linear/sdk": "^33.0.0",
-    "@mobrienv/autoloop-issue-sync-core": "0.10.1"
+    "@mobrienv/autoloop-issue-sync-core": "0.11.0"
   },
   "scripts": {
     "build": "tsc"

--- a/packages/presets/package.json
+++ b/packages/presets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mobrienv/autoloop-presets",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "MIT",
   "description": "Bundled preset definitions (data-only) for autoloop",
   "type": "module",

--- a/plugins/autoloop-memory/.claude-plugin/plugin.json
+++ b/plugins/autoloop-memory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autoloop-memory",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Persist and recall Autoloop loop memory — add, list, find, and render learnings and preferences.",
   "homepage": "https://github.com/mikeyobrien/autoloop",
   "repository": "https://github.com/mikeyobrien/autoloop",

--- a/plugins/autoloop/.claude-plugin/plugin.json
+++ b/plugins/autoloop/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autoloop",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Run and operate autoloops — start runs, monitor progress, inject guidance, manage worktrees, inspect artifacts, and clean up.",
   "homepage": "https://github.com/mikeyobrien/autoloop",
   "repository": "https://github.com/mikeyobrien/autoloop",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Version bump for `@mobrienv/autoloop` and lock-step workspace packages from **0.10.1 → 0.11.0**.

Minor (not patch) because the Unreleased section already listed new product surfaces: memory plugins, durable waits, opt-in backend environment policy, and the frozen-paths guard.

## Changelog
- Promotes those notes into `[0.11.0]`.
- Backfills a `[0.10.1]` section for the already-published patch (standalone binaries + wrapper/hook/resume fixes) so those items are not listed twice.

## Local gates (`docs/ci-local.md`)
On a fresh clone, `bin/release` needs `npm run build` before `tsc` can resolve workspace packages.

```
npm run build    # exit 0
npm run check    # biome + tsc --noEmit + vitest coverage
```

`npm run check`: biome clean; tsc clean after build; **209 files / 2372 tests passed, 4 skipped**.

`gh signoff status`: ✓ signoff on `194652ff844f4447e650c0c30afbc38c5f01cf42`.

## Publish (done from tip after bump)

Tag `v0.11.0` was pushed from this bump commit. Not merged to `main` first.

- Commit: `194652ff844f4447e650c0c30afbc38c5f01cf42`
- Tag: `v0.11.0`
- Workflow: https://github.com/mikeyobrien/autoloop/actions/runs/34484576987 (success)
- GitHub release: https://github.com/mikeyobrien/autoloop/releases/tag/v0.11.0

Registry proof:

```
$ npm view @mobrienv/autoloop version
0.11.0

$ npm view @mobrienv/autoloop dist-tags
{ latest: '0.11.0' }
```

`latest` is **0.11.0 > 0.10.1**. Workspace packages (`cli`, `core`, `harness`, `backends`, `dashboard`, `presets`, `kanban`) are also `0.11.0` / `latest`.

Roadmap sequencing is unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9371875-8c7c-47aa-8546-19926ccedff5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9371875-8c7c-47aa-8546-19926ccedff5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

